### PR TITLE
Add upper-bound install E2E and relaxed resolver sync

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -449,15 +449,6 @@ pub async fn resolve(
     Ok(Resolution { packages: resolved })
 }
 
-fn select_package_from_candidates(
-    reqs: &BTreeMap<String, Vec<Requirement>>,
-    name: &str,
-    candidates: &[ResolvedPackage],
-    requested_by: Option<&str>,
-) -> Result<ResolvedPackage, ResolveError> {
-    select_with_constraints(reqs, name, candidates, requested_by)
-}
-
 fn select_with_constraints(
     reqs: &BTreeMap<String, Vec<Requirement>>,
     name: &str,
@@ -631,7 +622,7 @@ fn parse_version_relaxed(input: &str) -> Option<Version> {
     }
     let prefix_norm = parts[..3].join(".");
     let suffix_norm = suffix
-        .trim_start_matches(|c| c == '-' || c == '_' || c == '.')
+        .trim_start_matches(['-', '_', '.'])
         .to_ascii_lowercase();
     let semver_str = if suffix_norm.is_empty() {
         prefix_norm

--- a/tests/cli_install.rs
+++ b/tests/cli_install.rs
@@ -256,6 +256,31 @@ fn install_with_compatible_release_specifier() {
     assert_eq!(lib.version, "1.4.5", "~=1.4.0 should select 1.4.5");
 }
 
+#[test]
+fn install_resolves_under_upper_bound_with_higher_version_available() {
+    // numpy<2.4 should pick 2.3.5 even if 2.4.0 exists
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_specifiers_path();
+
+    bin()
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "root-numpy==1.0.0",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let numpy = lock.packages.get("numpy").expect("numpy entry");
+    assert_eq!(numpy.version, "2.3.5");
+}
+
 // =============================================================================
 // PR1.8: Install from pyproject.toml (normal flow)
 // =============================================================================

--- a/tests/fixtures/index_specifiers.json
+++ b/tests/fixtures/index_specifiers.json
@@ -25,6 +25,21 @@
     "dependencies": ["lib~=1.4.0"]
   },
   {
+    "name": "root-numpy",
+    "version": "1.0.0",
+    "dependencies": ["numpy<2.4"]
+  },
+  {
+    "name": "numpy",
+    "version": "2.3.5",
+    "dependencies": []
+  },
+  {
+    "name": "numpy",
+    "version": "2.4.0",
+    "dependencies": []
+  },
+  {
     "name": "lib",
     "version": "1.0.0",
     "dependencies": []


### PR DESCRIPTION
## Summary
- add CLI install E2E to verify upper-bound resolution picks 2.3.5 when 2.4.0 also exists (numpy<2.4)
- extend index_specifiers fixture with numpy variants and root-numpy package
- align resolver changes by carrying relaxed constraint intersection already synced from main

## Testing
- CARGO_INCREMENTAL=0 cargo test install_resolves_under_upper_bound_with_higher_version_available -- --nocapture
- CARGO_INCREMENTAL=0 cargo test
