### PR TITLE
feat: add lockfile serialization primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +224,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,12 +244,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -262,6 +305,12 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "memchr"
@@ -370,9 +419,13 @@ name = "pybun"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "bincode",
  "clap",
  "color-eyre",
  "predicates",
+ "serde",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -383,6 +436,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -420,12 +479,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -475,10 +548,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"
@@ -558,6 +664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,3 +686,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,11 @@ edition = "2024"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 color-eyre = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3"
+thiserror = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.1"
+tempfile = "3.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod cli;
+pub mod commands;
+pub mod lockfile;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use thiserror::Error;
+
+const MAGIC: &[u8; 8] = b"PYBUNLK1";
+const VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum LockfileError {
+    #[error("invalid magic header")]
+    InvalidMagic,
+    #[error("unsupported lockfile version {0}")]
+    UnsupportedVersion(u32),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("encode error: {0}")]
+    Encode(#[from] bincode::Error),
+}
+
+pub type Result<T> = std::result::Result<T, LockfileError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lockfile {
+    pub python_versions: Vec<String>,
+    pub platforms: Vec<String>,
+    pub packages: BTreeMap<String, Package>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Package {
+    pub name: String,
+    pub version: String,
+    pub source: PackageSource,
+    pub wheel: String,
+    pub hash: String,
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PackageSource {
+    Registry { index: String, url: String },
+    Url { url: String },
+}
+
+impl Lockfile {
+    pub fn new(python_versions: Vec<String>, platforms: Vec<String>) -> Self {
+        Self {
+            python_versions,
+            platforms,
+            packages: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_package(&mut self, package: Package) {
+        self.packages.insert(package.name.clone(), package);
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(MAGIC);
+        buf.extend_from_slice(&VERSION.to_le_bytes());
+        let body = bincode::serialize(self)?;
+        buf.extend_from_slice(&body);
+        Ok(buf)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < MAGIC.len() + 4 {
+            return Err(LockfileError::InvalidMagic);
+        }
+        if &bytes[..MAGIC.len()] != MAGIC {
+            return Err(LockfileError::InvalidMagic);
+        }
+        let version_start = MAGIC.len();
+        let version = u32::from_le_bytes([
+            bytes[version_start],
+            bytes[version_start + 1],
+            bytes[version_start + 2],
+            bytes[version_start + 3],
+        ]);
+        if version != VERSION {
+            return Err(LockfileError::UnsupportedVersion(version));
+        }
+        let body = &bytes[version_start + 4..];
+        let parsed: Lockfile = bincode::deserialize(body)?;
+        Ok(parsed)
+    }
+
+    pub fn save_to_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let bytes = self.to_bytes()?;
+        fs::write(path, bytes)?;
+        Ok(())
+    }
+
+    pub fn load_from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let bytes = fs::read(path)?;
+        Self::from_bytes(&bytes)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,5 @@
-mod cli;
-mod commands;
-
 use clap::Parser;
-use cli::Cli;
-use commands::execute;
+use pybun::{cli::Cli, commands::execute};
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;

--- a/tests/lockfile_roundtrip.rs
+++ b/tests/lockfile_roundtrip.rs
@@ -1,0 +1,71 @@
+use pybun::lockfile::{Lockfile, Package, PackageSource};
+
+#[test]
+fn roundtrip_preserves_data() {
+    let mut lock = Lockfile::new(vec!["3.12".into()], vec!["macos-arm64".into()]);
+    lock.add_package(Package {
+        name: "requests".into(),
+        version: "2.31.0".into(),
+        source: PackageSource::Registry {
+            index: "pypi".into(),
+            url: "https://pypi.org/simple".into(),
+        },
+        wheel: "requests-2.31.0-py3-none-any.whl".into(),
+        hash: "sha256:deadbeef".into(),
+        dependencies: vec!["urllib3>=1.26".into(), "certifi>=2023.0".into()],
+    });
+
+    let bytes = lock.to_bytes().expect("encode");
+    let decoded = Lockfile::from_bytes(&bytes).expect("decode");
+
+    assert_eq!(decoded, lock);
+}
+
+#[test]
+fn serialization_is_deterministic() {
+    let mut lock_a = Lockfile::new(vec!["3.11".into()], vec!["linux-x86_64".into()]);
+    for name in ["b", "a", "c"] {
+        lock_a.add_package(Package {
+            name: name.into(),
+            version: "1.0.0".into(),
+            source: PackageSource::Registry {
+                index: "pypi".into(),
+                url: "https://pypi.org/simple".into(),
+            },
+            wheel: format!("{name}-1.0.0-py3-none-any.whl"),
+            hash: "sha256:abc123".into(),
+            dependencies: vec![],
+        });
+    }
+
+    let mut lock_b = Lockfile::new(vec!["3.11".into()], vec!["linux-x86_64".into()]);
+    for name in ["c", "b", "a"] {
+        lock_b.add_package(Package {
+            name: name.into(),
+            version: "1.0.0".into(),
+            source: PackageSource::Registry {
+                index: "pypi".into(),
+                url: "https://pypi.org/simple".into(),
+            },
+            wheel: format!("{name}-1.0.0-py3-none-any.whl"),
+            hash: "sha256:abc123".into(),
+            dependencies: vec![],
+        });
+    }
+
+    let bytes_a = lock_a.to_bytes().expect("encode a");
+    let bytes_b = lock_b.to_bytes().expect("encode b");
+
+    assert_eq!(bytes_a, bytes_b, "serialization should be deterministic");
+}
+
+#[test]
+fn invalid_magic_is_rejected() {
+    let lock = Lockfile::new(vec!["3.10".into()], vec!["linux-x86_64".into()]);
+    let bytes = lock.to_bytes().expect("encode");
+    let mut corrupted = bytes.clone();
+    corrupted[0] = b'X';
+
+    let err = Lockfile::from_bytes(&corrupted).expect_err("should reject bad magic");
+    assert!(err.to_string().contains("magic"));
+}


### PR DESCRIPTION
Implements initial lockfile format scaffolding per docs/PLAN.md M1.\n\nChanges:\n- Add lockfile module with binary header (magic/version) and bincode body, deterministic ordering via BTreeMap.\n- Add load/save helpers and custom errors.\n- Expose library module for reuse in CLI.\n- Integration tests for roundtrip, deterministic serialization, and invalid magic rejection.\n\nStatus: format and primitives only; CLI wiring to follow in subsequent PRs.