### PR TITLE
PR5.0: bootstrap build command

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -143,9 +143,11 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Tests: 9 observability E2E tests (trace_id presence/absence, event timestamps, duration_ms, schema version, diagnostics, env var redaction, log level, event types).
 
 ### M5: Builder & Security (Phase 3/4)
-- PR5.0 (bootstrap): `pybun build` の “まず動く” 実装（`python -m build` の薄いラッパー + `--sbom` はスタブ出力）  
+- [DONE] PR5.0 (bootstrap): `pybun build` の “まず動く” 実装（`python -m build` の薄いラッパー + `--sbom` はスタブ出力）  
   - Goal: CLI/JSON/成果物ディレクトリの外形を固める。  
   - Notes: SBOMの本実装は PR5.3 で良いが、`--sbom` が何かを出すこと自体は早めに整えるとUXが良い。
+  - Current: `pybun build` がプロジェクトの `pyproject.toml` を検出して `python -m build` を実行し、dist配下の成果物を列挙してJSON/Textで報告。`--sbom` 指定時は `dist/pybun-sbom.json` にスタブを書き出す。stdout/stderr/exit_codeをJSONに含め、Python環境情報も返す。
+  - Tests: `cargo test --test cli_build`, `cargo test --test json_schema`, `cargo test`.
 - PR5.1: C/C++ build wrapper (setuptools/maturin/scikit-build isolation) + build cache.  
   - Depends on: M1 installer infra.  
   - Tests: integration building sample C extension; cache hit/miss assertions.

--- a/tests/cli_build.rs
+++ b/tests/cli_build.rs
@@ -1,0 +1,130 @@
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn bin() -> Command {
+    cargo_bin_cmd!("pybun")
+}
+
+fn setup_fake_build_project() -> (TempDir, PathBuf, std::ffi::OsString) {
+    let temp = tempfile::tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir_all(&project_dir).unwrap();
+
+    // Minimal pyproject for build backends
+    fs::write(
+        project_dir.join("pyproject.toml"),
+        r#"[project]
+name = "demo-build"
+version = "0.1.0"
+"#,
+    )
+    .unwrap();
+
+    // Stub `build` module so tests don't depend on external packages.
+    let fake_build_dir = temp.path().join("fake_build");
+    let package_dir = fake_build_dir.join("build");
+    fs::create_dir_all(&package_dir).unwrap();
+    fs::write(package_dir.join("__init__.py"), "").unwrap();
+    fs::write(
+        package_dir.join("__main__.py"),
+        r#"
+import pathlib
+import sys
+
+def main():
+    root = pathlib.Path.cwd()
+    dist = root / "dist"
+    dist.mkdir(exist_ok=True)
+    # Write predictable artifacts for assertions
+    (dist / "demo-build-0.1.0.tar.gz").write_text("sdist")
+    (dist / "demo-build-0.1.0-py3-none-any.whl").write_text("wheel")
+    print("fake build completed", file=sys.stdout)
+
+if __name__ == "__main__":
+    main()
+"#,
+    )
+    .unwrap();
+
+    // Compose PYTHONPATH that ensures our stub takes precedence.
+    let mut paths = vec![fake_build_dir.into_os_string()];
+    if let Some(existing) = std::env::var_os("PYTHONPATH") {
+        paths.push(existing);
+    }
+    let pythonpath = std::env::join_paths(paths).unwrap();
+
+    (temp, project_dir, pythonpath)
+}
+
+#[test]
+fn build_invokes_python_module_and_collects_artifacts() {
+    let (_temp, project_dir, pythonpath) = setup_fake_build_project();
+
+    let mut cmd = bin();
+    cmd.current_dir(&project_dir)
+        .env("PYTHONPATH", pythonpath)
+        .arg("build");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Built 2 artifacts"))
+        .stdout(predicate::str::contains("dist"));
+
+    // Dist artifacts should be created by the stubbed build backend
+    let dist_dir = project_dir.join("dist");
+    assert!(dist_dir.join("demo-build-0.1.0.tar.gz").exists());
+    assert!(dist_dir.join("demo-build-0.1.0-py3-none-any.whl").exists());
+}
+
+#[test]
+fn build_json_reports_artifacts_and_sbom_stub() {
+    let (_temp, project_dir, pythonpath) = setup_fake_build_project();
+
+    let output = bin()
+        .current_dir(&project_dir)
+        .env("PYTHONPATH", pythonpath)
+        .args(["--format=json", "build", "--sbom"])
+        .output()
+        .expect("failed to run pybun build");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("output should be valid JSON");
+
+    assert_eq!(json["command"], "pybun build");
+    assert_eq!(json["status"], "ok");
+
+    let detail = &json["detail"];
+    let artifacts: Vec<String> = detail["artifacts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect();
+    assert!(
+        artifacts
+            .iter()
+            .any(|a| a.ends_with("demo-build-0.1.0.tar.gz")),
+        "tar.gz artifact should be reported"
+    );
+    assert!(
+        artifacts
+            .iter()
+            .any(|a| a.ends_with("demo-build-0.1.0-py3-none-any.whl")),
+        "wheel artifact should be reported"
+    );
+
+    assert_eq!(detail["builder"], "python -m build");
+    assert_eq!(detail["sbom"]["status"], "stub");
+    let sbom_path = detail["sbom"]["path"].as_str().expect("sbom path missing");
+    assert!(
+        Path::new(sbom_path).exists(),
+        "sbom stub file should exist on disk"
+    );
+}


### PR DESCRIPTION
## Summary
- implement python -m build wrapper for pybun build with dist artifact reporting and sbom stub file
- add build CLI/json tests and mark PR5.0 as done in PLAN
- record benchmark results after release build

## Testing
- cargo test --test '*'
- PATH=/Volumes/SSD2TB_DATA/src/PyBun/target/release:/Users/takurot/.nodebrew/current/bin:/Users/takurot/.nodebrew/current/bin:/Users/takurot/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools:/var/folders/0z/wsc39bn52pvb9c3clp9fjdf80000gq/T/.tmp3iO4RV:/Users/takurot/.antigravity/antigravity/bin:/opt/homebrew/opt/node@20/bin:/Users/takurot/.nvm/versions/node/v20.19.4/bin:/Users/takurot/.nodebrew/current/bin:/Users/takurot/.rbenv/shims:/Users/takurot/.cargo/bin:/opt/homebrew/include:/opt/homebrew/lib:/usr/local/lib:/usr/local/include:/usr/lib:/Users/takurot/.vscode/extensions/openai.chatgpt-0.4.51-darwin-arm64/bin/macos-aarch64:/opt/homebrew/include:/opt/homebrew/lib:/usr/bin:/usr/local/bin:/usr/local/lib:/usr/local/include:/usr/lib python3 scripts/benchmark/bench.py -s run --format markdown (after clearing ~/.cache/pybun/pep723-envs)
