### PR TITLE
feat: add simple resolver scaffold

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cli;
 pub mod commands;
 pub mod lockfile;
+pub mod resolver;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,125 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Requirement {
+    pub name: String,
+    pub version: String,
+}
+
+impl Requirement {
+    pub fn exact(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPackage {
+    pub name: String,
+    pub version: String,
+    pub dependencies: Vec<Requirement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolution {
+    pub packages: BTreeMap<String, ResolvedPackage>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ResolveError {
+    #[error("package {name}=={version} not found")]
+    Missing { name: String, version: String },
+    #[error("version conflict for {name}: existing {existing} vs requested {requested}")]
+    Conflict {
+        name: String,
+        existing: String,
+        requested: String,
+    },
+}
+
+pub trait PackageIndex {
+    fn get(&self, name: &str, version: &str) -> Option<ResolvedPackage>;
+}
+
+/// Deterministic resolver that works with exact-version requirements.
+pub fn resolve(
+    requirements: Vec<Requirement>,
+    index: &impl PackageIndex,
+) -> Result<Resolution, ResolveError> {
+    let mut resolved: BTreeMap<String, ResolvedPackage> = BTreeMap::new();
+    let mut stack: Vec<Requirement> = requirements;
+
+    while let Some(req) = stack.pop() {
+        if let Some(existing) = resolved.get(&req.name) {
+            if existing.version != req.version {
+                return Err(ResolveError::Conflict {
+                    name: req.name,
+                    existing: existing.version.clone(),
+                    requested: req.version,
+                });
+            }
+            continue;
+        }
+
+        let pkg = index
+            .get(&req.name, &req.version)
+            .ok_or_else(|| ResolveError::Missing {
+                name: req.name.clone(),
+                version: req.version.clone(),
+            })?;
+
+        // queue dependencies before inserting to keep deterministic traversal order
+        for dep in pkg.dependencies.iter().rev() {
+            stack.push(dep.clone());
+        }
+
+        resolved.insert(req.name.clone(), pkg);
+    }
+
+    Ok(Resolution { packages: resolved })
+}
+
+#[derive(Default)]
+pub struct InMemoryIndex {
+    pkgs: BTreeMap<(String, String), ResolvedPackage>,
+}
+
+impl InMemoryIndex {
+    pub fn add(
+        &mut self,
+        name: impl Into<String>,
+        version: impl Into<String>,
+        deps: impl IntoIterator<Item = impl AsRef<str>>,
+    ) {
+        let name = name.into();
+        let version = version.into();
+        let deps = deps
+            .into_iter()
+            .map(|d| parse_req(d.as_ref()))
+            .collect::<Vec<_>>();
+        let pkg = ResolvedPackage {
+            name: name.clone(),
+            version: version.clone(),
+            dependencies: deps,
+        };
+        self.pkgs.insert((name, version), pkg);
+    }
+}
+
+impl PackageIndex for InMemoryIndex {
+    fn get(&self, name: &str, version: &str) -> Option<ResolvedPackage> {
+        self.pkgs
+            .get(&(name.to_string(), version.to_string()))
+            .cloned()
+    }
+}
+
+fn parse_req(input: &str) -> Requirement {
+    if let Some((name, version)) = input.split_once("==") {
+        Requirement::exact(name.trim(), version.trim())
+    } else {
+        Requirement::exact(input.trim(), "*")
+    }
+}

--- a/tests/resolver_basic.rs
+++ b/tests/resolver_basic.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+
+use pybun::resolver::{InMemoryIndex, Requirement, ResolveError, resolve};
+
+#[test]
+fn resolves_simple_dependency_tree() {
+    let mut index = InMemoryIndex::default();
+    index.add("app", "1.0.0", ["lib-a==1.0.0", "lib-b==2.0.0"]);
+    index.add("lib-a", "1.0.0", ["lib-c==1.0.0"]);
+    index.add("lib-b", "2.0.0", Vec::<&str>::new());
+    index.add("lib-c", "1.0.0", Vec::<&str>::new());
+
+    let resolution = resolve(vec![Requirement::exact("app", "1.0.0")], &index).unwrap();
+    let expect: HashMap<&str, &str> = HashMap::from([
+        ("app", "1.0.0"),
+        ("lib-a", "1.0.0"),
+        ("lib-b", "2.0.0"),
+        ("lib-c", "1.0.0"),
+    ]);
+
+    assert_eq!(resolution.packages.len(), expect.len());
+    for (name, pkg) in resolution.packages.iter() {
+        assert_eq!(
+            expect.get(name.as_str()).copied(),
+            Some(pkg.version.as_str())
+        );
+    }
+}
+
+#[test]
+fn fails_on_missing_package() {
+    let index = InMemoryIndex::default();
+    let err = resolve(vec![Requirement::exact("missing", "1.0.0")], &index).unwrap_err();
+    assert!(matches!(err, ResolveError::Missing { name, .. } if name == "missing"));
+}
+
+#[test]
+fn detects_version_conflict() {
+    let mut index = InMemoryIndex::default();
+    index.add("root", "1.0.0", ["lib==1.0.0", "lib==2.0.0"]);
+    index.add("lib", "1.0.0", Vec::<&str>::new());
+    index.add("lib", "2.0.0", Vec::<&str>::new());
+
+    let err = resolve(vec![Requirement::exact("root", "1.0.0")], &index).unwrap_err();
+    assert!(matches!(err, ResolveError::Conflict { name, .. } if name == "lib"));
+}


### PR DESCRIPTION
Implements a minimal deterministic resolver scaffold (M1 step) with exact-version handling.\n\nChanges:\n- Add resolver module with Requirement, Resolution, errors (missing/conflict), and trait-based PackageIndex.\n- Provide InMemoryIndex helper for testing and future fake index integration.\n- Resolve function walks requirement stack, enforces exact version matches, and yields deterministic BTreeMap ordering.\n- Tests: resolves a dependency tree, detects missing packages, and surfaces version conflicts.\n\nStatus: exact-version, in-memory only; future work will add real index client, specifier ranges, and SAT behavior per PLAN.