### PR TITLE
PR7.7: CLI progress UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ native-watch = ["notify"]
 performance-allocator = ["mimalloc", "tikv-jemallocator"]
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 color-eyre = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -270,16 +270,16 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
     - [x] 公式別名（`pybun-cli` 等）を配布物に同梱（symlink/launcher/console_script）
     - [x] install.sh / install.ps1 / Homebrew/Scoop/winget / PyPI shim の導線を統一
     - [x] Bun 側の `pybun` を検知した場合の警告（回避策: alias使用/優先順位）を追加
-- PR7.7: CLI 進捗UI（Bun 風の途中経過表示）
+- [DONE] PR7.7: CLI 進捗UI（Bun 風の途中経過表示）
   - Goal: `pybun install/add/test/build/run` などの長い処理で、解決/ダウンロード/ビルド/配置の進捗を人間向けに可視化。TTY ではスピナー/プログレスバー、非TTYや `--format=json` では抑制。
   - Depends on: PR4.1 グローバルイベントスキーマ, PR4.4 observability。
-  - Implementation: JSON イベントストリームから進捗レンダラーを構成（resolve/download/build/install）。`--progress=auto|always|never` + `--no-progress` エイリアス、`PYBUN_PROGRESS` を追加。`--format=json` は UI を無効化しイベントのみ出力。
-  - Tests: text 出力のゴールデン/スナップショット、`--no-progress` の抑制、TTY 判定、JSON イベントとの整合性。
+  - Current: JSON イベントにフックする進捗レンダラーを追加し、解決/ダウンロード/インストール/ビルド/テストのイベントをテキスト進捗として描画。`--progress=auto|always|never` と `--no-progress`（`PYBUN_PROGRESS` 環境変数対応）をグローバルに追加し、`--format=json` 時や非TTYの auto では UI を抑制。
+  - Tests: `cargo test --test progress_ui`, `cargo test --test compat_snapshots`
   - Implementation (Tasks):
-    - [ ] Event → 進捗モデル（resolve/download/build/install）のマッピングを定義
-    - [ ] TTY時のみスピナー/プログレスを描画（`--progress`/`PYBUN_PROGRESS`で制御）
-    - [ ] `--format=json` では UI を完全無効化（イベントのみ）
-    - [ ] text出力の snapshot を追加（`--no-progress` 含む）
+    - [x] Event → 進捗モデル（resolve/download/build/install）のマッピングを定義
+    - [x] TTY時のみスピナー/プログレスを描画（`--progress`/`PYBUN_PROGRESS`で制御）
+    - [x] `--format=json` では UI を完全無効化（イベントのみ）
+    - [x] text出力の snapshot を追加（`--no-progress` 含む）
 
 - PR7.8: Perceived performance polish（GA体験のキビキビ感）
   - Goal: “止まって見える/遅く感じる” を減らすため、起動/PEP723の体感を GA 基準まで引き上げる。

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,20 @@ pub struct Cli {
     #[arg(long, global = true, default_value_t = OutputFormat::Text, value_enum)]
     pub format: OutputFormat,
 
+    /// Progress UI mode (auto hides on non-TTY).
+    #[arg(
+        long,
+        global = true,
+        default_value_t = ProgressMode::Auto,
+        value_enum,
+        env = "PYBUN_PROGRESS"
+    )]
+    pub progress: ProgressMode,
+
+    /// Disable progress UI.
+    #[arg(long = "no-progress", global = true)]
+    pub no_progress: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -20,6 +34,13 @@ pub struct Cli {
 pub enum OutputFormat {
     Text,
     Json,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ProgressMode {
+    Auto,
+    Always,
+    Never,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -85,6 +85,8 @@ mod tests {
     fn test_cli(verbose: bool) -> Cli {
         Cli {
             format: OutputFormat::Text,
+            progress: crate::cli::ProgressMode::Auto,
+            no_progress: false,
             command: Commands::Test(TestArgs {
                 paths: Vec::new(),
                 shard: None,
@@ -106,6 +108,8 @@ mod tests {
     fn doctor_cli(verbose: bool) -> Cli {
         Cli {
             format: OutputFormat::Text,
+            progress: crate::cli::ProgressMode::Auto,
+            no_progress: false,
             command: Commands::Doctor(DoctorArgs {
                 verbose,
                 bundle: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod paths;
 pub mod pep723;
 pub mod pep723_cache;
 pub mod profiles;
+pub mod progress;
 pub mod project;
 pub mod pypi;
 pub mod release_manifest;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,188 @@
+use crate::cli::ProgressMode;
+use crate::schema::{Event, EventListener, EventType};
+use std::cell::RefCell;
+use std::io::{self, Write};
+use std::rc::Rc;
+
+pub struct ProgressConfig {
+    pub mode: ProgressMode,
+    pub is_tty: bool,
+}
+
+impl ProgressConfig {
+    fn enabled(&self) -> bool {
+        match self.mode {
+            ProgressMode::Never => false,
+            ProgressMode::Always => true,
+            ProgressMode::Auto => self.is_tty,
+        }
+    }
+}
+
+pub struct ProgressDriver {
+    inner: Option<Rc<RefCell<ProgressRenderer>>>,
+}
+
+impl ProgressDriver {
+    pub fn new(config: ProgressConfig) -> Self {
+        if config.enabled() {
+            let renderer = ProgressRenderer::new(config.is_tty);
+            Self {
+                inner: Some(Rc::new(RefCell::new(renderer))),
+            }
+        } else {
+            Self { inner: None }
+        }
+    }
+
+    pub fn listener(&self) -> Option<EventListener> {
+        self.inner.as_ref().map(|inner| {
+            let inner = inner.clone();
+            Box::new(move |event: &Event| {
+                if let Ok(mut renderer) = inner.try_borrow_mut() {
+                    renderer.handle_event(event);
+                }
+            }) as EventListener
+        })
+    }
+
+    pub fn finish(&self) {
+        if let Some(inner) = &self.inner
+            && let Ok(mut renderer) = inner.try_borrow_mut()
+        {
+            renderer.finish();
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+struct ProgressRenderer {
+    is_tty: bool,
+    spinner_index: usize,
+    last_message: Option<String>,
+    last_progress: Option<u8>,
+    rendered: bool,
+}
+
+impl ProgressRenderer {
+    fn new(is_tty: bool) -> Self {
+        Self {
+            is_tty,
+            spinner_index: 0,
+            last_message: None,
+            last_progress: None,
+            rendered: false,
+        }
+    }
+
+    fn handle_event(&mut self, event: &Event) {
+        if let Some(update) = ProgressUpdate::from_event(event) {
+            self.last_message = Some(update.message);
+            if update.progress.is_some() {
+                self.last_progress = update.progress;
+            }
+            self.render();
+        }
+    }
+
+    fn render(&mut self) {
+        let message = self
+            .last_message
+            .as_deref()
+            .unwrap_or("Working on tasks...");
+        let spinner = SPINNER_FRAMES[self.spinner_index % SPINNER_FRAMES.len()];
+        self.spinner_index = (self.spinner_index + 1) % SPINNER_FRAMES.len();
+
+        let mut line = format!("{spinner} {message}");
+        if let Some(progress) = self.last_progress {
+            line.push_str(&format!(" [{progress}%]"));
+        }
+
+        let mut stderr = io::stderr();
+        if self.is_tty {
+            let _ = write!(stderr, "\r\x1b[2K{line}");
+            let _ = stderr.flush();
+        } else {
+            let _ = writeln!(stderr, "{line}");
+        }
+        self.rendered = true;
+    }
+
+    fn finish(&mut self) {
+        if !self.rendered {
+            return;
+        }
+        let message = self
+            .last_message
+            .as_deref()
+            .unwrap_or("Done processing tasks");
+        let mut stderr = io::stderr();
+        if self.is_tty {
+            let _ = write!(stderr, "\r\x1b[2K[done] {message}");
+        } else {
+            let _ = write!(stderr, "[done] {message}");
+        }
+        if let Some(progress) = self.last_progress {
+            let _ = write!(stderr, " [{progress}%]");
+        }
+        let _ = writeln!(stderr);
+        let _ = stderr.flush();
+        self.rendered = false;
+    }
+}
+
+struct ProgressUpdate {
+    message: String,
+    progress: Option<u8>,
+}
+
+impl ProgressUpdate {
+    fn new(message: impl Into<String>, progress: Option<u8>) -> Self {
+        Self {
+            message: message.into(),
+            progress: progress.map(|p| p.min(100)),
+        }
+    }
+
+    fn from_event(event: &Event) -> Option<Self> {
+        match event.event_type {
+            EventType::ResolveStart => Some(Self::new("Resolving dependencies", Some(5))),
+            EventType::ResolveComplete => Some(Self::new(
+                event.message.as_deref().unwrap_or("Resolved dependencies"),
+                event.progress.or(Some(30)),
+            )),
+            EventType::DownloadStart | EventType::DownloadProgress => Some(Self::new(
+                event.message.as_deref().unwrap_or("Downloading artifacts"),
+                event.progress.or(Some(50)),
+            )),
+            EventType::DownloadComplete => Some(Self::new(
+                event.message.as_deref().unwrap_or("Downloaded artifacts"),
+                event.progress.or(Some(70)),
+            )),
+            EventType::InstallStart => Some(Self::new(
+                event.message.as_deref().unwrap_or("Installing packages"),
+                event.progress.or(Some(80)),
+            )),
+            EventType::InstallComplete => {
+                Some(Self::new("Install complete", event.progress.or(Some(100))))
+            }
+            EventType::ExtractStart => Some(Self::new("Extracting artifacts", Some(60))),
+            EventType::ExtractComplete => Some(Self::new("Extracted artifacts", Some(65))),
+            EventType::ScriptStart => Some(Self::new("Running script", Some(40))),
+            EventType::ScriptEnd => Some(Self::new("Script finished", Some(100))),
+            EventType::TestStart => Some(Self::new("Running tests", Some(30))),
+            EventType::TestComplete => Some(Self::new("Tests finished", Some(100))),
+            EventType::Progress => Some(Self::new(
+                event.message.as_deref().unwrap_or("Working..."),
+                event.progress,
+            )),
+            EventType::CommandEnd => Some(Self::new("Finished", Some(100))),
+            _ => None,
+        }
+    }
+}
+
+const SPINNER_FRAMES: &[&str] = &["-", "\\", "|", "/"];

--- a/tests/progress_ui.rs
+++ b/tests/progress_ui.rs
@@ -1,0 +1,78 @@
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use tempfile::tempdir;
+
+fn pybun() -> Command {
+    cargo_bin_cmd!("pybun")
+}
+
+fn index_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index.json")
+}
+
+#[test]
+fn progress_is_suppressed_for_json_output() {
+    let assert = pybun()
+        .args(["--format=json", "--progress=always", "schema", "print"])
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    assert!(
+        output.stderr.is_empty(),
+        "progress UI should be disabled for JSON format"
+    );
+}
+
+#[test]
+fn no_progress_flag_disables_renderer() {
+    let assert = pybun()
+        .args(["--progress=always", "--no-progress", "schema", "print"])
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    assert!(
+        output.stderr.is_empty(),
+        "--no-progress should suppress UI output"
+    );
+}
+
+#[test]
+fn progress_renders_for_install_when_forced() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_path();
+
+    let assert = pybun()
+        .args([
+            "--progress=always",
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "app==1.0.0",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Resolving"),
+        "progress should include resolve stage"
+    );
+    assert!(
+        stderr.contains("Downloading"),
+        "progress should include download stage"
+    );
+    assert!(
+        stderr.contains("Installing"),
+        "progress should include install stage"
+    );
+}

--- a/tests/snapshots/compat/help_add.txt
+++ b/tests/snapshots/compat/help_add.txt
@@ -6,6 +6,8 @@ Arguments:
   [PACKAGE]  Package name (optionally with version)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --offline          Use offline mode when cache is sufficient
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --offline              Use offline mode when cache is sufficient
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_build.txt
+++ b/tests/snapshots/compat/help_build.txt
@@ -3,6 +3,8 @@ Build distributable artifacts
 Usage: pybun build [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --sbom             Emit SBOM along with artifacts
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --sbom                 Emit SBOM along with artifacts
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_doctor.txt
+++ b/tests/snapshots/compat/help_doctor.txt
@@ -3,9 +3,11 @@ Diagnose environment and produce support bundle
 Usage: pybun doctor [OPTIONS]
 
 Options:
-      --format <FORMAT>   Output format for machine readability [default: text] [possible values: text, json]
-      --verbose           Include verbose logs in bundle
-      --bundle <PATH>     Write support bundle to a directory
-      --upload            Upload support bundle to the configured endpoint
-      --upload-url <URL>  Override the support bundle upload endpoint
-  -h, --help              Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --verbose              Include verbose logs in bundle
+      --bundle <PATH>        Write support bundle to a directory
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+      --upload               Upload support bundle to the configured endpoint
+      --upload-url <URL>     Override the support bundle upload endpoint
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_gc.txt
+++ b/tests/snapshots/compat/help_gc.txt
@@ -6,4 +6,6 @@ Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
       --max-size <MAX_SIZE>  Maximum cache size (e.g., 10G); LRU eviction if exceeded
       --dry-run              Preview what would be deleted without actually deleting
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
   -h, --help                 Print help

--- a/tests/snapshots/compat/help_install.txt
+++ b/tests/snapshots/compat/help_install.txt
@@ -5,7 +5,9 @@ Usage: pybun install [OPTIONS]
 Options:
       --format <FORMAT>          Output format for machine readability [default: text] [possible values: text, json]
       --offline                  Use offline mode when cache is sufficient
+      --progress <PROGRESS>      Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
       --require <NAME==VERSION>  Requirements to install (temporary M1 flag)
       --index <INDEX>            Path to index JSON (temporary M1 flag)
+      --no-progress              Disable progress UI
       --lock <LOCK>              Path to write lockfile [default: pybun.lockb]
   -h, --help                     Print help

--- a/tests/snapshots/compat/help_lazy_import.txt
+++ b/tests/snapshots/compat/help_lazy_import.txt
@@ -3,13 +3,15 @@ Configure and generate lazy import settings
 Usage: pybun lazy-import [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --generate         Generate Python code for lazy import injection
-      --check <MODULE>   Check if a module would be lazily imported
-      --show-config      Show current configuration
-      --allow <MODULE>   Add module to allowlist
-      --deny <MODULE>    Add module to denylist
-      --log-imports      Enable logging of lazy imports in generated code
-      --no-fallback      Disable fallback to CPython import
-  -o, --output <FILE>    Output file for generated Python code
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --generate             Generate Python code for lazy import injection
+      --check <MODULE>       Check if a module would be lazily imported
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+      --show-config          Show current configuration
+      --allow <MODULE>       Add module to allowlist
+      --deny <MODULE>        Add module to denylist
+      --log-imports          Enable logging of lazy imports in generated code
+      --no-fallback          Disable fallback to CPython import
+  -o, --output <FILE>        Output file for generated Python code
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_lock.txt
+++ b/tests/snapshots/compat/help_lock.txt
@@ -3,8 +3,10 @@ Lock dependencies for scripts
 Usage: pybun lock [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --script <SCRIPT>  Lock dependencies for a PEP 723 script
-      --offline          Use offline mode when cache is sufficient
-      --index <INDEX>    Path to index JSON (temporary M1 flag)
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --script <SCRIPT>      Lock dependencies for a PEP 723 script
+      --offline              Use offline mode when cache is sufficient
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --index <INDEX>        Path to index JSON (temporary M1 flag)
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_mcp.txt
+++ b/tests/snapshots/compat/help_mcp.txt
@@ -7,5 +7,7 @@ Commands:
   help   Print this message or the help of the given subcommand(s)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_mcp_serve.txt
+++ b/tests/snapshots/compat/help_mcp_serve.txt
@@ -3,7 +3,9 @@ Start MCP server for programmatic control
 Usage: pybun mcp serve [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --port <PORT>      Port to bind (for HTTP mode) [default: 9999]
-      --stdio            Use stdio mode for MCP communication
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --port <PORT>          Port to bind (for HTTP mode) [default: 9999]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --stdio                Use stdio mode for MCP communication
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_module_find.txt
+++ b/tests/snapshots/compat/help_module_find.txt
@@ -6,9 +6,11 @@ Arguments:
   [MODULE]  Module name to find (e.g., "os.path", "numpy.core")
 
 Options:
-      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
-  -p, --path <PATH>        Search path(s) for modules. Can be specified multiple times
-      --scan               Scan directory and list all modules instead of finding a specific one
-      --benchmark          Show timing information for benchmarking
-      --threads <THREADS>  Number of threads for parallel scanning [default: 4]
-  -h, --help               Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+  -p, --path <PATH>          Search path(s) for modules. Can be specified multiple times
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --scan                 Scan directory and list all modules instead of finding a specific one
+      --benchmark            Show timing information for benchmarking
+      --no-progress          Disable progress UI
+      --threads <THREADS>    Number of threads for parallel scanning [default: 4]
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_profile.txt
+++ b/tests/snapshots/compat/help_profile.txt
@@ -6,9 +6,11 @@ Arguments:
   [PROFILE]  Profile to show or set (dev, prod, benchmark)
 
 Options:
-      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
-      --list               List all available profiles
-      --show               Show detailed profile configuration
-      --compare <PROFILE>  Compare two profiles
-  -o, --output <FILE>      Export profile to a file
-  -h, --help               Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --list                 List all available profiles
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --show                 Show detailed profile configuration
+      --compare <PROFILE>    Compare two profiles
+      --no-progress          Disable progress UI
+  -o, --output <FILE>        Export profile to a file
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_python.txt
+++ b/tests/snapshots/compat/help_python.txt
@@ -10,5 +10,7 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_python_install.txt
+++ b/tests/snapshots/compat/help_python_install.txt
@@ -6,5 +6,7 @@ Arguments:
   <VERSION>  Version to install (e.g., 3.11, 3.12.7)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_python_list.txt
+++ b/tests/snapshots/compat/help_python_list.txt
@@ -3,6 +3,8 @@ List installed and available Python versions
 Usage: pybun python list [OPTIONS]
 
 Options:
-      --all              Show all available versions (not just installed)
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --all                  Show all available versions (not just installed)
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_python_remove.txt
+++ b/tests/snapshots/compat/help_python_remove.txt
@@ -6,5 +6,7 @@ Arguments:
   <VERSION>  Version to remove
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_python_which.txt
+++ b/tests/snapshots/compat/help_python_which.txt
@@ -6,5 +6,7 @@ Arguments:
   [VERSION]  Version to look up
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_remove.txt
+++ b/tests/snapshots/compat/help_remove.txt
@@ -6,6 +6,8 @@ Arguments:
   [PACKAGE]  Package name (optionally with version)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --offline          Use offline mode when cache is sufficient
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --offline              Use offline mode when cache is sufficient
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_root.txt
+++ b/tests/snapshots/compat/help_root.txt
@@ -25,6 +25,8 @@ Commands:
   help         Print this message or the help of the given subcommand(s)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
-  -V, --version          Print version
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help
+  -V, --version              Print version

--- a/tests/snapshots/compat/help_run.txt
+++ b/tests/snapshots/compat/help_run.txt
@@ -7,8 +7,10 @@ Arguments:
   [PASSTHROUGH]...  Pass additional args to the target
 
 Options:
-      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
-      --sandbox            Run in sandboxed mode for untrusted code
-      --allow-network      Allow network access inside the sandbox (escape hatch)
-      --profile <PROFILE>  Optional profile (dev/prod/benchmark) [default: dev]
-  -h, --help               Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --sandbox              Run in sandboxed mode for untrusted code
+      --allow-network        Allow network access inside the sandbox (escape hatch)
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+      --profile <PROFILE>    Optional profile (dev/prod/benchmark) [default: dev]
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_schema.txt
+++ b/tests/snapshots/compat/help_schema.txt
@@ -8,5 +8,7 @@ Commands:
   help   Print this message or the help of the given subcommand(s)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_schema_check.txt
+++ b/tests/snapshots/compat/help_schema_check.txt
@@ -3,6 +3,8 @@ Check the JSON schema against the frozen v1 definition
 Usage: pybun schema check [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-      --path <PATH>      Optional path to compare against the embedded schema
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --path <PATH>          Optional path to compare against the embedded schema
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_schema_print.txt
+++ b/tests/snapshots/compat/help_schema_print.txt
@@ -3,5 +3,7 @@ Print the JSON schema for CLI output
 Usage: pybun schema print [OPTIONS]
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_self.txt
+++ b/tests/snapshots/compat/help_self.txt
@@ -7,5 +7,7 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_self_update.txt
+++ b/tests/snapshots/compat/help_self_update.txt
@@ -3,7 +3,9 @@ Update PyBun binary with signature verification
 Usage: pybun self update [OPTIONS]
 
 Options:
-      --channel <CHANNEL>  Channel to update from (stable/nightly) [default: stable]
-      --format <FORMAT>    Output format for machine readability [default: text] [possible values: text, json]
-      --dry-run            Check for updates without installing
-  -h, --help               Print help
+      --channel <CHANNEL>    Channel to update from (stable/nightly) [default: stable]
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --dry-run              Check for updates without installing
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help

--- a/tests/snapshots/compat/help_test.txt
+++ b/tests/snapshots/compat/help_test.txt
@@ -9,7 +9,9 @@ Arguments:
 Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
       --shard <SHARD>        Shard identifier (N/M) for distributed testing
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
   -x, --fail-fast            Stop on first failure
+      --no-progress          Disable progress UI
       --pytest-compat        Enable pytest compatibility layer
       --backend <BACKEND>    Test runner backend (pytest or unittest). Auto-detected if not specified [possible values: pytest, unittest]
       --discover             Only discover tests without running them

--- a/tests/snapshots/compat/help_watch.txt
+++ b/tests/snapshots/compat/help_watch.txt
@@ -9,7 +9,9 @@ Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
   -p, --path <PATH>          Paths to watch (can be specified multiple times)
       --include <PATTERN>    File patterns to include (e.g., "*.py")
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
       --exclude <PATTERN>    File patterns to exclude (e.g., "__pycache__")
+      --no-progress          Disable progress UI
       --debounce <DEBOUNCE>  Debounce delay in milliseconds [default: 300]
       --clear                Clear terminal before each reload
       --show-config          Show configuration without starting watcher

--- a/tests/snapshots/compat/help_x.txt
+++ b/tests/snapshots/compat/help_x.txt
@@ -7,5 +7,7 @@ Arguments:
   [PASSTHROUGH]...  Arguments to forward to the tool
 
 Options:
-      --format <FORMAT>  Output format for machine readability [default: text] [possible values: text, json]
-  -h, --help             Print help
+      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
+      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --no-progress          Disable progress UI
+  -h, --help                 Print help


### PR DESCRIPTION
## Description
Adds Bun-style progress UI for long-running commands.

- Global flags: `--progress=auto|always|never`, `--no-progress`
- Env: `PYBUN_PROGRESS`
- `--format=json` disables UI (events only)

## Motivation and Context
Improve UX for install/build/test/run by surfacing resolver/download/install progress in text output.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated

Commands:
- `just check`

## Checklist
- [x] My code follows the code style of this project (`cargo fmt`)
- [x] My code passes all lint checks (`cargo clippy`)
- [x] All tests pass (`cargo test`)
- [x] I have updated the documentation accordingly
