### PR TITLE
Add structured install JSON output

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,84 +1,157 @@
 use crate::cli::{Cli, Commands, McpCommands, OutputFormat, SelfCommands};
+use crate::index::load_index_from_path;
 use crate::lockfile::{Lockfile, Package, PackageSource};
-use crate::resolver::{InMemoryIndex, ResolveError, resolve};
+use crate::resolver::{ResolveError, resolve};
 use color_eyre::eyre::{Result, eyre};
-use serde::Deserialize;
-use std::fs;
+use serde_json::{Value, json};
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 pub fn execute(cli: Cli) -> Result<()> {
-    let rendered = match &cli.command {
+    let start = Instant::now();
+    let (command, detail) = match &cli.command {
         Commands::Install(args) => {
-            let detail = install(args)?;
-            render("install", &detail, cli.format)
+            let InstallOutcome {
+                summary,
+                packages,
+                lockfile,
+            } = install(args)?;
+            (
+                "install".to_string(),
+                RenderDetail::with_json(
+                    summary,
+                    json!({
+                        "lockfile": lockfile.display().to_string(),
+                        "packages": packages,
+                    }),
+                ),
+            )
         }
-        Commands::Add(args) => render(
-            "add",
-            &format!("package={:?} offline={}", args.package, args.offline),
-            cli.format,
-        ),
-        Commands::Remove(args) => render(
-            "remove",
-            &format!("package={:?} offline={}", args.package, args.offline),
-            cli.format,
-        ),
-        Commands::Run(args) => render(
-            "run",
-            &format!(
-                "target={:?} sandbox={} profile={} passthrough={:?}",
-                args.target, args.sandbox, args.profile, args.passthrough
+        Commands::Add(args) => (
+            "add".to_string(),
+            stub_detail(
+                format!("package={:?} offline={}", args.package, args.offline),
+                json!({"package": args.package, "offline": args.offline}),
             ),
-            cli.format,
         ),
-        Commands::X(args) => render(
-            "x",
-            &format!(
-                "package={:?} passthrough={:?}",
-                args.package, args.passthrough
+        Commands::Remove(args) => (
+            "remove".to_string(),
+            stub_detail(
+                format!("package={:?} offline={}", args.package, args.offline),
+                json!({"package": args.package, "offline": args.offline}),
             ),
-            cli.format,
         ),
-        Commands::Test(args) => render(
-            "test",
-            &format!(
-                "shard={:?} fail_fast={} pytest_compat={}",
-                args.shard, args.fail_fast, args.pytest_compat
+        Commands::Run(args) => (
+            "run".to_string(),
+            stub_detail(
+                format!(
+                    "target={:?} sandbox={} profile={} passthrough={:?}",
+                    args.target, args.sandbox, args.profile, args.passthrough
+                ),
+                json!({
+                    "target": args.target,
+                    "sandbox": args.sandbox,
+                    "profile": args.profile,
+                    "passthrough": args.passthrough,
+                }),
             ),
-            cli.format,
         ),
-        Commands::Build(args) => render("build", &format!("sbom={}", args.sbom), cli.format),
-        Commands::Doctor(args) => {
-            render("doctor", &format!("verbose={}", args.verbose), cli.format)
-        }
+        Commands::X(args) => (
+            "x".to_string(),
+            stub_detail(
+                format!(
+                    "package={:?} passthrough={:?}",
+                    args.package, args.passthrough
+                ),
+                json!({"package": args.package, "passthrough": args.passthrough}),
+            ),
+        ),
+        Commands::Test(args) => (
+            "test".to_string(),
+            stub_detail(
+                format!(
+                    "shard={:?} fail_fast={} pytest_compat={}",
+                    args.shard, args.fail_fast, args.pytest_compat
+                ),
+                json!({
+                    "shard": args.shard,
+                    "fail_fast": args.fail_fast,
+                    "pytest_compat": args.pytest_compat,
+                }),
+            ),
+        ),
+        Commands::Build(args) => (
+            "build".to_string(),
+            stub_detail(format!("sbom={}", args.sbom), json!({"sbom": args.sbom})),
+        ),
+        Commands::Doctor(args) => (
+            "doctor".to_string(),
+            stub_detail(
+                format!("verbose={}", args.verbose),
+                json!({"verbose": args.verbose}),
+            ),
+        ),
         Commands::Mcp(cmd) => match cmd {
-            McpCommands::Serve(args) => {
-                render("mcp serve", &format!("port={}", args.port), cli.format)
-            }
+            McpCommands::Serve(args) => (
+                "mcp serve".to_string(),
+                stub_detail(format!("port={}", args.port), json!({"port": args.port})),
+            ),
         },
         Commands::SelfCmd(cmd) => match cmd {
-            SelfCommands::Update(args) => render(
-                "self update",
-                &format!("channel={}", args.channel),
-                cli.format,
+            SelfCommands::Update(args) => (
+                "self update".to_string(),
+                stub_detail(
+                    format!("channel={}", args.channel),
+                    json!({"channel": args.channel}),
+                ),
             ),
         },
-        Commands::Gc(args) => render("gc", &format!("max_size={:?}", args.max_size), cli.format),
+        Commands::Gc(args) => (
+            "gc".to_string(),
+            stub_detail(
+                format!("max_size={:?}", args.max_size),
+                json!({"max_size": args.max_size}),
+            ),
+        ),
     };
 
+    let rendered = render(&command, detail, cli.format, start.elapsed());
     println!("{rendered}");
     Ok(())
 }
 
-fn render(command: &str, detail: &str, format: OutputFormat) -> String {
+fn render(command: &str, detail: RenderDetail, format: OutputFormat, duration: Duration) -> String {
     match format {
-        OutputFormat::Text => format!("pybun {command} (stub): {detail}"),
+        OutputFormat::Text => format!("pybun {command}: {}", detail.text),
         OutputFormat::Json => {
-            format!(r#"{{"command":"pybun {command}","status":"stub","detail":"{detail}"}}"#)
+            let envelope = JsonEnvelope {
+                version: "1",
+                command: format!("pybun {command}"),
+                status: "ok",
+                duration_ms: duration.as_millis() as u64,
+                detail: detail.json,
+                events: Vec::new(),
+                diagnostics: Vec::new(),
+                trace_id: None,
+            };
+            serde_json::to_string(&envelope).expect("json render")
         }
     }
 }
 
-fn install(args: &crate::cli::InstallArgs) -> Result<String> {
+fn stub_detail(message: String, payload: Value) -> RenderDetail {
+    let message = format!("{message} (not implemented yet)");
+    RenderDetail::with_json(
+        message.clone(),
+        json!({
+            "status": "stub",
+            "message": message,
+            "payload": payload,
+        }),
+    )
+}
+
+fn install(args: &crate::cli::InstallArgs) -> Result<InstallOutcome> {
     if args.requirements.is_empty() {
         return Err(eyre!(
             "no requirements provided (temporary flag --require needed)"
@@ -89,8 +162,7 @@ fn install(args: &crate::cli::InstallArgs) -> Result<String> {
         .clone()
         .ok_or_else(|| eyre!("index path is required for now (--index)"))?;
 
-    let pkgs = load_index(&index_path)?;
-    let index = InMemoryIndex::from_packages(pkgs);
+    let index = load_index_from_path(&index_path).map_err(|e| eyre!(e))?;
     let resolution = resolve(args.requirements.clone(), &index).map_err(|e| match e {
         ResolveError::Missing { name, .. } => eyre!("missing package {name}"),
         ResolveError::Conflict {
@@ -120,32 +192,48 @@ fn install(args: &crate::cli::InstallArgs) -> Result<String> {
     }
     lock.save_to_path(&args.lock)?;
 
-    Ok(format!(
-        "resolved {} packages -> {}",
-        lock.packages.len(),
-        args.lock.display()
-    ))
+    Ok(InstallOutcome {
+        summary: format!(
+            "resolved {} packages -> {}",
+            lock.packages.len(),
+            args.lock.display()
+        ),
+        packages: lock.packages.keys().cloned().collect(),
+        lockfile: args.lock.clone(),
+    })
 }
 
-#[derive(Debug, Deserialize)]
-pub struct IndexPackage {
-    name: String,
-    version: String,
-    dependencies: Vec<String>,
+#[derive(Debug)]
+struct InstallOutcome {
+    summary: String,
+    packages: Vec<String>,
+    lockfile: PathBuf,
 }
 
-fn load_index(path: &PathBuf) -> Result<Vec<IndexPackage>> {
-    let data = fs::read_to_string(path)?;
-    let parsed: Vec<IndexPackage> = serde_json::from_str(&data)?;
-    Ok(parsed)
+#[derive(Debug)]
+struct RenderDetail {
+    text: String,
+    json: Value,
 }
 
-impl InMemoryIndex {
-    pub fn from_packages(pkgs: Vec<IndexPackage>) -> Self {
-        let mut index = InMemoryIndex::default();
-        for pkg in pkgs {
-            index.add(pkg.name, pkg.version, pkg.dependencies);
+impl RenderDetail {
+    fn with_json(text: impl Into<String>, json: Value) -> Self {
+        Self {
+            text: text.into(),
+            json,
         }
-        index
     }
+}
+
+#[derive(serde::Serialize)]
+struct JsonEnvelope {
+    version: &'static str,
+    command: String,
+    status: &'static str,
+    duration_ms: u64,
+    detail: Value,
+    events: Vec<Value>,
+    diagnostics: Vec<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace_id: Option<String>,
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,64 @@
+use crate::resolver::InMemoryIndex;
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Package record as stored in the simple JSON index fixture.
+#[derive(Debug, Deserialize)]
+pub struct IndexPackage {
+    pub name: String,
+    pub version: String,
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum IndexError {
+    #[error("failed to read index {path}: {source}")]
+    Io {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+    #[error("failed to parse index json: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+pub type Result<T> = std::result::Result<T, IndexError>;
+
+/// Load a JSON index file into an in-memory index usable by the resolver.
+pub fn load_index_from_path(path: impl AsRef<Path>) -> Result<InMemoryIndex> {
+    let path = path.as_ref();
+    let data = fs::read_to_string(path).map_err(|source| IndexError::Io {
+        source,
+        path: path.to_path_buf(),
+    })?;
+    let packages: Vec<IndexPackage> = serde_json::from_str(&data)?;
+    Ok(build_index(packages))
+}
+
+fn build_index(packages: Vec<IndexPackage>) -> InMemoryIndex {
+    let mut index = InMemoryIndex::default();
+    for pkg in packages {
+        index.add(pkg.name, pkg.version, pkg.dependencies);
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolver::PackageIndex;
+
+    #[test]
+    fn builds_inmemory_index() {
+        let index = build_index(vec![IndexPackage {
+            name: "app".into(),
+            version: "1.0.0".into(),
+            dependencies: vec!["dep==2.0.0".into()],
+        }]);
+        let pkg = index.get("app", "1.0.0").expect("package");
+        assert_eq!(pkg.dependencies.len(), 1);
+        assert_eq!(pkg.dependencies[0].name, "dep");
+        assert_eq!(pkg.dependencies[0].version, "2.0.0");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
 pub mod commands;
+pub mod index;
 pub mod lockfile;
 pub mod resolver;

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -1,0 +1,69 @@
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn bin() -> Command {
+    cargo_bin_cmd!("pybun")
+}
+
+#[test]
+fn install_outputs_structured_json() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_path();
+
+    let output = bin()
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "app==1.0.0",
+            "--lock",
+            lock_path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let parsed: Value = serde_json::from_str(&stdout).expect("json output");
+
+    assert_eq!(parsed["version"], "1");
+    assert_eq!(parsed["command"], "pybun install");
+    assert_eq!(parsed["status"], "ok");
+    assert!(parsed["duration_ms"].as_u64().is_some());
+    assert_eq!(parsed["detail"]["lockfile"], lock_path.to_str().unwrap());
+    assert_eq!(
+        parsed["detail"]["packages"]
+            .as_array()
+            .expect("packages array")
+            .len(),
+        4
+    );
+    assert!(
+        parsed["events"]
+            .as_array()
+            .expect("events array")
+            .is_empty()
+    );
+    assert!(
+        parsed["diagnostics"]
+            .as_array()
+            .expect("diagnostics array")
+            .is_empty()
+    );
+}
+
+fn index_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index.json")
+}


### PR DESCRIPTION
## Summary
- add reusable index loader to share index parsing
- wrap CLI output in structured envelope and stub JSON detail payloads
- add regression test ensuring install emits structured JSON with metadata

## Testing
- cargo test