### PR TITLE
docs: expand PLAN tasks for GA & perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 
 # Benchmark results (generated)
 scripts/benchmark/results/
+
+ref/uv


### PR DESCRIPTION
This PR updates the project plan with concrete follow-up tasks and uv-inspired performance work.

- Add actionable GA/UX tasks under PR7.1/7.3/7.4/7.6/7.7 + new PR7.8
- Add perf optimization items inspired by uv (PR-OPT9..12: runtime/allocator, metadata fetch, caching, dedupe)
- Ignore local reference symlink `ref/uv` in `.gitignore`

Files:
- docs/PLAN.md
- .gitignore
