### PR TITLE
PR7.3: Supportability bundle + crash report hook

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -241,15 +241,11 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Depends on: PR6.3。
   - Current: `src/telemetry.rs` で TelemetryConfig/TelemetryManager/レダクションを実装。`cli.rs` に Telemetry サブコマンド (status/enable/disable) を追加。`~/.pybun/telemetry.json` に設定を永続化。環境変数 `PYBUN_TELEMETRY=0|1` でオーバーライド可能。デフォルトは無効 (opt-in)。README.md に Privacy Notice セクションを追加。
   - Tests: 12 E2E tests in `tests/telemetry.rs`（help, status with JSON, enable/disable, env override, redaction patterns）。10 unit tests in telemetry module.
-- PR7.3: Supportability bundle + crash report hook
+- [DONE] PR7.3: Supportability bundle + crash report hook
   - Goal: `pybun doctor --bundle` でログ/設定/trace を収集し、`--upload`（エンドポイントは env/flag 指定）でサニタイズ済みバンドルを送信。クラッシュ時にダンプ収集の opt-in フローを追加。
   - Depends on: PR5.4 doctor, PR4.4 observability.
-  - Tests: Bundle 内容のシークレットレダクション、オフライン時の graceful fallback、アップロード先モックでのE2Eを追加。
-  - Implementation (Tasks):
-    - [ ] `pybun doctor --bundle <path>` を実装（logs/config/trace/versions を収集）
-    - [ ] バンドル内の secrets を redact（env/token/URL credential 等のルール化）
-    - [ ] `pybun doctor --upload` を実装（エンドポイントは env/flag、デフォルト無送信）
-    - [ ] クラッシュ時の opt-in 収集フロー（ユーザー確認→保存/送信）
+  - Current: `src/support_bundle.rs` を追加し、`pybun doctor --bundle/--upload/--upload-url` で bundle 作成とアップロードを実装。ログ/設定/環境/versions を収集し、env・URL・クエリのシークレットレダクションを適用。クラッシュ時の opt-in プロンプトで bundle 作成/送信をサポート。
+  - Tests: `cargo test --test support_bundle`（bundle 作成＋env redaction、upload の E2E）、`src/support_bundle.rs` のユニットテスト（redaction ルール）。
 - PR7.4: GA docs + release note automation
   - Goal: docs を GA 用に再編（インストール導線/Homebrew/winget/PyPI shim/手動バイナリ、Quickstart、各コマンドのJSON例、sandbox/profile/test/build/MCPの運用ガイド）。タグから CHANGELOG/release notes を自動生成し、アップグレードガイド（pre-GA→GA）を用意。
   - Depends on: M6.6–6.8 チャネル整備。

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -240,6 +240,15 @@ pub struct DoctorArgs {
     /// Include verbose logs in bundle.
     #[arg(long)]
     pub verbose: bool,
+    /// Write support bundle to a directory.
+    #[arg(long, value_name = "PATH")]
+    pub bundle: Option<std::path::PathBuf>,
+    /// Upload support bundle to the configured endpoint.
+    #[arg(long)]
+    pub upload: bool,
+    /// Override the support bundle upload endpoint.
+    #[arg(long, value_name = "URL")]
+    pub upload_url: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -106,7 +106,12 @@ mod tests {
     fn doctor_cli(verbose: bool) -> Cli {
         Cli {
             format: OutputFormat::Text,
-            command: Commands::Doctor(DoctorArgs { verbose }),
+            command: Commands::Doctor(DoctorArgs {
+                verbose,
+                bundle: None,
+                upload: false,
+                upload_url: None,
+            }),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod schema;
 pub mod security;
 pub mod self_heal;
 pub mod snapshot;
+pub mod support_bundle;
 pub mod telemetry;
 pub mod test_discovery;
 pub mod test_executor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
 use clap::Parser;
 use color_eyre::eyre::{Result, WrapErr, eyre};
-use pybun::{cli::Cli, commands::execute, entry};
+use pybun::{cli::Cli, commands::execute, entry, support_bundle};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     if entry::should_install_color_eyre(&cli) {
         color_eyre::install()?;
     }
+    support_bundle::install_crash_hook();
 
     let stack_size = entry::runtime_stack_size();
     let main2 = move || -> Result<()> {

--- a/src/support_bundle.rs
+++ b/src/support_bundle.rs
@@ -1,0 +1,739 @@
+use crate::cache::Cache;
+use crate::paths::{ArtifactInfo, PyBunPaths};
+use crate::telemetry::DEFAULT_REDACTION_PATTERNS;
+use base64::Engine;
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_FILE_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug)]
+pub struct BundleContext {
+    pub checks: Vec<Value>,
+    pub verbose_logs: bool,
+    pub trace_id: Option<String>,
+    pub command: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BundleFile {
+    pub path: String,
+    pub bytes: u64,
+    pub truncated: bool,
+    pub redactions: usize,
+    pub encoding: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct BundleCollection {
+    pub path: PathBuf,
+    pub files: Vec<BundleFile>,
+    pub redactions: usize,
+    pub logs_included: bool,
+}
+
+#[derive(Debug)]
+pub struct UploadOutcome {
+    pub url: String,
+    pub status: String,
+    pub http_status: Option<u16>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct BundleReport {
+    pub bundle_path: Option<PathBuf>,
+    pub files: Vec<BundleFile>,
+    pub redactions: usize,
+    pub logs_included: bool,
+    pub upload: Option<UploadOutcome>,
+}
+
+static CRASH_HOOK_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+pub fn install_crash_hook() {
+    if CRASH_HOOK_INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        previous(info);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if !should_offer_crash_bundle() {
+                return;
+            }
+            if !io::stderr().is_terminal() || !io::stdin().is_terminal() {
+                return;
+            }
+            if !prompt_yes_no("PyBun crashed. Create a support bundle? [y/N] ") {
+                return;
+            }
+
+            let support_dir = default_support_dir();
+            let bundle_dir = support_dir.join(format!("crash-{}", unix_timestamp()));
+            let context = BundleContext {
+                checks: vec![json!({
+                    "name": "crash",
+                    "status": "error",
+                    "message": info.to_string(),
+                })],
+                verbose_logs: true,
+                trace_id: None,
+                command: "pybun crash".to_string(),
+            };
+
+            match build_support_bundle(&bundle_dir, &context) {
+                Ok(collection) => {
+                    eprintln!("Support bundle written to {}", collection.path.display());
+                    if let Ok(url) = std::env::var("PYBUN_SUPPORT_UPLOAD_URL") {
+                        let outcome = upload_bundle(&collection, &url);
+                        if outcome.status == "uploaded" {
+                            eprintln!("Support bundle uploaded to {}", url);
+                        } else if let Some(err) = outcome.error {
+                            eprintln!("Support bundle upload failed: {}", err);
+                        }
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Support bundle creation failed: {:?}", err);
+                }
+            }
+        }));
+    }));
+}
+
+impl BundleReport {
+    pub fn to_json(&self) -> Value {
+        let files: Vec<Value> = self
+            .files
+            .iter()
+            .map(|file| {
+                json!({
+                    "path": file.path,
+                    "bytes": file.bytes,
+                    "truncated": file.truncated,
+                    "redactions": file.redactions,
+                    "encoding": file.encoding,
+                })
+            })
+            .collect();
+
+        json!({
+            "path": self.bundle_path.as_ref().map(|path| path.display().to_string()),
+            "files": files,
+            "redactions": self.redactions,
+            "logs_included": self.logs_included,
+            "upload": self.upload.as_ref().map(|upload| {
+                json!({
+                    "url": upload.url,
+                    "status": upload.status,
+                    "http_status": upload.http_status,
+                    "error": upload.error,
+                })
+            }),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum BundleError {
+    Io(String),
+    Serialize(String),
+}
+
+impl From<std::io::Error> for BundleError {
+    fn from(err: std::io::Error) -> Self {
+        BundleError::Io(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for BundleError {
+    fn from(err: serde_json::Error) -> Self {
+        BundleError::Serialize(err.to_string())
+    }
+}
+
+pub fn build_support_bundle(
+    path: &Path,
+    context: &BundleContext,
+) -> Result<BundleCollection, BundleError> {
+    if path.exists() && !path.is_dir() {
+        return Err(BundleError::Io(format!(
+            "bundle path is not a directory: {}",
+            path.display()
+        )));
+    }
+
+    fs::create_dir_all(path)?;
+
+    let rules = RedactionRules::default();
+    let mut files = Vec::new();
+    let mut total_redactions = 0usize;
+
+    let manifest = build_manifest(context);
+    let manifest_path = path.join("manifest.json");
+    let (file, redactions) = write_json_file(&manifest_path, &manifest, &rules)?;
+    files.push(file);
+    total_redactions += redactions;
+
+    let doctor_path = path.join("doctor.json");
+    let doctor_json = json!({
+        "checks": context.checks,
+        "trace_id": context.trace_id,
+    });
+    let (file, redactions) = write_json_file(&doctor_path, &doctor_json, &rules)?;
+    files.push(file);
+    total_redactions += redactions;
+
+    let env_path = path.join("env.json");
+    let env_json = collect_env_json(&rules);
+    let (file, redactions) = write_json_file(&env_path, &env_json, &rules)?;
+    files.push(file);
+    total_redactions += redactions;
+
+    let versions_path = path.join("versions.json");
+    let versions_json = build_versions_json(context.trace_id.as_deref());
+    let (file, redactions) = write_json_file(&versions_path, &versions_json, &rules)?;
+    files.push(file);
+    total_redactions += redactions;
+
+    let mut logs_included = false;
+    if context.verbose_logs {
+        let mut log_files = Vec::new();
+        if let Ok(paths) = PyBunPaths::new() {
+            log_files.extend(collect_files(&paths.logs_dir()));
+        }
+        if let Ok(cache) = Cache::new() {
+            log_files.extend(collect_files(&cache.logs_dir()));
+        }
+        for log_file in log_files {
+            let rel = bundle_relpath("logs", &log_file);
+            let dest = path.join(&rel);
+            if let Some(parent) = dest.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let (file, redactions) = write_sanitized_file(&log_file, &dest, &rules)?;
+            files.push(BundleFile { path: rel, ..file });
+            total_redactions += redactions;
+        }
+        logs_included = true;
+    }
+
+    let mut config_files = Vec::new();
+    if let Ok(paths) = PyBunPaths::new() {
+        let telemetry = paths.root().join("telemetry.json");
+        if telemetry.exists() {
+            config_files.push(telemetry);
+        }
+    }
+    let env_cache = crate::env::pybun_home().join("env_cache.json");
+    if env_cache.exists() {
+        config_files.push(env_cache);
+    }
+
+    for config_file in config_files {
+        let rel = bundle_relpath("config", &config_file);
+        let dest = path.join(&rel);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let (file, redactions) = write_sanitized_file(&config_file, &dest, &rules)?;
+        files.push(BundleFile { path: rel, ..file });
+        total_redactions += redactions;
+    }
+
+    Ok(BundleCollection {
+        path: path.to_path_buf(),
+        files,
+        redactions: total_redactions,
+        logs_included,
+    })
+}
+
+pub fn upload_bundle(bundle: &BundleCollection, upload_url: &str) -> UploadOutcome {
+    let payload = json!({
+        "bundle_path": bundle.path.display().to_string(),
+        "files": bundle
+            .files
+            .iter()
+            .map(|file| {
+                let content = fs::read(bundle.path.join(&file.path))
+                    .ok()
+                    .and_then(|bytes| String::from_utf8(bytes).ok());
+                json!({
+                    "path": file.path,
+                    "bytes": file.bytes,
+                    "truncated": file.truncated,
+                    "redactions": file.redactions,
+                    "encoding": file.encoding,
+                    "content": content,
+                })
+            })
+            .collect::<Vec<_>>(),
+    });
+    let upload_url = upload_url.to_string();
+    let payload = payload.clone();
+    let upload_url_thread = upload_url.clone();
+
+    std::thread::spawn(move || {
+        let client = reqwest::blocking::Client::new();
+        match client.post(&upload_url_thread).json(&payload).send() {
+            Ok(response) => UploadOutcome {
+                url: upload_url_thread.clone(),
+                status: if response.status().is_success() {
+                    "uploaded".to_string()
+                } else {
+                    "failed".to_string()
+                },
+                http_status: Some(response.status().as_u16()),
+                error: response.error_for_status().err().map(|err| err.to_string()),
+            },
+            Err(err) => UploadOutcome {
+                url: upload_url_thread.clone(),
+                status: "failed".to_string(),
+                http_status: None,
+                error: Some(err.to_string()),
+            },
+        }
+    })
+    .join()
+    .unwrap_or_else(|_| UploadOutcome {
+        url: upload_url,
+        status: "failed".to_string(),
+        http_status: None,
+        error: Some("upload thread panicked".to_string()),
+    })
+}
+
+fn build_manifest(context: &BundleContext) -> Value {
+    json!({
+        "schema": 1,
+        "command": context.command,
+        "created_at": unix_timestamp(),
+        "trace_id": context.trace_id,
+    })
+}
+
+fn build_versions_json(trace_id: Option<&str>) -> Value {
+    let artifact = ArtifactInfo::from_env();
+    json!({
+        "pybun_version": artifact.version,
+        "target": artifact.target,
+        "commit": artifact.commit,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "trace_id": trace_id,
+    })
+}
+
+fn collect_env_json(rules: &RedactionRules) -> Value {
+    let mut env_map: BTreeMap<String, String> = BTreeMap::new();
+    for (key, value) in std::env::vars() {
+        let (redacted, _) = rules.redact_value(&key, &value);
+        env_map.insert(key, redacted);
+    }
+    json!({ "environment": env_map })
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn default_support_dir() -> PathBuf {
+    if let Ok(paths) = PyBunPaths::new() {
+        paths.root().join("support")
+    } else {
+        std::env::temp_dir().join("pybun-support")
+    }
+}
+
+fn should_offer_crash_bundle() -> bool {
+    if let Ok(value) = std::env::var("PYBUN_CRASH_REPORT") {
+        let value = value.trim().to_ascii_lowercase();
+        return matches!(value.as_str(), "1" | "true" | "yes" | "on" | "ask");
+    }
+    true
+}
+
+fn prompt_yes_no(prompt: &str) -> bool {
+    eprint!("{}", prompt);
+    let _ = io::stderr().flush();
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+    matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+fn bundle_relpath(prefix: &str, path: &Path) -> String {
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("{}/{}", prefix, file_name)
+}
+
+fn collect_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if !root.exists() {
+        return files;
+    }
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn write_json_file(
+    path: &Path,
+    value: &Value,
+    rules: &RedactionRules,
+) -> Result<(BundleFile, usize), BundleError> {
+    let redacted = rules.redact_json_value(value);
+    let content = serde_json::to_string_pretty(&redacted)?;
+    write_text_file(path, &content, rules)
+}
+
+fn write_text_file(
+    path: &Path,
+    content: &str,
+    rules: &RedactionRules,
+) -> Result<(BundleFile, usize), BundleError> {
+    let (sanitized, redactions) = rules.redact_text(content);
+    fs::write(path, sanitized.as_bytes())?;
+    let bytes = fs::metadata(path)?.len();
+    Ok((
+        BundleFile {
+            path: path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            bytes,
+            truncated: false,
+            redactions,
+            encoding: None,
+        },
+        redactions,
+    ))
+}
+
+fn write_sanitized_file(
+    src: &Path,
+    dest: &Path,
+    rules: &RedactionRules,
+) -> Result<(BundleFile, usize), BundleError> {
+    let mut file = fs::File::open(src)?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+
+    let truncated = buffer.len() > MAX_FILE_BYTES;
+    if truncated {
+        buffer.truncate(MAX_FILE_BYTES);
+    }
+
+    if let Ok(text) = std::str::from_utf8(&buffer) {
+        if let Ok(json_value) = serde_json::from_str::<Value>(text) {
+            let redacted = rules.redact_json_value(&json_value);
+            let content = serde_json::to_string_pretty(&redacted)?;
+            fs::write(dest, content.as_bytes())?;
+            let bytes = fs::metadata(dest)?.len();
+            let redactions = rules.redact_text(&content).1;
+            return Ok((
+                BundleFile {
+                    path: dest
+                        .file_name()
+                        .map(|name| name.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    bytes,
+                    truncated,
+                    redactions,
+                    encoding: None,
+                },
+                redactions,
+            ));
+        }
+
+        let (sanitized, redactions) = rules.redact_text(text);
+        fs::write(dest, sanitized.as_bytes())?;
+        let bytes = fs::metadata(dest)?.len();
+        return Ok((
+            BundleFile {
+                path: dest
+                    .file_name()
+                    .map(|name| name.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                bytes,
+                truncated,
+                redactions,
+                encoding: None,
+            },
+            redactions,
+        ));
+    }
+
+    let engine = base64::engine::general_purpose::STANDARD;
+    let encoded = engine.encode(buffer);
+    fs::write(dest, encoded.as_bytes())?;
+    let bytes = fs::metadata(dest)?.len();
+    Ok((
+        BundleFile {
+            path: dest
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            bytes,
+            truncated,
+            redactions: 0,
+            encoding: Some("base64".to_string()),
+        },
+        0,
+    ))
+}
+
+#[derive(Debug)]
+struct RedactionRules {
+    patterns: Vec<String>,
+}
+
+impl Default for RedactionRules {
+    fn default() -> Self {
+        let mut patterns: Vec<String> = DEFAULT_REDACTION_PATTERNS
+            .iter()
+            .map(|pattern| pattern.to_string())
+            .collect();
+        patterns.extend([
+            "*TOKEN*".to_string(),
+            "*PASSWORD*".to_string(),
+            "*SECRET*".to_string(),
+            "*KEY*".to_string(),
+        ]);
+        Self { patterns }
+    }
+}
+
+impl RedactionRules {
+    fn redact_value(&self, key: &str, value: &str) -> (String, usize) {
+        if self.key_matches(key) {
+            return ("<redacted>".to_string(), 1);
+        }
+        self.redact_text(value)
+    }
+
+    fn redact_text(&self, text: &str) -> (String, usize) {
+        let mut redactions = 0usize;
+        let mut output = String::new();
+        for (idx, line) in text.lines().enumerate() {
+            if idx > 0 {
+                output.push('\n');
+            }
+            let mut current = line.to_string();
+            if let Some((key, delimiter)) = extract_key_delimiter(line)
+                && self.key_matches(&key)
+            {
+                current = format!("{}{} <redacted>", key, delimiter);
+                redactions += 1;
+            }
+            let (url_redacted, count) = redact_url_credentials(&current);
+            current = url_redacted;
+            redactions += count;
+
+            let (query_redacted, count) = redact_query_params(&current);
+            current = query_redacted;
+            redactions += count;
+
+            output.push_str(&current);
+        }
+        (output, redactions)
+    }
+
+    fn redact_json_value(&self, value: &Value) -> Value {
+        match value {
+            Value::Object(map) => {
+                let mut redacted = serde_json::Map::new();
+                for (key, value) in map {
+                    if self.key_matches(key) {
+                        redacted.insert(key.clone(), Value::String("<redacted>".to_string()));
+                    } else {
+                        redacted.insert(key.clone(), self.redact_json_value(value));
+                    }
+                }
+                Value::Object(redacted)
+            }
+            Value::Array(items) => Value::Array(
+                items
+                    .iter()
+                    .map(|item| self.redact_json_value(item))
+                    .collect(),
+            ),
+            Value::String(text) => {
+                let (redacted, _) = self.redact_text(text);
+                Value::String(redacted)
+            }
+            other => other.clone(),
+        }
+    }
+
+    fn key_matches(&self, key: &str) -> bool {
+        let uppercase = key.to_ascii_uppercase();
+        self.patterns
+            .iter()
+            .any(|pattern| glob_match(pattern, &uppercase))
+    }
+}
+
+fn extract_key_delimiter(line: &str) -> Option<(String, String)> {
+    if let Some(pos) = line.find('=') {
+        let key = line[..pos].trim().trim_matches('"').to_string();
+        return Some((key, "=".to_string()));
+    }
+    if let Some(pos) = line.find(':') {
+        let key = line[..pos].trim().trim_matches('"').to_string();
+        return Some((key, ":".to_string()));
+    }
+    None
+}
+
+fn glob_match(pattern: &str, text: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    let mut parts = pattern.split('*').collect::<Vec<_>>();
+    if parts.len() == 1 {
+        return pattern == text;
+    }
+
+    let mut remainder = text;
+    let starts_with_wildcard = pattern.starts_with('*');
+    let ends_with_wildcard = pattern.ends_with('*');
+
+    if !starts_with_wildcard {
+        let start = parts.remove(0);
+        if !remainder.starts_with(start) {
+            return false;
+        }
+        remainder = &remainder[start.len()..];
+    }
+
+    if !ends_with_wildcard {
+        let end = parts.pop().unwrap_or_default();
+        if !remainder.ends_with(end) {
+            return false;
+        }
+        remainder = &remainder[..remainder.len() - end.len()];
+    }
+
+    for part in parts {
+        if part.is_empty() {
+            continue;
+        }
+        if let Some(idx) = remainder.find(part) {
+            remainder = &remainder[idx + part.len()..];
+        } else {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn redact_url_credentials(input: &str) -> (String, usize) {
+    let mut redactions = 0usize;
+    let mut output = input.to_string();
+    let mut offset = 0usize;
+    while let Some(pos) = output[offset..].find("://") {
+        let scheme_end = offset + pos + 3;
+        let remainder = &output[scheme_end..];
+        if let Some(at_pos) = remainder.find('@') {
+            let before_at = &remainder[..at_pos];
+            if before_at.contains(':') || !before_at.is_empty() {
+                let replace_start = scheme_end;
+                let replace_end = scheme_end + at_pos;
+                output.replace_range(replace_start..replace_end, "<redacted>");
+                redactions += 1;
+                offset = replace_start + "<redacted>".len() + 1;
+                continue;
+            }
+        }
+        offset = scheme_end;
+    }
+    (output, redactions)
+}
+
+fn redact_query_params(input: &str) -> (String, usize) {
+    let keys = ["token", "password", "secret", "key", "access_token"];
+    let mut redactions = 0usize;
+    let mut output = input.to_string();
+    for key in keys {
+        let mut search = output.to_ascii_lowercase();
+        let mut start = 0usize;
+        while let Some(pos) = search[start..].find(&format!("{}=", key)) {
+            let abs = start + pos;
+            let value_start = abs + key.len() + 1;
+            let value_end = output[value_start..]
+                .find(&['&', ' ', '"'][..])
+                .map(|idx| value_start + idx)
+                .unwrap_or(output.len());
+            output.replace_range(value_start..value_end, "<redacted>");
+            redactions += 1;
+            search = output.to_ascii_lowercase();
+            start = value_start + "<redacted>".len();
+        }
+    }
+    (output, redactions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_env_key_patterns() {
+        let rules = RedactionRules::default();
+        let (value, redactions) = rules.redact_value("PYBUN_API_TOKEN", "secret");
+        assert_eq!(value, "<redacted>");
+        assert_eq!(redactions, 1);
+    }
+
+    #[test]
+    fn redacts_url_credentials() {
+        let (redacted, count) = redact_url_credentials("https://user:pass@example.com");
+        assert_eq!(redacted, "https://<redacted>@example.com");
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn redacts_json_keys() {
+        let rules = RedactionRules::default();
+        let value = json!({
+            "token": "abc",
+            "nested": { "password": "secret" },
+            "safe": "ok",
+        });
+        let redacted = rules.redact_json_value(&value);
+        assert_eq!(redacted["token"], "<redacted>");
+        assert_eq!(redacted["nested"]["password"], "<redacted>");
+        assert_eq!(redacted["safe"], "ok");
+    }
+}

--- a/tests/snapshots/compat/help_doctor.txt
+++ b/tests/snapshots/compat/help_doctor.txt
@@ -3,6 +3,9 @@ Diagnose environment and produce support bundle
 Usage: pybun doctor [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --verbose          Include verbose logs in bundle
-  -h, --help             Print help
+      --format <FORMAT>   Output format for machine readability [default: text] [possible values: text, json]
+      --verbose           Include verbose logs in bundle
+      --bundle <PATH>     Write support bundle to a directory
+      --upload            Upload support bundle to the configured endpoint
+      --upload-url <URL>  Override the support bundle upload endpoint
+  -h, --help              Print help

--- a/tests/support_bundle.rs
+++ b/tests/support_bundle.rs
@@ -1,0 +1,62 @@
+//! E2E tests for support bundle creation and upload.
+//!
+//! PR7.3: Supportability bundle + crash report hook.
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use httpmock::prelude::*;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn pybun() -> Command {
+    cargo_bin_cmd!("pybun")
+}
+
+#[test]
+fn doctor_bundle_creates_bundle_and_redacts_env() {
+    let temp = TempDir::new().unwrap();
+    let bundle_path = temp.path().join("bundle");
+    let home = temp.path().join("home");
+
+    pybun()
+        .env("PYBUN_HOME", &home)
+        .env("PYBUN_TEST_TOKEN", "super-secret")
+        .args([
+            "--format=json",
+            "doctor",
+            "--bundle",
+            bundle_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"bundle\""));
+
+    let env_json = fs::read_to_string(bundle_path.join("env.json")).unwrap();
+    assert!(env_json.contains("<redacted>"));
+    assert!(!env_json.contains("super-secret"));
+}
+
+#[test]
+fn doctor_upload_posts_bundle() {
+    let server = MockServer::start();
+    let upload = server.mock(|when, then| {
+        when.method(POST).path("/upload");
+        then.status(200).header("Content-Type", "application/json");
+    });
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let url = format!("{}/upload", server.base_url());
+
+    pybun()
+        .env("PYBUN_HOME", &home)
+        .env("PYBUN_SUPPORT_UPLOAD_URL", &url)
+        .args(["--format=json", "doctor", "--upload"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"upload\""))
+        .stdout(predicate::str::contains("\"status\":\"uploaded\""));
+
+    upload.assert_hits(1);
+}


### PR DESCRIPTION
## Description
- Add support bundle generation/upload for `pybun doctor` with redaction and bundle metadata.
- Install crash hook with opt-in prompt to collect/upload bundles on panic.
- Update CLI flags and compat help snapshot.

## Motivation and Context
- Provide a supportability bundle for diagnostics and crash triage (PR7.3).

Fixes #N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manually tested on [OS/Platform]

Tests run:
- `cargo test`
- `cargo test --test '*'`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just lint`
- `just fmt`

## Checklist
- [x] My code follows the code style of this project (`cargo fmt`)
- [x] My code passes all lint checks (`cargo clippy`)
- [x] All tests pass (`cargo test`)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)
- N/A

## Additional Notes
- `just test-e2e` is not defined in the Justfile; ran `cargo test --test '*'` instead.