### PR TITLE
PR7.8: Perceived performance polish

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,60 @@
+name: Benchmark UX Gate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  ux-gate:
+    if: >
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+      contains(github.event.pull_request.labels.*.name, 'perf')
+    name: ux gate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: true
+          cache-on-failure: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Build pybun (release)
+        run: cargo build --release
+
+      - name: Run benchmarks (B3)
+        run: |
+          cd scripts/benchmark
+          python bench.py -s run --config config_ci.toml --format json -o results-ci
+
+      - name: UX gate
+        run: |
+          cd scripts/benchmark
+          python ux_gate.py results-ci --criteria ux_criteria.toml --format text
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.os }}
+          path: scripts/benchmark/results-ci/
+

--- a/scripts/benchmark/config_ci.toml
+++ b/scripts/benchmark/config_ci.toml
@@ -1,0 +1,27 @@
+# CI-focused benchmark configuration (fast + stable).
+
+[general]
+iterations = 5
+warmup = 1
+trim_ratio = 0.1
+timeout_seconds = 300
+
+[tools]
+pybun = true
+uv = true
+python = true
+pip = false
+pipx = false
+poetry = false
+
+[paths]
+pybun = "../../target/release/pybun"
+
+[scenarios.run]
+enabled = true
+pep723 = true
+profiles = []
+pep723_fixture = "fixtures/pep723.py"
+pep723_clear_envs = true
+pep723_clear_fs_cache = false
+

--- a/scripts/benchmark/tests/test_ux_gate.py
+++ b/scripts/benchmark/tests/test_ux_gate.py
@@ -1,0 +1,44 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import ux_gate
+
+
+class TestUxGate(unittest.TestCase):
+    def test_rule_fails_when_ratio_exceeds_threshold(self) -> None:
+        report = {
+            "results": [
+                {
+                    "scenario": "B3.1_simple_startup",
+                    "tool": "pybun",
+                    "duration_ms": 30.0,
+                    "success": True,
+                },
+                {
+                    "scenario": "B3.1_simple_startup",
+                    "tool": "python",
+                    "duration_ms": 20.0,
+                    "success": True,
+                },
+            ]
+        }
+        rules = [
+            {
+                "scenario": "B3.1_simple_startup",
+                "tool": "pybun",
+                "compare_to": "python",
+                "max_ratio": 1.25,
+            }
+        ]
+
+        outcome = ux_gate.evaluate_rules(report, rules)
+        self.assertFalse(outcome.passed)
+        self.assertEqual(len(outcome.failures), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/scripts/benchmark/ux_criteria.toml
+++ b/scripts/benchmark/ux_criteria.toml
@@ -1,0 +1,43 @@
+# UX criteria for "perceived performance" regression gating.
+#
+# Rules are evaluated against `benchmark_*.json` output from `bench.py`.
+# A rule fails if:
+# - `max_ms` is set and the measured duration exceeds it, or
+# - `compare_to` + `max_ratio` are set and the ratio exceeds it.
+#
+# Fields:
+# - scenario: benchmark scenario ID (e.g. "B3.1_simple_startup")
+# - tool: tool name in results ("pybun", "python", "uv", ...)
+# - max_ms: absolute upper bound (optional)
+# - compare_to: baseline tool to compare against (optional)
+# - max_ratio: upper bound for tool/baseline ratio (optional; requires compare_to)
+
+[[rules]]
+scenario = "B3.1_simple_startup"
+tool = "pybun"
+compare_to = "python"
+max_ratio = 1.5
+
+[[rules]]
+scenario = "B3.1_simple_startup"
+tool = "pybun"
+max_ms = 80.0
+
+[[rules]]
+scenario = "B3.2_pep723_warm"
+tool = "pybun"
+compare_to = "uv"
+max_ratio = 1.5
+
+[[rules]]
+scenario = "B3.2_pep723_cold"
+tool = "pybun"
+compare_to = "uv"
+max_ratio = 1.5
+
+[[rules]]
+scenario = "B3.3_heavy_import"
+tool = "pybun"
+compare_to = "python"
+max_ratio = 1.5
+

--- a/scripts/benchmark/ux_gate.py
+++ b/scripts/benchmark/ux_gate.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+UX gate for PyBun benchmarks.
+
+This script evaluates a benchmark JSON report against a small set of "perceived performance"
+criteria and exits non-zero when any rule fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Try to import tomllib (Python 3.11+) or fall back to toml
+try:
+    import tomllib
+except ImportError:
+    try:
+        import toml as tomllib  # type: ignore
+    except ImportError:
+        print("Error: Please install toml package: pip install toml", file=sys.stderr)
+        raise
+
+
+@dataclass
+class UxGateOutcome:
+    passed: bool
+    failures: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _index_results(report: dict) -> dict[tuple[str, str], dict]:
+    indexed: dict[tuple[str, str], dict] = {}
+    for item in report.get("results", []) or []:
+        scenario = item.get("scenario")
+        tool = item.get("tool")
+        if isinstance(scenario, str) and isinstance(tool, str):
+            indexed[(scenario, tool)] = item
+    return indexed
+
+
+def evaluate_rules(report: dict, rules: list[dict]) -> UxGateOutcome:
+    indexed = _index_results(report)
+    failures: list[dict[str, Any]] = []
+
+    for rule in rules:
+        scenario = rule.get("scenario")
+        tool = rule.get("tool")
+        if not isinstance(scenario, str) or not isinstance(tool, str):
+            failures.append({"rule": rule, "reason": "invalid_rule"})
+            continue
+
+        result = indexed.get((scenario, tool))
+        if not result:
+            failures.append(
+                {"scenario": scenario, "tool": tool, "reason": "missing_result"}
+            )
+            continue
+
+        if result.get("success") is False:
+            failures.append(
+                {"scenario": scenario, "tool": tool, "reason": "unsuccessful_run"}
+            )
+            continue
+
+        duration_ms = float(result.get("duration_ms", 0.0) or 0.0)
+
+        max_ms = rule.get("max_ms")
+        if max_ms is not None:
+            max_ms_f = float(max_ms)
+            if duration_ms > max_ms_f:
+                failures.append(
+                    {
+                        "scenario": scenario,
+                        "tool": tool,
+                        "reason": "max_ms_exceeded",
+                        "duration_ms": duration_ms,
+                        "max_ms": max_ms_f,
+                    }
+                )
+                continue
+
+        compare_to = rule.get("compare_to")
+        max_ratio = rule.get("max_ratio")
+        if isinstance(compare_to, str) and max_ratio is not None:
+            baseline = indexed.get((scenario, compare_to))
+            if not baseline or baseline.get("success") is False:
+                failures.append(
+                    {
+                        "scenario": scenario,
+                        "tool": tool,
+                        "reason": "missing_baseline",
+                        "compare_to": compare_to,
+                    }
+                )
+                continue
+
+            baseline_ms = float(baseline.get("duration_ms", 0.0) or 0.0)
+            if baseline_ms <= 0:
+                failures.append(
+                    {
+                        "scenario": scenario,
+                        "tool": tool,
+                        "reason": "invalid_baseline_duration",
+                        "compare_to": compare_to,
+                        "baseline_ms": baseline_ms,
+                    }
+                )
+                continue
+
+            ratio = duration_ms / baseline_ms
+            max_ratio_f = float(max_ratio)
+            if ratio > max_ratio_f:
+                failures.append(
+                    {
+                        "scenario": scenario,
+                        "tool": tool,
+                        "reason": "max_ratio_exceeded",
+                        "duration_ms": duration_ms,
+                        "compare_to": compare_to,
+                        "baseline_ms": baseline_ms,
+                        "ratio": round(ratio, 3),
+                        "max_ratio": max_ratio_f,
+                    }
+                )
+
+    return UxGateOutcome(passed=(len(failures) == 0), failures=failures)
+
+
+def _load_report(path: Path) -> dict:
+    if path.is_dir():
+        candidates = sorted(path.glob("benchmark_*.json"))
+        if not candidates:
+            raise FileNotFoundError(f"No benchmark_*.json found in {path}")
+        path = candidates[-1]
+
+    with path.open() as f:
+        return json.load(f)
+
+
+def _load_rules(path: Path) -> list[dict]:
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    rules = data.get("rules", [])
+    if not isinstance(rules, list):
+        raise ValueError("ux criteria must define [[rules]] as a list")
+    return rules
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PyBun UX performance gate")
+    parser.add_argument(
+        "results",
+        help="Path to a benchmark JSON file or directory containing benchmark_*.json",
+    )
+    parser.add_argument(
+        "--criteria",
+        default=str(Path(__file__).with_name("ux_criteria.toml")),
+        help="Path to UX criteria TOML (default: ux_criteria.toml)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for gate result",
+    )
+    args = parser.parse_args()
+
+    report = _load_report(Path(args.results))
+    rules = _load_rules(Path(args.criteria))
+    outcome = evaluate_rules(report, rules)
+
+    if args.format == "json":
+        print(json.dumps({"passed": outcome.passed, "failures": outcome.failures}, indent=2))
+    else:
+        if outcome.passed:
+            print("UX gate: PASS")
+        else:
+            print(f"UX gate: FAIL ({len(outcome.failures)} failure(s))")
+            for failure in outcome.failures:
+                scenario = failure.get("scenario", "?")
+                tool = failure.get("tool", "?")
+                reason = failure.get("reason", "?")
+                print(f"- {scenario} [{tool}]: {reason}")
+
+    return 0 if outcome.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,10 @@ fn main() -> Result<()> {
     }
     support_bundle::install_crash_hook();
 
+    if !entry::requires_tokio_runtime(&cli) {
+        return futures::executor::block_on(execute(cli));
+    }
+
     let stack_size = entry::runtime_stack_size();
     let main2 = move || -> Result<()> {
         let runtime = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
## Description
- PEP 723 run defaults to `uv run` when available with backend selection and JSON-safe stdout/stderr capture.
- Reduce startup overhead by skipping Tokio runtime when not needed.
- Add benchmark UX gate (criteria + CI workflow) and stabilize run benchmark env.

## Motivation and Context
- Improve perceived performance for GA readiness (PR7.8).

Fixes #N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/Build changes

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested on macOS

Tests:
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- python3 -m unittest discover -s scripts/benchmark/tests

## Checklist
- [x] My code follows the code style of this project (cargo fmt)
- [x] My code passes all lint checks (cargo clippy)
- [x] All tests pass (cargo test)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)
- N/A

## Additional Notes
- UX gate workflow runs on nightly or when PR is labeled `perf`/`benchmark`.
