### PR TITLE
PR1.8 & PR1.9: pyproject.toml install flow + PEP 723 auto-install

### DIFF
--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -103,3 +103,98 @@ fn run_script_with_exit_code() {
         .success() // pybun itself succeeds, reports script exit code
         .stdout(predicate::str::contains("\"exit_code\":42"));
 }
+
+// =============================================================================
+// PR1.9: PEP 723 dependencies auto-install in isolated environment
+// =============================================================================
+
+#[test]
+fn run_pep723_auto_installs_dependencies() {
+    // Test that PEP 723 dependencies are auto-installed in a temp env
+    // Note: This test uses dry-run mode for faster execution
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("pep723_with_deps.py");
+
+    // Create a PEP 723 script with dependencies
+    let content = r#"# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "cowsay",
+# ]
+# ///
+print("Hello with deps")
+"#;
+    fs::write(&script, content).unwrap();
+
+    // Set dry-run mode for testing
+    bin()
+        .env("PYBUN_PEP723_DRY_RUN", "1")
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pep723_dependencies"))
+        .stdout(predicate::str::contains("cowsay"))
+        .stdout(predicate::str::contains("temp_env"));
+}
+
+#[test]
+fn run_pep723_json_shows_auto_install_info() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("pep723_info.py");
+
+    let content = r#"# /// script
+# dependencies = ["requests>=2.28.0", "rich"]
+# ///
+print("test")
+"#;
+    fs::write(&script, content).unwrap();
+
+    bin()
+        .env("PYBUN_PEP723_DRY_RUN", "1")
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"pep723_dependencies\""))
+        .stdout(predicate::str::contains("requests>=2.28.0"))
+        .stdout(predicate::str::contains("rich"))
+        // Should indicate temp env was created (in dry-run mode, shows it would be)
+        .stdout(predicate::str::contains("temp_env").or(predicate::str::contains("isolated")));
+}
+
+#[test]
+fn run_pep723_empty_deps_no_temp_env() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("pep723_empty.py");
+
+    // PEP 723 block but no dependencies
+    let content = r#"# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+print("no deps needed")
+"#;
+    fs::write(&script, content).unwrap();
+
+    // Should run directly without creating temp env
+    bin()
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"exit_code\":0"));
+}
+
+#[test]
+fn run_without_pep723_uses_system_env() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("simple_script.py");
+    fs::write(&script, "print('no pep723')").unwrap();
+
+    // Should run with system/project env, no temp env created
+    bin()
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"exit_code\":0"))
+        // Should have empty pep723_dependencies
+        .stdout(predicate::str::contains("\"pep723_dependencies\":[]"));
+}


### PR DESCRIPTION
## Summary

This PR implements two related features from the PLAN.md:

### PR1.8: `pybun install` Normal Flow (pyproject.toml support)

**Goal**: Graduate from the temporary `--require/--index` flags to reading dependencies from `pyproject.toml`.

**Changes**:
- `pybun install` now reads dependencies from `pyproject.toml` when `--require` is not specified
- Empty dependencies list creates an empty lockfile (valid case)
- `--require` flag takes precedence over `pyproject.toml` when specified
- Proper error message when no pyproject.toml found and no `--require` flag

### PR1.9: PEP 723 Auto-install in Isolated Environment

**Goal**: `pybun run` detects PEP 723 scripts and auto-installs dependencies in a temporary environment.

**Changes**:
- `pybun run` detects PEP 723 metadata in scripts
- Automatically creates a temporary virtual environment
- Installs dependencies via pip in the isolated environment
- Executes the script using the temp venv Python
- Automatic cleanup after script completion
- JSON output now includes `temp_env` (path) and `cleanup` (bool) fields

## Tests

- 7 E2E tests for pyproject.toml install flow
- 4 E2E tests for PEP 723 auto-install

## Checklist

- [x] Branch created from main
- [x] Tests written first (TDD)
- [x] All tests pass
- [x] cargo clippy passes
- [x] PLAN.md updated