### PR TITLE
PR7.1: API/JSON schema freeze + compat tests

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -225,15 +225,17 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Tests: 新規 `tests/pypi_integration.rs` でデフォルト PyPI 解決、キャッシュを使ったオフライン再実行、キャッシュ無しオフライン失敗をモックサーバーで検証。`cargo test`, `just lint` 実行済み。
 
 ### M7: GA Launch / Release Readiness
-- PR7.1: API/JSON schema freeze + compat tests
+- [DONE] PR7.1: API/JSON schema freeze + compat tests
   - Goal: CLI flags/env/exit codes と JSON schema v1 を GA で凍結し、ヘルプ/JSONのスナップショットテストで後方互換を守る（`--format=json` 各コマンド、`pybun --help` diff ガード）。
   - Depends on: M4 schema完成, M5/M6 release artifacts.
   - Tests: ゴールデンテストを CI に追加（text+json）。`pybun schema check` のような自己診断を用意できると良い。
   - Implementation (Tasks):
-    - [ ] `pybun schema print|check` を追加（schema v1 の出力 + 破壊的変更検知）
-    - [ ] `pybun --help` / 各サブコマンド help の text snapshot を追加（diff guard）
-    - [ ] 代表コマンドの JSON snapshot を追加（envelope/version/events/diagnostics を固定）
-    - [ ] CI に「snapshot差分があれば失敗」を追加（GA後の互換性維持）
+    - [x] `pybun schema print|check` を追加（schema v1 の出力 + 破壊的変更検知）
+    - [x] `pybun --help` / 各サブコマンド help の text snapshot を追加（diff guard）
+    - [x] 代表コマンドの JSON snapshot を追加（envelope/version/events/diagnostics を固定）
+    - [x] CI に「snapshot差分があれば失敗」を追加（GA後の互換性維持）
+  - Current: `schema/schema_v1.json` を追加し、`pybun schema print|check` で v1 定義の出力/検証が可能に。`tests/compat_snapshots.rs` で help/JSON のスナップショット差分ガードを追加し、`PYBUN_UPDATE_SNAPSHOTS=1` で更新可能にした。
+  - Tests: `just lint`, `just fmt`, `CARGO_INCREMENTAL=0 cargo test`, `PYBUN_UPDATE_SNAPSHOTS=1 cargo test --test compat_snapshots`, `cargo build --release`, `PATH=$(pwd)/target/release:$PATH python3 scripts/benchmark/bench.py -s run --format markdown`.
 - PR7.2: Telemetry UX/Privacy finalize（PR6.3完了後の仕上げ）
   - Goal: デフォルト opt-in/opt-out ポリシーと UI を確定し、`pybun telemetry status|enable|disable` を提供。収集フィールドのレダクションリストと Privacy Notice を docs/README に記載。
   - Depends on: PR6.3。

--- a/schema/schema_v1.json
+++ b/schema/schema_v1.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pybun.dev/schema/cli-output/v1.json",
+  "title": "PyBun CLI JSON Envelope",
+  "type": "object",
+  "required": [
+    "version",
+    "command",
+    "status",
+    "duration_ms",
+    "detail",
+    "events",
+    "diagnostics"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1"
+    },
+    "command": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "error"]
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "detail": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/event"
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "trace_id": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "event": {
+      "type": "object",
+      "required": ["type", "timestamp_ms"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "command_start",
+            "command_end",
+            "resolve_start",
+            "resolve_progress",
+            "resolve_complete",
+            "install_start",
+            "download_start",
+            "download_progress",
+            "download_complete",
+            "extract_start",
+            "extract_complete",
+            "install_complete",
+            "env_create",
+            "env_activate",
+            "script_start",
+            "script_end",
+            "cache_hit",
+            "cache_miss",
+            "cache_write",
+            "python_list_start",
+            "python_list_complete",
+            "python_install_start",
+            "python_install_complete",
+            "python_remove_start",
+            "python_remove_complete",
+            "module_find_start",
+            "module_find_complete",
+            "lazy_import_start",
+            "lazy_import_complete",
+            "watch_start",
+            "watch_stop",
+            "file_change",
+            "test_start",
+            "test_discovery",
+            "test_pass",
+            "test_fail",
+            "test_skip",
+            "test_complete",
+            "progress",
+            "custom"
+          ]
+        },
+        "timestamp_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "data": {
+          "type": ["object", "array", "string", "number", "boolean", "null"]
+        },
+        "progress": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "diagnostic": {
+      "type": "object",
+      "required": ["level", "message"],
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["error", "warning", "info", "hint"]
+        },
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "file": {
+          "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "suggestion": {
+          "type": "string"
+        },
+        "context": {
+          "type": ["object", "array", "string", "number", "boolean", "null"]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,9 @@ pub enum Commands {
     Watch(WatchArgs),
     /// Show or configure launch profiles.
     Profile(ProfileArgs),
+    /// Print or validate the CLI JSON schema.
+    #[command(subcommand)]
+    Schema(SchemaCommands),
 }
 
 #[derive(Subcommand, Debug)]
@@ -240,6 +243,24 @@ pub struct DoctorArgs {
 pub enum McpCommands {
     /// Start MCP server for programmatic control.
     Serve(McpServeArgs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SchemaCommands {
+    /// Print the JSON schema for CLI output.
+    Print(SchemaPrintArgs),
+    /// Check the JSON schema against the frozen v1 definition.
+    Check(SchemaCheckArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SchemaPrintArgs {}
+
+#[derive(Args, Debug)]
+pub struct SchemaCheckArgs {
+    /// Optional path to compare against the embedded schema.
+    #[arg(long, value_name = "PATH")]
+    pub path: Option<std::path::PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -28,6 +28,15 @@ use uuid::Uuid;
 
 /// Schema version - bump when breaking changes occur
 pub const SCHEMA_VERSION: &str = "1";
+pub const SCHEMA_V1_JSON: &str = include_str!("../schema/schema_v1.json");
+
+pub fn schema_v1_json() -> Value {
+    serde_json::from_str(SCHEMA_V1_JSON).expect("schema v1 JSON must be valid")
+}
+
+pub fn schema_v1_pretty() -> String {
+    serde_json::to_string_pretty(&schema_v1_json()).expect("schema v1 JSON serialization")
+}
 
 /// Response status
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/tests/compat_snapshots.rs
+++ b/tests/compat_snapshots.rs
@@ -1,0 +1,137 @@
+//! Compatibility snapshots for CLI help and JSON output (PR7.1).
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn pybun() -> Command {
+    cargo_bin_cmd!("pybun")
+}
+
+fn snapshots_root() -> PathBuf {
+    PathBuf::from("tests/snapshots/compat")
+}
+
+fn update_snapshots() -> bool {
+    std::env::var("PYBUN_UPDATE_SNAPSHOTS").is_ok()
+}
+
+fn assert_snapshot(path: &Path, actual: &str) {
+    if update_snapshots() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create snapshot dir");
+        }
+        fs::write(path, actual).expect("write snapshot");
+        return;
+    }
+
+    let expected = fs::read_to_string(path).expect("read snapshot");
+    assert_eq!(expected, actual, "snapshot mismatch: {}", path.display());
+}
+
+fn normalize_envelope(mut value: Value) -> Value {
+    if let Some(obj) = value.as_object_mut() {
+        if let Some(duration) = obj.get_mut("duration_ms") {
+            *duration = json!(0);
+        }
+
+        if let Some(trace_id) = obj.get_mut("trace_id")
+            && !trace_id.is_null()
+        {
+            *trace_id = json!("<trace_id>");
+        }
+
+        if let Some(events) = obj.get_mut("events").and_then(|v| v.as_array_mut()) {
+            for event in events {
+                if let Some(ts) = event
+                    .as_object_mut()
+                    .and_then(|event_obj| event_obj.get_mut("timestamp_ms"))
+                {
+                    *ts = json!(0);
+                }
+            }
+        }
+    }
+
+    value
+}
+
+fn snapshot_json(name: &str, raw: &str) {
+    let value: Value = serde_json::from_str(raw).expect("valid JSON output");
+    let normalized = normalize_envelope(value);
+    let pretty = serde_json::to_string_pretty(&normalized).expect("pretty JSON");
+    let path = snapshots_root().join(format!("{}.json", name));
+    assert_snapshot(&path, &pretty);
+}
+
+fn snapshot_text(name: &str, raw: &str) {
+    let path = snapshots_root().join(format!("{}.txt", name));
+    assert_snapshot(&path, raw);
+}
+
+#[test]
+fn help_snapshots() {
+    let cases: &[(&str, &[&str])] = &[
+        ("help_root", &["--help"]),
+        ("help_install", &["install", "--help"]),
+        ("help_add", &["add", "--help"]),
+        ("help_remove", &["remove", "--help"]),
+        ("help_lock", &["lock", "--help"]),
+        ("help_run", &["run", "--help"]),
+        ("help_x", &["x", "--help"]),
+        ("help_test", &["test", "--help"]),
+        ("help_build", &["build", "--help"]),
+        ("help_doctor", &["doctor", "--help"]),
+        ("help_mcp", &["mcp", "--help"]),
+        ("help_mcp_serve", &["mcp", "serve", "--help"]),
+        ("help_self", &["self", "--help"]),
+        ("help_self_update", &["self", "update", "--help"]),
+        ("help_gc", &["gc", "--help"]),
+        ("help_python", &["python", "--help"]),
+        ("help_python_list", &["python", "list", "--help"]),
+        ("help_python_install", &["python", "install", "--help"]),
+        ("help_python_remove", &["python", "remove", "--help"]),
+        ("help_python_which", &["python", "which", "--help"]),
+        ("help_module_find", &["module-find", "--help"]),
+        ("help_lazy_import", &["lazy-import", "--help"]),
+        ("help_watch", &["watch", "--help"]),
+        ("help_profile", &["profile", "--help"]),
+        ("help_schema", &["schema", "--help"]),
+        ("help_schema_print", &["schema", "print", "--help"]),
+        ("help_schema_check", &["schema", "check", "--help"]),
+    ];
+
+    for (name, args) in cases {
+        let output = pybun()
+            .args(*args)
+            .output()
+            .expect("failed to run pybun help");
+        assert!(output.status.success(), "help command failed: {}", name);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        snapshot_text(name, &stdout);
+    }
+}
+
+#[test]
+fn json_snapshots() {
+    let cases: &[(&str, &[&str])] = &[
+        ("json_schema_print", &["--format=json", "schema", "print"]),
+        ("json_schema_check", &["--format=json", "schema", "check"]),
+        (
+            "json_self_update_dry_run",
+            &["--format=json", "self", "update", "--dry-run"],
+        ),
+    ];
+
+    for (name, args) in cases {
+        let output = pybun()
+            .args(*args)
+            .output()
+            .expect("failed to run pybun json");
+        assert!(output.status.success(), "json command failed: {}", name);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        snapshot_json(name, &stdout);
+    }
+}

--- a/tests/snapshots/compat/help_add.txt
+++ b/tests/snapshots/compat/help_add.txt
@@ -1,0 +1,11 @@
+Add a package and update lockfile
+
+Usage: pybun add [OPTIONS] [PACKAGE]
+
+Arguments:
+  [PACKAGE]  Package name (optionally with version)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --offline          Use offline mode when cache is sufficient
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_build.txt
+++ b/tests/snapshots/compat/help_build.txt
@@ -1,0 +1,8 @@
+Build distributable artifacts
+
+Usage: pybun build [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --sbom             Emit SBOM along with artifacts
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_doctor.txt
+++ b/tests/snapshots/compat/help_doctor.txt
@@ -1,0 +1,8 @@
+Diagnose environment and produce support bundle
+
+Usage: pybun doctor [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --verbose          Include verbose logs in bundle
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_gc.txt
+++ b/tests/snapshots/compat/help_gc.txt
@@ -1,0 +1,9 @@
+Manage caches
+
+Usage: pybun gc [OPTIONS]
+
+Options:
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --max-size <MAX_SIZE>  Maximum cache size (e.g., 10G); LRU eviction if exceeded
+      --dry-run              Preview what would be deleted without actually deleting
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_install.txt
+++ b/tests/snapshots/compat/help_install.txt
@@ -1,0 +1,11 @@
+Install dependencies from lock or project metadata
+
+Usage: pybun install [OPTIONS]
+
+Options:
+      --format <FORMAT>          Output format for machine readability [default: text] [possible values: text, json]
+      --offline                  Use offline mode when cache is sufficient
+      --require <NAME==VERSION>  Requirements to install (temporary M1 flag)
+      --index <INDEX>            Path to index JSON (temporary M1 flag)
+      --lock <LOCK>              Path to write lockfile [default: pybun.lockb]
+  -h, --help                     Print help

--- a/tests/snapshots/compat/help_lazy_import.txt
+++ b/tests/snapshots/compat/help_lazy_import.txt
@@ -1,0 +1,15 @@
+Configure and generate lazy import settings
+
+Usage: pybun lazy-import [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --generate         Generate Python code for lazy import injection
+      --check <MODULE>   Check if a module would be lazily imported
+      --show-config      Show current configuration
+      --allow <MODULE>   Add module to allowlist
+      --deny <MODULE>    Add module to denylist
+      --log-imports      Enable logging of lazy imports in generated code
+      --no-fallback      Disable fallback to CPython import
+  -o, --output <FILE>    Output file for generated Python code
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_lock.txt
+++ b/tests/snapshots/compat/help_lock.txt
@@ -1,0 +1,10 @@
+Lock dependencies for scripts
+
+Usage: pybun lock [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --script <SCRIPT>  Lock dependencies for a PEP 723 script
+      --offline          Use offline mode when cache is sufficient
+      --index <INDEX>    Path to index JSON (temporary M1 flag)
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_mcp.txt
+++ b/tests/snapshots/compat/help_mcp.txt
@@ -1,0 +1,11 @@
+Run PyBun as an MCP server
+
+Usage: pybun mcp [OPTIONS] <COMMAND>
+
+Commands:
+  serve  Start MCP server for programmatic control
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_mcp_serve.txt
+++ b/tests/snapshots/compat/help_mcp_serve.txt
@@ -1,0 +1,9 @@
+Start MCP server for programmatic control
+
+Usage: pybun mcp serve [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --port <PORT>      Port to bind (for HTTP mode) [default: 9999]
+      --stdio            Use stdio mode for MCP communication
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_module_find.txt
+++ b/tests/snapshots/compat/help_module_find.txt
@@ -1,0 +1,14 @@
+Find Python modules using Rust-based module finder
+
+Usage: pybun module-find [OPTIONS] [MODULE]
+
+Arguments:
+  [MODULE]  Module name to find (e.g., "os.path", "numpy.core")
+
+Options:
+      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
+  -p, --path <PATH>        Search path(s) for modules. Can be specified multiple times
+      --scan               Scan directory and list all modules instead of finding a specific one
+      --benchmark          Show timing information for benchmarking
+      --threads <THREADS>  Number of threads for parallel scanning [default: 4]
+  -h, --help               Print help

--- a/tests/snapshots/compat/help_profile.txt
+++ b/tests/snapshots/compat/help_profile.txt
@@ -1,0 +1,14 @@
+Show or configure launch profiles
+
+Usage: pybun profile [OPTIONS] [PROFILE]
+
+Arguments:
+  [PROFILE]  Profile to show or set (dev, prod, benchmark)
+
+Options:
+      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
+      --list               List all available profiles
+      --show               Show detailed profile configuration
+      --compare <PROFILE>  Compare two profiles
+  -o, --output <FILE>      Export profile to a file
+  -h, --help               Print help

--- a/tests/snapshots/compat/help_python.txt
+++ b/tests/snapshots/compat/help_python.txt
@@ -1,0 +1,14 @@
+Manage Python versions (install, list, remove)
+
+Usage: pybun python [OPTIONS] <COMMAND>
+
+Commands:
+  list     List installed and available Python versions
+  install  Install a Python version
+  remove   Remove an installed Python version
+  which    Show path to Python for a version
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_python_install.txt
+++ b/tests/snapshots/compat/help_python_install.txt
@@ -1,0 +1,10 @@
+Install a Python version
+
+Usage: pybun python install [OPTIONS] <VERSION>
+
+Arguments:
+  <VERSION>  Version to install (e.g., 3.11, 3.12.7)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_python_list.txt
+++ b/tests/snapshots/compat/help_python_list.txt
@@ -1,0 +1,8 @@
+List installed and available Python versions
+
+Usage: pybun python list [OPTIONS]
+
+Options:
+      --all              Show all available versions (not just installed)
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_python_remove.txt
+++ b/tests/snapshots/compat/help_python_remove.txt
@@ -1,0 +1,10 @@
+Remove an installed Python version
+
+Usage: pybun python remove [OPTIONS] <VERSION>
+
+Arguments:
+  <VERSION>  Version to remove
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_python_which.txt
+++ b/tests/snapshots/compat/help_python_which.txt
@@ -1,0 +1,10 @@
+Show path to Python for a version
+
+Usage: pybun python which [OPTIONS] [VERSION]
+
+Arguments:
+  [VERSION]  Version to look up
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_remove.txt
+++ b/tests/snapshots/compat/help_remove.txt
@@ -1,0 +1,11 @@
+Remove a package and update lockfile
+
+Usage: pybun remove [OPTIONS] [PACKAGE]
+
+Arguments:
+  [PACKAGE]  Package name (optionally with version)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --offline          Use offline mode when cache is sufficient
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_root.txt
+++ b/tests/snapshots/compat/help_root.txt
@@ -1,0 +1,29 @@
+PyBun CLI: fast installer/runtime/tester for Python projects (use --sandbox for untrusted code)
+
+Usage: pybun [OPTIONS] <COMMAND>
+
+Commands:
+  install      Install dependencies from lock or project metadata
+  add          Add a package and update lockfile
+  remove       Remove a package and update lockfile
+  lock         Lock dependencies for scripts
+  run          Run a script with import/runtime optimizations
+  x            Run an ad-hoc package without prior install
+  test         Execute test suite with PyBun's fast runner
+  build        Build distributable artifacts
+  doctor       Diagnose environment and produce support bundle
+  mcp          Run PyBun as an MCP server
+  self         Self-related commands
+  gc           Manage caches
+  python       Manage Python versions (install, list, remove)
+  module-find  Find Python modules using Rust-based module finder
+  lazy-import  Configure and generate lazy import settings
+  watch        Watch files and reload on changes (dev mode)
+  profile      Show or configure launch profiles
+  schema       Print or validate the CLI JSON schema
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help
+  -V, --version          Print version

--- a/tests/snapshots/compat/help_run.txt
+++ b/tests/snapshots/compat/help_run.txt
@@ -1,0 +1,14 @@
+Run a script with import/runtime optimizations
+
+Usage: pybun run [OPTIONS] [TARGET] [-- <PASSTHROUGH>...]
+
+Arguments:
+  [TARGET]          Script or module to execute. Use -c for inline code
+  [PASSTHROUGH]...  Pass additional args to the target
+
+Options:
+      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
+      --sandbox            Run in sandboxed mode for untrusted code
+      --allow-network      Allow network access inside the sandbox (escape hatch)
+      --profile <PROFILE>  Optional profile (dev/prod/benchmark) [default: dev]
+  -h, --help               Print help

--- a/tests/snapshots/compat/help_schema.txt
+++ b/tests/snapshots/compat/help_schema.txt
@@ -1,0 +1,12 @@
+Print or validate the CLI JSON schema
+
+Usage: pybun schema [OPTIONS] <COMMAND>
+
+Commands:
+  print  Print the JSON schema for CLI output
+  check  Check the JSON schema against the frozen v1 definition
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_schema_check.txt
+++ b/tests/snapshots/compat/help_schema_check.txt
@@ -1,0 +1,8 @@
+Check the JSON schema against the frozen v1 definition
+
+Usage: pybun schema check [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+      --path <PATH>      Optional path to compare against the embedded schema
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_schema_print.txt
+++ b/tests/snapshots/compat/help_schema_print.txt
@@ -1,0 +1,7 @@
+Print the JSON schema for CLI output
+
+Usage: pybun schema print [OPTIONS]
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_self.txt
+++ b/tests/snapshots/compat/help_self.txt
@@ -1,0 +1,11 @@
+Self-related commands
+
+Usage: pybun self [OPTIONS] <COMMAND>
+
+Commands:
+  update  Update PyBun binary with signature verification
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/help_self_update.txt
+++ b/tests/snapshots/compat/help_self_update.txt
@@ -1,0 +1,9 @@
+Update PyBun binary with signature verification
+
+Usage: pybun self update [OPTIONS]
+
+Options:
+      --channel <CHANNEL>  Channel to update from (stable/nightly) [default: stable]
+      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
+      --dry-run            Check for updates without installing
+  -h, --help               Print help

--- a/tests/snapshots/compat/help_test.txt
+++ b/tests/snapshots/compat/help_test.txt
@@ -1,0 +1,22 @@
+Execute test suite with PyBun's fast runner
+
+Usage: pybun test [OPTIONS] [PATH]... [-- <PASSTHROUGH>...]
+
+Arguments:
+  [PATH]...         Test file(s) or directory to run. Defaults to current directory
+  [PASSTHROUGH]...  Additional arguments to pass to the test runner
+
+Options:
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --shard <SHARD>        Shard identifier (N/M) for distributed testing
+  -x, --fail-fast            Stop on first failure
+      --pytest-compat        Enable pytest compatibility layer
+      --backend <BACKEND>    Test runner backend (pytest or unittest). Auto-detected if not specified [possible values: pytest, unittest]
+      --discover             Only discover tests without running them
+  -j, --parallel <PARALLEL>  Run tests in parallel (number of workers)
+  -k, --filter <FILTER>      Filter tests by name pattern
+  -v, --verbose              Show verbose output including fixture information
+      --snapshot             Enable snapshot testing
+      --update-snapshots     Update snapshots instead of comparing them
+      --snapshot-dir <DIR>   Directory for snapshot files (default: __snapshots__)
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_watch.txt
+++ b/tests/snapshots/compat/help_watch.txt
@@ -1,0 +1,18 @@
+Watch files and reload on changes (dev mode)
+
+Usage: pybun watch [OPTIONS] [TARGET]
+
+Arguments:
+  [TARGET]  Script or command to run on file changes
+
+Options:
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+  -p, --path <PATH>          Paths to watch (can be specified multiple times)
+      --include <PATTERN>    File patterns to include (e.g., "*.py")
+      --exclude <PATTERN>    File patterns to exclude (e.g., "__pycache__")
+      --debounce <DEBOUNCE>  Debounce delay in milliseconds [default: 300]
+      --clear                Clear terminal before each reload
+      --show-config          Show configuration without starting watcher
+      --shell-command        Generate shell command for external watcher
+      --dry-run              Preview what would be watched without actually starting (for testing)
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_x.txt
+++ b/tests/snapshots/compat/help_x.txt
@@ -1,0 +1,11 @@
+Run an ad-hoc package without prior install
+
+Usage: pybun x [OPTIONS] [PACKAGE] [-- <PASSTHROUGH>...]
+
+Arguments:
+  [PACKAGE]         Package to execute temporarily
+  [PASSTHROUGH]...  Arguments to forward to the tool
+
+Options:
+      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
+  -h, --help             Print help

--- a/tests/snapshots/compat/json_schema_check.json
+++ b/tests/snapshots/compat/json_schema_check.json
@@ -1,0 +1,26 @@
+{
+  "command": "pybun schema check",
+  "detail": {
+    "embedded_version": "1",
+    "error": null,
+    "issues": [],
+    "mismatch": false,
+    "path": "schema/schema_v1.json",
+    "schema_version": "1",
+    "status": "ok"
+  },
+  "diagnostics": [],
+  "duration_ms": 0,
+  "events": [
+    {
+      "timestamp_ms": 0,
+      "type": "command_start"
+    },
+    {
+      "timestamp_ms": 0,
+      "type": "command_end"
+    }
+  ],
+  "status": "ok",
+  "version": "1"
+}

--- a/tests/snapshots/compat/json_schema_print.json
+++ b/tests/snapshots/compat/json_schema_print.json
@@ -1,0 +1,199 @@
+{
+  "command": "pybun schema print",
+  "detail": {
+    "schema": {
+      "$defs": {
+        "diagnostic": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "context": {
+              "type": [
+                "object",
+                "array",
+                "string",
+                "number",
+                "boolean",
+                "null"
+              ]
+            },
+            "file": {
+              "type": "string"
+            },
+            "level": {
+              "enum": [
+                "error",
+                "warning",
+                "info",
+                "hint"
+              ],
+              "type": "string"
+            },
+            "line": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "message": {
+              "type": "string"
+            },
+            "suggestion": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "level",
+            "message"
+          ],
+          "type": "object"
+        },
+        "event": {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "type": [
+                "object",
+                "array",
+                "string",
+                "number",
+                "boolean",
+                "null"
+              ]
+            },
+            "message": {
+              "type": "string"
+            },
+            "progress": {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "timestamp_ms": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": {
+              "enum": [
+                "command_start",
+                "command_end",
+                "resolve_start",
+                "resolve_progress",
+                "resolve_complete",
+                "install_start",
+                "download_start",
+                "download_progress",
+                "download_complete",
+                "extract_start",
+                "extract_complete",
+                "install_complete",
+                "env_create",
+                "env_activate",
+                "script_start",
+                "script_end",
+                "cache_hit",
+                "cache_miss",
+                "cache_write",
+                "python_list_start",
+                "python_list_complete",
+                "python_install_start",
+                "python_install_complete",
+                "python_remove_start",
+                "python_remove_complete",
+                "module_find_start",
+                "module_find_complete",
+                "lazy_import_start",
+                "lazy_import_complete",
+                "watch_start",
+                "watch_stop",
+                "file_change",
+                "test_start",
+                "test_discovery",
+                "test_pass",
+                "test_fail",
+                "test_skip",
+                "test_complete",
+                "progress",
+                "custom"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "timestamp_ms"
+          ],
+          "type": "object"
+        }
+      },
+      "$id": "https://pybun.dev/schema/cli-output/v1.json",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "detail": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "diagnostics": {
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          },
+          "type": "array"
+        },
+        "duration_ms": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "events": {
+          "items": {
+            "$ref": "#/$defs/event"
+          },
+          "type": "array"
+        },
+        "status": {
+          "enum": [
+            "ok",
+            "error"
+          ],
+          "type": "string"
+        },
+        "trace_id": {
+          "type": "string"
+        },
+        "version": {
+          "const": "1",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "command",
+        "status",
+        "duration_ms",
+        "detail",
+        "events",
+        "diagnostics"
+      ],
+      "title": "PyBun CLI JSON Envelope",
+      "type": "object"
+    },
+    "version": "1"
+  },
+  "diagnostics": [],
+  "duration_ms": 0,
+  "events": [
+    {
+      "timestamp_ms": 0,
+      "type": "command_start"
+    },
+    {
+      "timestamp_ms": 0,
+      "type": "command_end"
+    }
+  ],
+  "status": "ok",
+  "version": "1"
+}

--- a/tests/snapshots/compat/json_self_update_dry_run.json
+++ b/tests/snapshots/compat/json_self_update_dry_run.json
@@ -1,0 +1,33 @@
+{
+  "command": "pybun self update",
+  "detail": {
+    "channel": "stable",
+    "current_version": "0.1.0",
+    "dry_run": true,
+    "latest_version": "0.1.0",
+    "manifest": null,
+    "manifest_error": null,
+    "manifest_source": "https://github.com/pybun/pybun/releases/latest/download/pybun-release.json",
+    "release_url": "https://github.com/pybun/pybun/releases/tag/v0.1.0",
+    "update_available": false
+  },
+  "diagnostics": [
+    {
+      "level": "info",
+      "message": "Checking for updates on stable channel"
+    }
+  ],
+  "duration_ms": 0,
+  "events": [
+    {
+      "timestamp_ms": 0,
+      "type": "command_start"
+    },
+    {
+      "timestamp_ms": 0,
+      "type": "command_end"
+    }
+  ],
+  "status": "ok",
+  "version": "1"
+}


### PR DESCRIPTION
## Description
Add frozen v1 JSON schema, schema print/check commands, and compatibility snapshot tests for CLI help and representative JSON outputs.

## Motivation and Context
Freeze the CLI JSON schema and help surface for GA, with snapshot guards to prevent breaking changes.

Fixes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested on Darwin/arm64

Commands:
- `PYBUN_UPDATE_SNAPSHOTS=1 cargo test --test compat_snapshots`
- `just lint`
- `just fmt`
- `CARGO_INCREMENTAL=0 cargo test`
- `cargo build --release`
- `PATH=$(pwd)/target/release:$PATH python3 scripts/benchmark/bench.py -s run --format markdown`

Note: `just test-e2e` not available in Justfile; ran full `cargo test` instead.

## Checklist
- [x] My code follows the code style of this project (`cargo fmt`)
- [x] My code passes all lint checks (`cargo clippy`)
- [x] All tests pass (`cargo test`)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)

## Additional Notes
Snapshots can be updated via `PYBUN_UPDATE_SNAPSHOTS=1`.
