### PR TITLE
PR6.6: One-liner installer (curl|sh / PowerShell) + verification-first UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,27 @@ A Rust-based single-binary Python toolchain. Integrates fast dependency installa
 ## Installation
 
 ```bash
-# Build from source
-cargo build --release
+# macOS / Linux (recommended)
+curl -LsSf https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.sh | sh
+
+# Nightly channel
+curl -LsSf https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.sh | sh -s -- --channel nightly
+
+# Custom prefix
+curl -LsSf https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.sh | sh -s -- --prefix ~/.local
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.ps1 | iex
+
+# With options
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.ps1))) -Channel nightly -Prefix "$env:LOCALAPPDATA\pybun"
+```
+
+```bash
+# Development (from source)
+cargo install --path .
 ```
 
 ## Quick Start

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -192,14 +192,11 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Current: Release workflow now signs artifacts via minisign (dummy key on dry-run), generates `SHA256SUMS`, `pybun-release.json` manifest, SBOM, and provenance, and uploads metadata/signature files to releases. Added release-manifest parser/selector for `pybun self update` along with scripts to generate manifest + provenance.
   - Tests: `cargo fmt`; `cargo clippy --all-targets --all-features -- -D warnings`; `CARGO_INCREMENTAL=0 cargo test`; `cargo build --release`; `PATH=$(pwd)/target/release:$PATH python3 scripts/benchmark/bench.py -s run --format markdown`.
 
-- PR6.6: One-liner installer (curl|sh / PowerShell) + verification-first UX
+- [DONE] PR6.6: One-liner installer (curl|sh / PowerShell) + verification-first UX
   - Goal: “初回導入” を最短にしつつ、デフォルトで検証（checksum/署名）を行う。
   - Depends on: PR6.5.
-  - Implementation:
-    - `scripts/install.sh` と `scripts/install.ps1` を追加し、OS/Arch 自動判定→該当アセット取得→検証→配置まで行う。
-    - `--version`/`--channel`/`--prefix`/`--bin-dir`/`--no-verify`（危険フラグ）などのオプションを定義。
-    - README / `docs/qiita.md` の推奨インストール手順をこのスクリプトに寄せる（`cargo install --path .` は開発者向けに格下げ）。
-  - Tests: スクリプトの `--dry-run`（取得URL/検証対象/配置先）を CI で検証。必要なら小さな `shellcheck` 相当の静的検査。
+  - Current: `scripts/install.sh` と `scripts/install.ps1` を追加し、OS/Arch 自動判定→リリースマニフェスト取得→SHA256/署名検証→配置まで対応。`--version`/`--channel`/`--prefix`/`--bin-dir`/`--no-verify`/`--dry-run` と JSON dry-run 出力を実装。README と `docs/qiita.md` をワンライナー導線に更新。
+  - Tests: `tests/install_scripts.rs` (`scripts/install.sh`/`scripts/install.ps1` の `--dry-run --format=json` 検証), `cargo test --test install_scripts`.
 
 - PR6.7: Package-manager channels (Homebrew/Scoop/winget) + automated updates on tag
   - Goal: 企業/チーム導入（IT管理・CI）で使いやすい配布チャネルを追加し、tag リリースから自動更新する。

--- a/docs/qiita.md
+++ b/docs/qiita.md
@@ -1,0 +1,35 @@
+# PyBun Installation Guide (Qiita draft)
+
+This note aligns the public install steps with the signed release artifacts.
+
+## Recommended install (macOS / Linux)
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.sh | sh
+
+# Nightly channel
+curl -LsSf https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.sh | sh -s -- --channel nightly
+
+# Custom prefix
+curl -LsSf https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.sh | sh -s -- --prefix ~/.local
+```
+
+## Recommended install (Windows PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.ps1 | iex
+
+# With options
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/pybun/pybun/main/scripts/install.ps1))) -Channel nightly -Prefix "$env:LOCALAPPDATA\pybun"
+```
+
+## Verification-first
+
+The installer verifies SHA256 checksums and minisign signatures by default.
+Use `--no-verify` only if you understand the risks.
+
+## Development install
+
+```bash
+cargo install --path .
+```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,306 @@
+param(
+    [string]$Version,
+    [ValidateSet("stable", "nightly")][string]$Channel = "stable",
+    [string]$Prefix,
+    [string]$BinDir,
+    [switch]$NoVerify,
+    [switch]$DryRun,
+    [ValidateSet("text", "json")][string]$Format = "text"
+)
+
+$IsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    [System.Runtime.InteropServices.OSPlatform]::Windows
+)
+$IsLinux = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    [System.Runtime.InteropServices.OSPlatform]::Linux
+)
+$IsMacOS = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    [System.Runtime.InteropServices.OSPlatform]::OSX
+)
+
+function Write-Log {
+    param([string]$Message)
+    if ($Format -eq "json") {
+        [Console]::Error.WriteLine($Message)
+    } else {
+        Write-Host $Message
+    }
+}
+
+function Expand-Path {
+    param([string]$PathValue)
+    if (-not $PathValue) {
+        return $null
+    }
+    if ($PathValue -like "~*") {
+        return $PathValue -replace "^~", $HOME
+    }
+    return $PathValue
+}
+
+function Detect-Target {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($IsWindows) {
+        if ($arch -ne "X64") {
+            throw "unsupported Windows architecture: $arch"
+        }
+        return "x86_64-pc-windows-msvc"
+    }
+    if ($IsMacOS) {
+        if ($arch -eq "Arm64") {
+            return "aarch64-apple-darwin"
+        }
+        if ($arch -eq "X64") {
+            return "x86_64-apple-darwin"
+        }
+        throw "unsupported macOS architecture: $arch"
+    }
+    if ($IsLinux) {
+        if ($arch -eq "Arm64") {
+            return "aarch64-unknown-linux-gnu"
+        }
+        if ($arch -eq "X64") {
+            if (Test-Path "/lib/ld-musl-x86_64.so.1") {
+                return "x86_64-unknown-linux-musl"
+            }
+            return "x86_64-unknown-linux-gnu"
+        }
+        throw "unsupported Linux architecture: $arch"
+    }
+    throw "unsupported OS (use install.sh on macOS/Linux)"
+}
+
+function Download-File {
+    param(
+        [string]$Url,
+        [string]$Destination
+    )
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing | Out-Null
+    } else {
+        Invoke-WebRequest -Uri $Url -OutFile $Destination | Out-Null
+    }
+}
+
+function Get-ManifestData {
+    param(
+        [string]$ManifestPath,
+        [string]$Target
+    )
+    $manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json
+    $asset = $manifest.assets | Where-Object { $_.target -eq $Target } | Select-Object -First 1
+    if (-not $asset) {
+        throw "no asset found in manifest for target: $Target"
+    }
+    return @{
+        Manifest = $manifest
+        Asset = $asset
+    }
+}
+
+if (-not $BinDir -and -not $Prefix) {
+    if ($IsWindows) {
+        $Prefix = Join-Path $env:LOCALAPPDATA "pybun"
+    } else {
+        $Prefix = Join-Path $HOME ".local"
+    }
+}
+
+if ($BinDir) {
+    $BinDir = Expand-Path $BinDir
+    if (-not $Prefix) {
+        $Prefix = Split-Path $BinDir -Parent
+    } else {
+        $Prefix = Expand-Path $Prefix
+    }
+} else {
+    $Prefix = Expand-Path $Prefix
+    $BinDir = Join-Path $Prefix "bin"
+}
+
+$Target = Detect-Target
+$ArchiveExt = if ($IsWindows) { "zip" } else { "tar.gz" }
+$AssetName = "pybun-$Target.$ArchiveExt"
+$BinaryName = if ($IsWindows) { "pybun.exe" } else { "pybun" }
+$InstallPath = Join-Path $BinDir $BinaryName
+
+$ManifestSource = $env:PYBUN_INSTALL_MANIFEST
+if (-not $ManifestSource) {
+    if ($Version) {
+        $Version = $Version.TrimStart("v")
+        $ReleaseTag = "v$Version"
+        $ManifestSource = "https://github.com/pybun/pybun/releases/download/$ReleaseTag/pybun-release.json"
+    } elseif ($Channel -eq "nightly") {
+        $ManifestSource = "https://github.com/pybun/pybun/releases/download/nightly/pybun-release.json"
+    } else {
+        $ManifestSource = "https://github.com/pybun/pybun/releases/latest/download/pybun-release.json"
+    }
+}
+
+if ($Version) {
+    $ReleaseTag = "v$($Version.TrimStart("v"))"
+    $AssetUrl = "https://github.com/pybun/pybun/releases/download/$ReleaseTag/$AssetName"
+} elseif ($Channel -eq "nightly") {
+    $AssetUrl = "https://github.com/pybun/pybun/releases/download/nightly/$AssetName"
+} else {
+    $AssetUrl = "https://github.com/pybun/pybun/releases/latest/download/$AssetName"
+}
+
+$ManifestPath = $null
+if ($ManifestSource -like "file://*") {
+    $ManifestPath = $ManifestSource.Substring(7)
+} elseif (Test-Path $ManifestSource) {
+    $ManifestPath = $ManifestSource
+} elseif ($ManifestSource -match "^https?://") {
+    if ($env:PYBUN_INSTALL_FETCH -eq "1" -or (-not $NoVerify -and -not $DryRun)) {
+        $ManifestPath = Join-Path ([System.IO.Path]::GetTempPath()) ("pybun-release-" + [System.Guid]::NewGuid().ToString() + ".json")
+        Download-File -Url $ManifestSource -Destination $ManifestPath
+    }
+}
+
+$ManifestVersion = $null
+$ManifestChannel = $null
+$ManifestReleaseUrl = $null
+$AssetSha = $null
+$SigType = $null
+$SigValue = $null
+$SigPub = $null
+
+if ($ManifestPath) {
+    $manifestData = Get-ManifestData -ManifestPath $ManifestPath -Target $Target
+    $manifest = $manifestData.Manifest
+    $asset = $manifestData.Asset
+    $ManifestVersion = $manifest.version
+    $ManifestChannel = $manifest.channel
+    $ManifestReleaseUrl = $manifest.release_url
+    $AssetName = $asset.name
+    $AssetUrl = $asset.url
+    $AssetSha = $asset.sha256
+    if ($asset.signature) {
+        $SigType = $asset.signature.type
+        $SigValue = $asset.signature.value
+        $SigPub = $asset.signature.public_key
+    }
+    if (-not $Version -and $ManifestVersion) {
+        $Version = $ManifestVersion
+    }
+} elseif (-not $NoVerify -and -not $DryRun) {
+    throw "manifest required for verification (set PYBUN_INSTALL_MANIFEST or use --no-verify)"
+}
+
+if ($DryRun) {
+    if ($Format -eq "json") {
+        $assetInfo = [ordered]@{
+            name = $AssetName
+            url = $AssetUrl
+            sha256 = $AssetSha
+        }
+        if ($SigType -or $SigValue -or $SigPub) {
+            $assetInfo.signature = [ordered]@{
+                type = $SigType
+                value = $SigValue
+                public_key = $SigPub
+            }
+        }
+        $manifestInfo = $null
+        if ($ManifestSource -or $ManifestVersion -or $ManifestChannel -or $ManifestReleaseUrl) {
+            $manifestInfo = [ordered]@{
+                source = $ManifestSource
+                version = $ManifestVersion
+                channel = $ManifestChannel
+                release_url = $ManifestReleaseUrl
+            }
+        }
+        $detail = [ordered]@{
+            status = "dry-run"
+            dry_run = $true
+            verify = (-not $NoVerify)
+            no_verify = [bool]$NoVerify
+            channel = $Channel
+            version = $Version
+            target = $Target
+            bin_dir = $BinDir
+            install_path = $InstallPath
+            manifest = $manifestInfo
+            asset = $assetInfo
+        }
+        $detail | ConvertTo-Json -Depth 6
+        exit 0
+    }
+
+    Write-Log "PyBun installer dry-run"
+    Write-Log "Target: $Target"
+    Write-Log "Manifest: $ManifestSource"
+    Write-Log "Asset: $AssetUrl"
+    Write-Log "Install path: $InstallPath"
+    Write-Log ("Verify: " + ($(if ($NoVerify) { "disabled" } else { "enabled" })))
+    exit 0
+}
+
+if ($NoVerify) {
+    Write-Log "warning: verification disabled (--no-verify)"
+}
+
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("pybun-install-" + [System.Guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $TempDir | Out-Null
+
+try {
+    $ArtifactPath = Join-Path $TempDir $AssetName
+    Write-Log "Downloading $AssetUrl"
+    Download-File -Url $AssetUrl -Destination $ArtifactPath
+
+    if (-not $NoVerify) {
+        if (-not $AssetSha) {
+            throw "manifest missing sha256 for asset"
+        }
+        Write-Log "Verifying SHA256"
+        $computed = (Get-FileHash -Algorithm SHA256 -Path $ArtifactPath).Hash.ToLowerInvariant()
+        if ($computed -ne $AssetSha.ToLowerInvariant()) {
+            throw "checksum mismatch: expected $AssetSha, got $computed"
+        }
+        if ($SigValue -and $SigPub) {
+            $minisign = Get-Command minisign -ErrorAction SilentlyContinue
+            if (-not $minisign) {
+                throw "minisign is required for signature verification (install minisign or use --no-verify)"
+            }
+            $SigPath = Join-Path $TempDir ($AssetName + ".minisig")
+            $PubPath = Join-Path $TempDir "pybun-release.pub"
+            Set-Content -Path $SigPath -Value $SigValue -Encoding ASCII
+            Set-Content -Path $PubPath -Value $SigPub -Encoding ASCII
+            Write-Log "Verifying signature (minisign)"
+            & minisign -Vm $ArtifactPath -x $SigPath -P $PubPath | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "minisign verification failed"
+            }
+        }
+    }
+
+    Write-Log "Extracting archive"
+    if ($ArchiveExt -eq "zip") {
+        Expand-Archive -Path $ArtifactPath -DestinationPath $TempDir -Force
+    } else {
+        & tar -xzf $ArtifactPath -C $TempDir
+    }
+
+    $ExtractedDir = Join-Path $TempDir ("pybun-" + $Target)
+    $BinSource = Join-Path $ExtractedDir $BinaryName
+    if (-not (Test-Path $BinSource)) {
+        throw "expected binary not found in archive: $BinSource"
+    }
+
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    Copy-Item -Path $BinSource -Destination $InstallPath -Force
+    if (-not $IsWindows) {
+        & chmod +x $InstallPath
+    }
+
+    Write-Log "Installed pybun to $InstallPath"
+} finally {
+    if (Test-Path $TempDir) {
+        Remove-Item -Recurse -Force $TempDir
+    }
+}
+
+if ($env:PATH -notlike "*$BinDir*") {
+    Write-Log "Add $BinDir to your PATH to use pybun."
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env sh
+set -eu
+
+CHANNEL="stable"
+VERSION=""
+PREFIX=""
+BIN_DIR=""
+NO_VERIFY=0
+DRY_RUN=0
+FORMAT="text"
+
+usage() {
+  cat <<'EOF'
+PyBun installer (macOS/Linux)
+
+Usage:
+  install.sh [options]
+
+Options:
+  --version <vX.Y.Z>   Install a specific version (overrides channel)
+  --channel <stable|nightly>
+  --prefix <path>      Install prefix (default: ~/.local)
+  --bin-dir <path>     Install bin directory (overrides prefix)
+  --no-verify          Skip checksum/signature verification (dangerous)
+  --dry-run            Print plan without downloading/installing
+  --format <text|json> Output format (default: text)
+  -h, --help           Show this help
+
+Environment:
+  PYBUN_INSTALL_MANIFEST   Override manifest source (path, file://, or URL)
+  PYBUN_INSTALL_FETCH=1    Fetch manifest even in dry-run
+EOF
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+die() {
+  log "error: $*"
+  exit 1
+}
+
+expand_path() {
+  case "$1" in
+    "~") printf '%s\n' "$HOME" ;;
+    "~/"*) printf '%s/%s\n' "$HOME" "${1#~/}" ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
+detect_target() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Darwin)
+      case "$arch" in
+        arm64) printf '%s\n' "aarch64-apple-darwin" ;;
+        x86_64) printf '%s\n' "x86_64-apple-darwin" ;;
+        *) die "unsupported macOS arch: $arch" ;;
+      esac
+      ;;
+    Linux)
+      case "$arch" in
+        x86_64)
+          if is_musl; then
+            printf '%s\n' "x86_64-unknown-linux-musl"
+          else
+            printf '%s\n' "x86_64-unknown-linux-gnu"
+          fi
+          ;;
+        aarch64|arm64) printf '%s\n' "aarch64-unknown-linux-gnu" ;;
+        *) die "unsupported Linux arch: $arch" ;;
+      esac
+      ;;
+    *)
+      die "unsupported OS: $os (use install.ps1 on Windows)"
+      ;;
+  esac
+}
+
+is_musl() {
+  if command -v ldd >/dev/null 2>&1; then
+    if ldd --version 2>&1 | grep -qi musl; then
+      return 0
+    fi
+  fi
+  if [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
+    return 0
+  fi
+  return 1
+}
+
+download_file() {
+  url="$1"
+  dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$dest"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO "$dest" "$url"
+    return
+  fi
+  die "curl or wget is required to download $url"
+}
+
+mktemp_file() {
+  mktemp 2>/dev/null || mktemp -t pybun
+}
+
+mktemp_dir() {
+  mktemp -d 2>/dev/null || mktemp -d -t pybun
+}
+
+sha256sum_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+  die "sha256sum or shasum is required for verification"
+}
+
+parse_manifest() {
+  manifest_path="$1"
+  target="$2"
+  python3 - "$manifest_path" "$target" <<'PY'
+import json
+import shlex
+import sys
+
+manifest_path = sys.argv[1]
+target = sys.argv[2]
+with open(manifest_path, "r", encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+asset = None
+for item in manifest.get("assets", []):
+    if item.get("target") == target:
+        asset = item
+        break
+
+if not asset:
+    sys.exit(2)
+
+sig = asset.get("signature") or {}
+def emit(name, value):
+    print(f"{name}={shlex.quote(value or '')}")
+
+emit("MANIFEST_VERSION", manifest.get("version", ""))
+emit("MANIFEST_CHANNEL", manifest.get("channel", ""))
+emit("MANIFEST_RELEASE_URL", manifest.get("release_url", ""))
+emit("ASSET_NAME_FROM_MANIFEST", asset.get("name", ""))
+emit("ASSET_URL_FROM_MANIFEST", asset.get("url", ""))
+emit("ASSET_SHA_FROM_MANIFEST", asset.get("sha256", ""))
+emit("SIG_TYPE_FROM_MANIFEST", sig.get("type", ""))
+emit("SIG_VALUE_FROM_MANIFEST", sig.get("value", ""))
+emit("SIG_PUB_FROM_MANIFEST", sig.get("public_key", ""))
+PY
+}
+
+emit_json() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 is required for JSON output"
+  fi
+  PYBUN_JSON_STATUS="$1" \
+  PYBUN_JSON_TARGET="$2" \
+  PYBUN_JSON_CHANNEL="$3" \
+  PYBUN_JSON_VERSION="$4" \
+  PYBUN_JSON_BIN_DIR="$5" \
+  PYBUN_JSON_INSTALL_PATH="$6" \
+  PYBUN_JSON_VERIFY="$7" \
+  PYBUN_JSON_NO_VERIFY="$8" \
+  PYBUN_JSON_DRY_RUN="$9" \
+  PYBUN_JSON_MANIFEST_SOURCE="${10}" \
+  PYBUN_JSON_MANIFEST_VERSION="${11}" \
+  PYBUN_JSON_MANIFEST_CHANNEL="${12}" \
+  PYBUN_JSON_MANIFEST_RELEASE_URL="${13}" \
+  PYBUN_JSON_ASSET_NAME="${14}" \
+  PYBUN_JSON_ASSET_URL="${15}" \
+  PYBUN_JSON_ASSET_SHA="${16}" \
+  PYBUN_JSON_SIG_TYPE="${17}" \
+  PYBUN_JSON_SIG_VALUE="${18}" \
+  PYBUN_JSON_SIG_PUB="${19}" \
+  python3 - <<'PY'
+import json
+import os
+
+def env(name):
+    return os.environ.get(name) or None
+
+def env_bool(name):
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    return value.lower() in ("1", "true", "yes")
+
+asset = {
+    "name": env("PYBUN_JSON_ASSET_NAME"),
+    "url": env("PYBUN_JSON_ASSET_URL"),
+    "sha256": env("PYBUN_JSON_ASSET_SHA"),
+}
+
+sig_type = env("PYBUN_JSON_SIG_TYPE")
+sig_value = env("PYBUN_JSON_SIG_VALUE")
+sig_pub = env("PYBUN_JSON_SIG_PUB")
+if sig_type or sig_value or sig_pub:
+    asset["signature"] = {
+        "type": sig_type,
+        "value": sig_value,
+        "public_key": sig_pub,
+    }
+
+manifest = {
+    "source": env("PYBUN_JSON_MANIFEST_SOURCE"),
+    "version": env("PYBUN_JSON_MANIFEST_VERSION"),
+    "channel": env("PYBUN_JSON_MANIFEST_CHANNEL"),
+    "release_url": env("PYBUN_JSON_MANIFEST_RELEASE_URL"),
+}
+manifest = {k: v for k, v in manifest.items() if v}
+
+payload = {
+    "status": env("PYBUN_JSON_STATUS"),
+    "dry_run": env_bool("PYBUN_JSON_DRY_RUN"),
+    "verify": env_bool("PYBUN_JSON_VERIFY"),
+    "no_verify": env_bool("PYBUN_JSON_NO_VERIFY"),
+    "channel": env("PYBUN_JSON_CHANNEL"),
+    "version": env("PYBUN_JSON_VERSION"),
+    "target": env("PYBUN_JSON_TARGET"),
+    "bin_dir": env("PYBUN_JSON_BIN_DIR"),
+    "install_path": env("PYBUN_JSON_INSTALL_PATH"),
+    "manifest": manifest or None,
+    "asset": asset,
+}
+
+print(json.dumps(payload))
+PY
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#*=}"
+      shift 1
+      ;;
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    --channel=*)
+      CHANNEL="${1#*=}"
+      shift 1
+      ;;
+    --prefix)
+      PREFIX="${2:-}"
+      shift 2
+      ;;
+    --prefix=*)
+      PREFIX="${1#*=}"
+      shift 1
+      ;;
+    --bin-dir)
+      BIN_DIR="${2:-}"
+      shift 2
+      ;;
+    --bin-dir=*)
+      BIN_DIR="${1#*=}"
+      shift 1
+      ;;
+    --no-verify)
+      NO_VERIFY=1
+      shift 1
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift 1
+      ;;
+    --format)
+      FORMAT="${2:-}"
+      shift 2
+      ;;
+    --format=*)
+      FORMAT="${1#*=}"
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+if [ "$CHANNEL" != "stable" ] && [ "$CHANNEL" != "nightly" ]; then
+  die "channel must be stable or nightly"
+fi
+
+if [ -z "${HOME:-}" ] && [ -z "$PREFIX" ] && [ -z "$BIN_DIR" ]; then
+  die "HOME is not set; pass --prefix or --bin-dir"
+fi
+
+if [ -n "$BIN_DIR" ]; then
+  BIN_DIR="$(expand_path "$BIN_DIR")"
+  if [ -z "$PREFIX" ]; then
+    PREFIX="$(dirname "$BIN_DIR")"
+  else
+    PREFIX="$(expand_path "$PREFIX")"
+  fi
+else
+  if [ -n "$PREFIX" ]; then
+    PREFIX="$(expand_path "$PREFIX")"
+  else
+    if [ "$(id -u)" -eq 0 ]; then
+      PREFIX="/usr/local"
+    else
+      PREFIX="$(expand_path "~/.local")"
+    fi
+  fi
+  BIN_DIR="$PREFIX/bin"
+fi
+
+TARGET="$(detect_target)"
+ARCHIVE_EXT="tar.gz"
+ASSET_NAME="pybun-${TARGET}.${ARCHIVE_EXT}"
+INSTALL_PATH="$BIN_DIR/pybun"
+
+MANIFEST_SOURCE="${PYBUN_INSTALL_MANIFEST:-}"
+if [ -z "$MANIFEST_SOURCE" ]; then
+  if [ -n "$VERSION" ]; then
+    VERSION="${VERSION#v}"
+    RELEASE_TAG="v$VERSION"
+    MANIFEST_SOURCE="https://github.com/pybun/pybun/releases/download/${RELEASE_TAG}/pybun-release.json"
+  elif [ "$CHANNEL" = "nightly" ]; then
+    MANIFEST_SOURCE="https://github.com/pybun/pybun/releases/download/nightly/pybun-release.json"
+  else
+    MANIFEST_SOURCE="https://github.com/pybun/pybun/releases/latest/download/pybun-release.json"
+  fi
+fi
+
+if [ -n "$VERSION" ]; then
+  RELEASE_TAG="v${VERSION#v}"
+  ASSET_URL="https://github.com/pybun/pybun/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
+elif [ "$CHANNEL" = "nightly" ]; then
+  ASSET_URL="https://github.com/pybun/pybun/releases/download/nightly/${ASSET_NAME}"
+else
+  ASSET_URL="https://github.com/pybun/pybun/releases/latest/download/${ASSET_NAME}"
+fi
+
+MANIFEST_PATH=""
+case "$MANIFEST_SOURCE" in
+  file://*)
+    MANIFEST_PATH="${MANIFEST_SOURCE#file://}"
+    ;;
+  http://*|https://*)
+    if [ "${PYBUN_INSTALL_FETCH:-}" = "1" ] || { [ "$NO_VERIFY" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; }; then
+      tmp_manifest="$(mktemp_file)"
+      download_file "$MANIFEST_SOURCE" "$tmp_manifest"
+      MANIFEST_PATH="$tmp_manifest"
+    fi
+    ;;
+  *)
+    if [ -f "$MANIFEST_SOURCE" ]; then
+      MANIFEST_PATH="$MANIFEST_SOURCE"
+    fi
+    ;;
+esac
+
+MANIFEST_VERSION=""
+MANIFEST_CHANNEL=""
+MANIFEST_RELEASE_URL=""
+ASSET_SHA=""
+SIG_TYPE=""
+SIG_VALUE=""
+SIG_PUB=""
+
+if [ -n "$MANIFEST_PATH" ]; then
+  if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 is required to parse the release manifest"
+  fi
+  if manifest_vars="$(parse_manifest "$MANIFEST_PATH" "$TARGET")"; then
+    eval "$manifest_vars"
+    MANIFEST_VERSION="${MANIFEST_VERSION:-}"
+    MANIFEST_CHANNEL="${MANIFEST_CHANNEL:-}"
+    MANIFEST_RELEASE_URL="${MANIFEST_RELEASE_URL:-}"
+    ASSET_NAME="${ASSET_NAME_FROM_MANIFEST:-$ASSET_NAME}"
+    ASSET_URL="${ASSET_URL_FROM_MANIFEST:-$ASSET_URL}"
+    ASSET_SHA="${ASSET_SHA_FROM_MANIFEST:-}"
+    SIG_TYPE="${SIG_TYPE_FROM_MANIFEST:-}"
+    SIG_VALUE="${SIG_VALUE_FROM_MANIFEST:-}"
+    SIG_PUB="${SIG_PUB_FROM_MANIFEST:-}"
+    if [ -n "$MANIFEST_VERSION" ] && [ -z "$VERSION" ]; then
+      VERSION="$MANIFEST_VERSION"
+    fi
+  else
+    die "no asset found in manifest for target: $TARGET"
+  fi
+elif [ "$NO_VERIFY" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+  die "manifest required for verification (set PYBUN_INSTALL_MANIFEST or use --no-verify)"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  if [ "$FORMAT" = "json" ]; then
+    emit_json \
+      "dry-run" \
+      "$TARGET" \
+      "$CHANNEL" \
+      "${VERSION:-}" \
+      "$BIN_DIR" \
+      "$INSTALL_PATH" \
+      "$([ "$NO_VERIFY" -eq 0 ] && printf 'true' || printf 'false')" \
+      "$([ "$NO_VERIFY" -eq 1 ] && printf 'true' || printf 'false')" \
+      "true" \
+      "$MANIFEST_SOURCE" \
+      "$MANIFEST_VERSION" \
+      "$MANIFEST_CHANNEL" \
+      "$MANIFEST_RELEASE_URL" \
+      "$ASSET_NAME" \
+      "$ASSET_URL" \
+      "$ASSET_SHA" \
+      "$SIG_TYPE" \
+      "$SIG_VALUE" \
+      "$SIG_PUB"
+    exit 0
+  fi
+
+  log "PyBun installer dry-run"
+  log "Target: $TARGET"
+  log "Manifest: $MANIFEST_SOURCE"
+  log "Asset: $ASSET_URL"
+  log "Install path: $INSTALL_PATH"
+  log "Verify: $([ "$NO_VERIFY" -eq 0 ] && printf 'enabled' || printf 'disabled')"
+  exit 0
+fi
+
+if [ "$NO_VERIFY" -eq 1 ]; then
+  log "warning: verification disabled (--no-verify)"
+fi
+
+tmp_dir="$(mktemp_dir)"
+trap 'rm -rf "$tmp_dir"' EXIT
+artifact_path="$tmp_dir/$ASSET_NAME"
+
+log "Downloading $ASSET_URL"
+download_file "$ASSET_URL" "$artifact_path"
+
+if [ "$NO_VERIFY" -eq 0 ]; then
+  if [ -z "$ASSET_SHA" ]; then
+    die "manifest missing sha256 for asset"
+  fi
+  log "Verifying SHA256"
+  computed_sha="$(sha256sum_file "$artifact_path")"
+  if [ "$computed_sha" != "$ASSET_SHA" ]; then
+    die "checksum mismatch: expected $ASSET_SHA, got $computed_sha"
+  fi
+  if [ -n "$SIG_VALUE" ] && [ -n "$SIG_PUB" ]; then
+    if ! command -v minisign >/dev/null 2>&1; then
+      die "minisign is required for signature verification (install minisign or use --no-verify)"
+    fi
+    sig_path="$tmp_dir/${ASSET_NAME}.minisig"
+    pub_path="$tmp_dir/pybun-release.pub"
+    printf '%s\n' "$SIG_VALUE" > "$sig_path"
+    printf '%s\n' "$SIG_PUB" > "$pub_path"
+    log "Verifying signature (minisign)"
+    minisign -Vm "$artifact_path" -x "$sig_path" -P "$pub_path" >/dev/null
+  fi
+fi
+
+log "Extracting archive"
+tar -xzf "$artifact_path" -C "$tmp_dir"
+extracted_dir="$tmp_dir/pybun-${TARGET}"
+bin_source="$extracted_dir/pybun"
+if [ ! -f "$bin_source" ]; then
+  die "expected binary not found in archive: $bin_source"
+fi
+
+mkdir -p "$BIN_DIR"
+if command -v install >/dev/null 2>&1; then
+  install -m 0755 "$bin_source" "$INSTALL_PATH"
+else
+  cp "$bin_source" "$INSTALL_PATH"
+  chmod +x "$INSTALL_PATH"
+fi
+
+log "Installed pybun to $INSTALL_PATH"
+
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *)
+    log "Add $BIN_DIR to your PATH to use pybun:"
+    log "  export PATH=\"$BIN_DIR:\$PATH\""
+    ;;
+esac

--- a/tests/install_scripts.rs
+++ b/tests/install_scripts.rs
@@ -1,0 +1,127 @@
+//! Tests for installer scripts (dry-run).
+
+use std::fs;
+use std::process::Command;
+
+use pybun::release_manifest::current_release_target;
+use serde_json::json;
+use tempfile::tempdir;
+
+fn write_manifest(target: &str, path: &std::path::Path) -> (String, String) {
+    let archive_ext = if target.contains("windows") {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    let asset_name = format!("pybun-{}.{}", target, archive_ext);
+    let asset_url = format!("https://example.com/{}", asset_name);
+    let manifest = json!({
+        "version": "9.9.9",
+        "channel": "stable",
+        "published_at": "2025-01-01T00:00:00Z",
+        "assets": [
+            {
+                "name": asset_name,
+                "target": target,
+                "url": asset_url,
+                "sha256": "deadbeef",
+                "signature": {
+                    "type": "minisign",
+                    "value": "ZHVtbXktc2lnbmF0dXJl",
+                    "public_key": "ZHVtbXktcHVibGljLWtleQ=="
+                }
+            }
+        ]
+    });
+
+    fs::write(path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+    (asset_url, "deadbeef".to_string())
+}
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_dry_run_emits_json() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join("pybun-release.json");
+    let target = current_release_target().expect("supported release target");
+    let (asset_url, asset_sha) = write_manifest(&target, &manifest_path);
+    let prefix = temp.path().join("prefix");
+    let expected_bin = prefix.join("bin");
+    let expected_bin_str = expected_bin.display().to_string();
+
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--dry-run")
+        .arg("--format")
+        .arg("json")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "installer should exit cleanly: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(detail["status"].as_str(), Some("dry-run"));
+    assert_eq!(detail["target"].as_str(), Some(target.as_str()));
+    assert_eq!(detail["asset"]["url"].as_str(), Some(asset_url.as_str()));
+    assert_eq!(detail["asset"]["sha256"].as_str(), Some(asset_sha.as_str()));
+    assert_eq!(detail["bin_dir"].as_str(), Some(expected_bin_str.as_str()));
+    assert_eq!(detail["verify"].as_bool(), Some(true));
+}
+
+#[test]
+fn install_ps1_dry_run_emits_json() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join("pybun-release.json");
+    let target = current_release_target().expect("supported release target");
+    let (asset_url, asset_sha) = write_manifest(&target, &manifest_path);
+    let prefix = temp.path().join("prefix");
+    let expected_bin = prefix.join("bin");
+    let expected_bin_str = expected_bin.display().to_string();
+
+    let pwsh_available = Command::new("pwsh")
+        .args(["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"])
+        .output()
+        .is_ok();
+    if !pwsh_available {
+        eprintln!("pwsh not available; skipping PowerShell installer test");
+        return;
+    }
+
+    let output = Command::new("pwsh")
+        .args([
+            "-NoProfile",
+            "-File",
+            "scripts/install.ps1",
+            "-DryRun",
+            "-Format",
+            "json",
+            "-Prefix",
+        ])
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "installer should exit cleanly: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(detail["status"].as_str(), Some("dry-run"));
+    assert_eq!(detail["target"].as_str(), Some(target.as_str()));
+    assert_eq!(detail["asset"]["url"].as_str(), Some(asset_url.as_str()));
+    assert_eq!(detail["asset"]["sha256"].as_str(), Some(asset_sha.as_str()));
+    assert_eq!(detail["bin_dir"].as_str(), Some(expected_bin_str.as_str()));
+    assert_eq!(detail["verify"].as_bool(), Some(true));
+}


### PR DESCRIPTION
## Description
- Add scripts/install.sh and scripts/install.ps1 with manifest-driven verification and dry-run JSON output
- Update install docs in README and docs/qiita.md
- Add tests/install_scripts.rs coverage for dry-run outputs
- Mark PR6.6 done in docs/PLAN.md

## Motivation and Context
Provide a verification-first, one-liner install UX that consumes signed release artifacts.

Fixes #N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manually tested on [OS/Platform]

Tests:
- cargo test --test install_scripts

## Checklist
- [ ] My code follows the code style of this project (cargo fmt)
- [ ] My code passes all lint checks (cargo clippy)
- [ ] All tests pass (cargo test)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass

## Additional Notes
N/A
