### PR TITLE
docs: add CLI progress UX plan and spec

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -250,6 +250,11 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Depends on: PR6.7 パッケージマネージャ導線, PR6.8 PyPI shim。
   - Implementation: install.sh/PowerShell の symlink/launcher 作成を追加、Homebrew Formula/Scoop/winget manifest に別名を登録、PyPI shim で追加 console_script を提供。README/Quickstart に別名と衝突時の案内を追記し、既存 `pybun` が Bun の場合に warning を出すオプションを検討。
   - Tests: install script dry-run で別名作成を確認、packaging テストで alias バイナリが配置されることを検証、衝突時の warning 表示が出ることを E2E で確認。
+- PR7.7: CLI 進捗UI（Bun 風の途中経過表示）
+  - Goal: `pybun install/add/test/build/run` などの長い処理で、解決/ダウンロード/ビルド/配置の進捗を人間向けに可視化。TTY ではスピナー/プログレスバー、非TTYや `--format=json` では抑制。
+  - Depends on: PR4.1 グローバルイベントスキーマ, PR4.4 observability。
+  - Implementation: JSON イベントストリームから進捗レンダラーを構成（resolve/download/build/install）。`--progress=auto|always|never` + `--no-progress` エイリアス、`PYBUN_PROGRESS` を追加。`--format=json` は UI を無効化しイベントのみ出力。
+  - Tests: text 出力のゴールデン/スナップショット、`--no-progress` の抑制、TTY 判定、JSON イベントとの整合性。
 
 ### Benchmark Analysis & Optimization Roadmap
 

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -187,6 +187,7 @@ CLI の出力を構造化データとして提供するモード。
 ## 6\. CLI インターフェース仕様 (CLI Reference)
 
 Bun の UX を踏襲し、短く直感的なコマンド体系とする。
+テキスト出力では、解決/ダウンロード/ビルド/配置の **途中経過** を逐次表示し、TTY ではスピナーやプログレスバーで視認性を高める。`--progress=auto|always|never`（または `--no-progress`）で制御し、`--format=json` の場合は UI を無効化してイベントのみ出力する。
 
 | コマンド | 説明 | 既存ツール対応 |
 | :--- | :--- | :--- |
@@ -201,7 +202,7 @@ Bun の UX を踏襲し、短く直感的なコマンド体系とする。
 | `pybun self update` | バイナリアップデート（署名検証付） | - |
 | `pybun mcp serve` | MCP サーバーとして待受（stdio先行、HTTPは段階導入） | - |
 
-**共通フラグ例:** `--format=json|text`, `--profile`, `--python 3.11`, `--cache-dir`, `--offline`, `--no-lock`, `--verbose`, `--quiet`.
+**共通フラグ例:** `--format=json|text`, `--profile`, `--python 3.11`, `--cache-dir`, `--offline`, `--no-lock`, `--verbose`, `--quiet`, `--progress=auto|always|never`.
 
 -----
 


### PR DESCRIPTION
## Summary
- add PR7.7 task for Bun-like CLI progress UI in the implementation plan
- document progress UI behavior and flags in SPECS

## Testing
- not run (docs-only changes)