### PR TITLE
chore(deps): update quinn-proto for cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Description
Update the locked `quinn-proto` dependency from `0.11.13` to `0.11.14` to clear the `cargo audit` failure on `main`.

## Motivation and Context
`cargo audit` started failing on March 10, 2026 because `reqwest 0.12.25` pulls in `quinn -> quinn-proto 0.11.13`, which is affected by `RUSTSEC-2026-0037`.

No linked issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/Build changes

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manually tested on macOS

Commands run:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo audit`

## Checklist
- [x] My code follows the code style of this project (`cargo fmt`)
- [x] My code passes all lint checks (`cargo clippy`)
- [x] All tests pass (`cargo test`)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass

## Additional Notes
`cargo audit` now passes. The remaining output is the repo's existing allowed warnings for `async-std`, `bincode`, and `instant`.