### PR TITLE
PR-OPT8: ベンチマークスクリプト改善

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -382,7 +382,7 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Expected: Simple startup を 22ms 以下に。
   - Priority: Medium
 
-- [ ] PR-OPT8: ベンチマークスクリプト改善
+- [DONE] PR-OPT8: ベンチマークスクリプト改善
   - **分析**: B3.2_warm の高 StdDev (78ms) はベンチマーク手法に起因する可能性。
   - **問題**:
     1. PEP 723 スクリプトが `tempfile.TemporaryDirectory` に配置されるため、毎回パスが変わる。
@@ -397,6 +397,8 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
     7. 依存ダウンロードの影響を分離するため、依存を事前取得した状態（wheel cache あり）での cold を追加測定。
   - Expected: StdDev を 10ms 以下に安定化。
   - Priority: Low
+  - Current: PEP 723  fixture を `scripts/benchmark/fixtures/pep723.py` に固定し、B3.2 の cold/warm 前に pep723 envs と FS cache のクリアを実施（許可/対応OSのみ）。trimmed mean 用に `trim_ratio` を追加し、デフォルト iterations を 10 に増加。ベンチ結果メタデータに cache 状態を付与。
+  - Tests: `python3 -m unittest discover -s scripts/benchmark/tests`
 
 - [DONE] PR-OPT9: CLI ランタイム/アロケータ最適化（uv の実装を踏襲）
   - **背景**: uv は current-thread tokio runtime + `shutdown_background()` により、起動オーバーヘッドと “終了時に待たされる” 問題を避けている（例: `ref/uv/crates/uv/src/lib.rs:2522`）。また jemalloc/mimalloc を global allocator として有効化している（例: `ref/uv/crates/uv-performance-memory-allocator/src/lib.rs`）。

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -63,8 +63,9 @@ scripts/benchmark/
 
 ```toml
 [general]
-iterations = 5           # 反復回数
+iterations = 10          # 反復回数
 warmup = 1               # ウォームアップ回数
+trim_ratio = 0.1         # 外れ値除外の割合（左右）
 timeout_seconds = 300    # タイムアウト
 
 [tools]
@@ -78,6 +79,9 @@ pipx = true
 enabled = true
 pep723 = true
 profiles = ["dev", "prod"]
+pep723_fixture = "fixtures/pep723.py"
+pep723_clear_envs = true
+pep723_clear_fs_cache = true
 ```
 
 ## 出力形式
@@ -209,4 +213,3 @@ uv = "/path/to/uv"
 [general]
 timeout_seconds = 600
 ```
-

--- a/scripts/benchmark/config.toml
+++ b/scripts/benchmark/config.toml
@@ -1,8 +1,9 @@
 # PyBun Benchmark Configuration
 
 [general]
-iterations = 5           # Number of iterations per benchmark
+iterations = 10          # Number of iterations per benchmark
 warmup = 1               # Warmup runs (not counted)
+trim_ratio = 0.1         # Trim ratio for outlier removal (per tail)
 timeout_seconds = 300    # Maximum time per scenario
 hyperfine_path = ""      # Optional: path to hyperfine binary for more accurate timing
 
@@ -34,6 +35,9 @@ warm_cache = true
 enabled = true
 pep723 = true
 profiles = ["dev", "prod"]
+pep723_fixture = "fixtures/pep723.py"
+pep723_clear_envs = true
+pep723_clear_fs_cache = true
 
 [scenarios.adhoc]
 enabled = true
@@ -61,4 +65,3 @@ format = "json"                     # json, markdown, csv
 include_system_info = true
 save_raw_results = true
 results_dir = "results"
-

--- a/scripts/benchmark/fixtures/pep723.py
+++ b/scripts/benchmark/fixtures/pep723.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "requests>=2.28.0",
+# ]
+# ///
+"""PEP 723 script with dependencies."""
+import requests
+
+print(f"requests version: {requests.__version__}")

--- a/scripts/benchmark/scenarios/adhoc.py
+++ b/scripts/benchmark/scenarios/adhoc.py
@@ -25,6 +25,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -61,6 +62,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                         warmup=0,  # No warmup for cold run
                         iterations=1,
                         env={"PYBUN_X_CACHE": tmpdir},  # Use temp cache
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B4.1_cold_{package}"
                     result.tool = "pybun"
@@ -82,6 +84,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                         warmup=0,
                         iterations=1,
                         env={"PIPX_HOME": tmpdir},
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B4.1_cold_{package}"
                     result.tool = "pipx"
@@ -108,6 +111,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                         warmup=0,
                         iterations=1,
                         env={"UV_TOOL_DIR": tmpdir},
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B4.1_cold_{package}"
                     result.tool = "uvx"
@@ -131,6 +135,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = f"B4.2_warm_{package}"
                 result.tool = "pybun"
@@ -151,6 +156,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = f"B4.2_warm_{package}"
                 result.tool = "pipx"
@@ -175,6 +181,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = f"B4.2_warm_{package}"
                 result.tool = "uvx"
@@ -196,11 +203,12 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
         else:
             if verbose:
                 print(f"  Running: {' '.join(cmd)}")
-            result = measure_command(
-                cmd,
-                warmup=warmup,
-                iterations=iterations,
-            )
+                result = measure_command(
+                    cmd,
+                    warmup=warmup,
+                    iterations=iterations,
+                    trim_ratio=trim_ratio,
+                )
             result.scenario = "B4.3_versioned"
             result.tool = "pybun"
             result.metadata["package"] = versioned_package
@@ -218,6 +226,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                 cmd,
                 warmup=warmup,
                 iterations=iterations,
+                trim_ratio=trim_ratio,
             )
             result.scenario = "B4.3_versioned"
             result.tool = "pipx"
@@ -240,6 +249,7 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
                 cmd,
                 warmup=warmup,
                 iterations=iterations,
+                trim_ratio=trim_ratio,
             )
             result.scenario = "B4.3_versioned"
             result.tool = "uvx"
@@ -248,4 +258,3 @@ def adhoc_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list
             print(f"  uvx {versioned_package}: {result.duration_ms:.2f}ms")
     
     return results
-

--- a/scripts/benchmark/scenarios/install.py
+++ b/scripts/benchmark/scenarios/install.py
@@ -80,6 +80,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -127,6 +128,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                         cmd,
                         warmup=0,  # No warmup for cold
                         iterations=1,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = "B2.1_cold_install"
@@ -153,6 +155,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                             cmd,
                             warmup=0,
                             iterations=1,
+                            trim_ratio=trim_ratio,
                             cwd=str(tmp),
                         )
                         result.scenario = "B2.1_cold_install"
@@ -203,6 +206,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                         cmd,
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = "B2.2_warm_install"
@@ -229,6 +233,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                             cmd,
                             warmup=warmup,
                             iterations=iterations,
+                            trim_ratio=trim_ratio,
                             cwd=str(tmp),
                         )
                         result.scenario = "B2.2_warm_install"
@@ -267,6 +272,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                     cmd,
                     warmup=0,
                     iterations=1,  # Large install, single run
+                    trim_ratio=trim_ratio,
                     cwd=str(tmp),
                 )
                 result.scenario = "B2.3_large_install"
@@ -294,6 +300,7 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                         cmd,
                         warmup=0,
                         iterations=1,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = "B2.3_large_install"
@@ -303,4 +310,3 @@ def install_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> li
                     print(f"  pip install (large): {result.duration_ms:.2f}ms")
     
     return results
-

--- a/scripts/benchmark/scenarios/lazy_import.py
+++ b/scripts/benchmark/scenarios/lazy_import.py
@@ -112,6 +112,7 @@ def lazy_import_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -145,6 +146,7 @@ def lazy_import_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
                         cmd,
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B6.1_heavy_{module}"
                     result.tool = "python"
@@ -178,6 +180,7 @@ print(f"{{(end - start) / 1e6:.2f}}")
                         warmup=warmup,
                         iterations=iterations,
                         env={"PYBUN_LAZY_IMPORT": "1"},
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B6.1_heavy_{module}"
                     result.tool = "pybun_lazy"
@@ -203,6 +206,7 @@ print(f"{{(end - start) / 1e6:.2f}}")
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B6.2_many_imports"
                 result.tool = "python"
@@ -222,6 +226,7 @@ print(f"{{(end - start) / 1e6:.2f}}")
                     warmup=warmup,
                     iterations=iterations,
                     env={"PYBUN_LAZY_IMPORT": "1"},
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B6.2_many_imports"
                 result.tool = "pybun_lazy"
@@ -272,6 +277,7 @@ print(f"import:{import_ms:.2f},access:{access_ms:.2f}")
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B6.3_access_timing"
                 result.tool = "python"
@@ -290,6 +296,7 @@ print(f"import:{import_ms:.2f},access:{access_ms:.2f}")
                     warmup=warmup,
                     iterations=iterations,
                     env={"PYBUN_LAZY_IMPORT": "1"},
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B6.3_access_timing"
                 result.tool = "pybun_lazy"
@@ -297,4 +304,3 @@ print(f"import:{import_ms:.2f},access:{access_ms:.2f}")
                 print(f"  pybun lazy: {result.duration_ms:.2f}ms")
     
     return results
-

--- a/scripts/benchmark/scenarios/mcp.py
+++ b/scripts/benchmark/scenarios/mcp.py
@@ -143,6 +143,7 @@ def mcp_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -254,6 +255,7 @@ def mcp_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                 cmd,
                 warmup=warmup,
                 iterations=iterations,
+                trim_ratio=trim_ratio,
             )
             result.scenario = "B8.4_json_overhead"
             result.tool = "pybun_text"
@@ -273,6 +275,7 @@ def mcp_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                 cmd,
                 warmup=warmup,
                 iterations=iterations,
+                trim_ratio=trim_ratio,
             )
             result.scenario = "B8.4_json_overhead"
             result.tool = "pybun_json"
@@ -286,4 +289,3 @@ def mcp_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                 print(f"  JSON overhead: {overhead:.1f}%")
     
     return results
-

--- a/scripts/benchmark/scenarios/module_find.py
+++ b/scripts/benchmark/scenarios/module_find.py
@@ -72,6 +72,7 @@ def module_find_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -108,6 +109,7 @@ def module_find_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
                         [python_path, str(timer_script), module],
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B5.1_stdlib_{module}"
                     result.tool = "python_import"
@@ -127,6 +129,7 @@ def module_find_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
                         [pybun_path, "module-find", module],
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B5.1_stdlib_{module}"
                     result.tool = "pybun"
@@ -152,6 +155,7 @@ def module_find_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
                         [pybun_path, "module-find", module],
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B5.2_thirdparty_{module}"
                     result.tool = "pybun"
@@ -184,6 +188,7 @@ def module_find_benchmark(config: dict, scenario_config: dict, base_dir: Path) -
                         [pybun_path, "module-find", "--scan", str(fake_pkg)],
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = "B5.3_large_scan"
                     result.tool = "pybun"
@@ -209,6 +214,7 @@ print(f"{{len(files)}} files in {{(end-start)/1e6:.2f}}ms")
                         [python_path, str(scan_script)],
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = "B5.3_large_scan"
                     result.tool = "python_glob"
@@ -228,6 +234,7 @@ print(f"{{len(files)}} files in {{(end-start)/1e6:.2f}}ms")
                     [pybun_path, "module-find", "os"],
                     warmup=0,
                     iterations=1,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B5.4_cache_cold"
                 result.tool = "pybun"
@@ -243,6 +250,7 @@ print(f"{{len(files)}} files in {{(end-start)/1e6:.2f}}ms")
                     [pybun_path, "module-find", "os"],
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B5.4_cache_warm"
                 result.tool = "pybun"
@@ -258,6 +266,7 @@ print(f"{{len(files)}} files in {{(end-start)/1e6:.2f}}ms")
                     [pybun_path, "module-find", "--benchmark", "os"],
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B5.4_benchmark_mode"
                 result.tool = "pybun"
@@ -266,4 +275,3 @@ print(f"{{len(files)}} files in {{(end-start)/1e6:.2f}}ms")
                 print(f"  pybun module-find --benchmark os: {result.duration_ms:.2f}ms")
     
     return results
-

--- a/scripts/benchmark/scenarios/resolution.py
+++ b/scripts/benchmark/scenarios/resolution.py
@@ -129,6 +129,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -170,6 +171,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                         cmd,
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = f"{scenario_id}_resolution"
@@ -208,6 +210,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                         cmd,
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = f"{scenario_id}_resolution"
@@ -245,6 +248,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                         cmd,
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = f"{scenario_id}_resolution"
@@ -272,6 +276,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                         cmd,
                         warmup=0,  # Poetry lock is slow
                         iterations=1,
+                        trim_ratio=trim_ratio,
                         cwd=str(tmp),
                     )
                     result.scenario = f"{scenario_id}_resolution"
@@ -297,6 +302,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                     cwd=str(tmp),
                 )
                 result.scenario = "B1.4_conflict"
@@ -316,6 +322,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                     cwd=str(tmp),
                 )
                 result.scenario = "B1.4_conflict"
@@ -341,6 +348,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                     cmd,
                     warmup=0,
                     iterations=1,
+                    trim_ratio=trim_ratio,
                     cwd=str(tmp),
                 )
                 result.scenario = "B1.5_cached_cold"
@@ -356,6 +364,7 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                     cwd=str(tmp),
                 )
                 result.scenario = "B1.5_cached_warm"
@@ -364,4 +373,3 @@ def resolution_benchmark(config: dict, scenario_config: dict, base_dir: Path) ->
                 print(f"  pybun (warm): {result.duration_ms:.2f}ms")
     
     return results
-

--- a/scripts/benchmark/scenarios/test.py
+++ b/scripts/benchmark/scenarios/test.py
@@ -118,6 +118,7 @@ def test_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
     general = config.get("general", {})
     iterations = general.get("iterations", 5)
     warmup = general.get("warmup", 1)
+    trim_ratio = scenario_config.get("trim_ratio", general.get("trim_ratio", 0.0))
     dry_run = config.get("dry_run", False)
     verbose = config.get("verbose", False)
     
@@ -156,6 +157,7 @@ def test_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.1_discovery"
                 result.tool = "pybun"
@@ -176,6 +178,7 @@ def test_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.1_discovery"
                 result.tool = "pytest"
@@ -199,6 +202,7 @@ def test_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.2_small_suite"
                 result.tool = "pybun"
@@ -217,6 +221,7 @@ def test_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.2_small_suite"
                 result.tool = "pytest"
@@ -252,6 +257,7 @@ if __name__ == "__main__":
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.2_small_suite"
                 result.tool = "unittest"
@@ -273,6 +279,7 @@ if __name__ == "__main__":
                         cmd,
                         warmup=warmup,
                         iterations=iterations,
+                        trim_ratio=trim_ratio,
                     )
                     result.scenario = f"B7.3_parallel_{workers}"
                     result.tool = "pybun"
@@ -299,6 +306,7 @@ if __name__ == "__main__":
                             cmd,
                             warmup=warmup,
                             iterations=iterations,
+                            trim_ratio=trim_ratio,
                         )
                         result.scenario = f"B7.3_parallel_{workers}"
                         result.tool = "pytest-xdist"
@@ -319,6 +327,7 @@ if __name__ == "__main__":
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.4_ast_vs_pytest"
                 result.tool = "pybun_ast"
@@ -334,6 +343,7 @@ if __name__ == "__main__":
                     cmd,
                     warmup=warmup,
                     iterations=iterations,
+                    trim_ratio=trim_ratio,
                 )
                 result.scenario = "B7.4_ast_vs_pytest"
                 result.tool = "pybun_pytest_compat"
@@ -341,4 +351,3 @@ if __name__ == "__main__":
                 print(f"  pybun --pytest-compat: {result.duration_ms:.2f}ms")
     
     return results
-

--- a/scripts/benchmark/tests/test_bench.py
+++ b/scripts/benchmark/tests/test_bench.py
@@ -1,0 +1,31 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import bench
+
+
+class TestTrimSamples(unittest.TestCase):
+    def test_trim_samples_drops_outliers(self) -> None:
+        samples = [1.0, 2.0, 100.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        trimmed = bench.trim_samples(samples, trim_ratio=0.1)
+        self.assertEqual(trimmed, [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+
+    def test_trim_samples_noop_when_ratio_zero(self) -> None:
+        samples = [3.0, 1.0, 2.0]
+        trimmed = bench.trim_samples(samples, trim_ratio=0.0)
+        self.assertEqual(trimmed, samples)
+
+
+class TestComputeStats(unittest.TestCase):
+    def test_compute_stats_uses_trimmed_samples(self) -> None:
+        samples = [1.0, 2.0, 100.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        stats = bench.compute_stats(samples, trim_ratio=0.1)
+        self.assertAlmostEqual(stats[0], 5.5, places=2)
+        self.assertEqual(stats[4], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark/tests/test_run.py
+++ b/scripts/benchmark/tests/test_run.py
@@ -1,0 +1,19 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scenarios import run as run_scenario
+
+
+class TestRunScenario(unittest.TestCase):
+    def test_resolve_pep723_script_default(self) -> None:
+        base_dir = Path(__file__).resolve().parents[1]
+        script = run_scenario.resolve_pep723_script(base_dir, {})
+        self.assertTrue(script.exists())
+        self.assertTrue(str(script).endswith("fixtures/pep723.py"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- 固定されたPEP 723フィクスチャを導入し、B3.2のパス変動を排除\n- trimmed meanの計測（trim_ratio）とiterations増加で外れ値影響を低減\n- pep723 envs/FS cacheのクリア状態をメタデータに記録\n\n## Tests\n- python3 -m unittest discover -s scripts/benchmark/tests\n- PATH=$(pwd)/target/release:$PATH python3 scripts/benchmark/bench.py -s run --format markdown