### PR TITLE
Fix relaxed semver handling for two-segment specs

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -563,9 +563,21 @@ fn build_requested_chain(
 
 /// Compare two version strings, returning their ordering.
 fn compare_versions(a: &str, b: &str) -> Ordering {
-    match (Version::parse(a), Version::parse(b)) {
-        (Ok(left), Ok(right)) => left.cmp(&right),
+    match (parse_version_relaxed(a), parse_version_relaxed(b)) {
+        (Some(left), Some(right)) => left.cmp(&right),
         _ => a.cmp(b),
+    }
+}
+
+fn parse_version_relaxed(input: &str) -> Option<Version> {
+    if let Ok(v) = Version::parse(input) {
+        return Some(v);
+    }
+    let parts: Vec<&str> = input.split('.').collect();
+    match parts.len() {
+        1 => Version::parse(&format!("{}.0.0", input)).ok(),
+        2 => Version::parse(&format!("{}.0", input)).ok(),
+        _ => None,
     }
 }
 

--- a/tests/resolver_basic.rs
+++ b/tests/resolver_basic.rs
@@ -182,6 +182,21 @@ async fn compatible_release_major_minor_only() {
 }
 
 #[tokio::test]
+async fn relaxed_semver_handles_two_segment_requirement() {
+    // >=3.7 should accept 3.10.8 even though the specifier omits patch
+    let mut index = InMemoryIndex::default();
+    index.add("root", "1.0.0", ["lib>=3.7"]);
+    index.add("lib", "3.10.8", Vec::<&str>::new());
+    index.add("lib", "3.6.9", Vec::<&str>::new());
+
+    let resolution = resolve(vec![Requirement::exact("root", "1.0.0")], &index)
+        .await
+        .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(lib.version, "3.10.8");
+}
+
+#[tokio::test]
 async fn errors_when_no_version_meets_maximum() {
     let mut index = InMemoryIndex::default();
     index.add("app", "1.0.0", ["lib<1.0.0"]);


### PR DESCRIPTION
## Summary
- allow resolver to parse 1- and 2-segment version specs by padding patch to 0
- fix version comparison to use relaxed parsing instead of string compare fallback
- add test covering >=3.7 requirement satisfied by 3.10.8

## Testing
- CARGO_INCREMENTAL=0 cargo test relaxed_semver_handles_two_segment_requirement -- --nocapture
- CARGO_INCREMENTAL=0 cargo test
