### PR TITLE
[codex] Fix issues #132 and #137 on main

### DIFF
--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -31,6 +31,8 @@ python bench.py --list
 | B7 | test | テスト実行のベンチマーク |
 | B8 | mcp | MCP/JSON出力のベンチマーク |
 
+`B8` の MCP 計測は 1 サンプルごとに `pybun mcp serve --stdio` を 1 回だけ起動し、同じ stdio セッション内で `initialize` と `tools/call` を連続実行します。成功判定は JSON-RPC の到達有無ではなく、`tools/call` の実際の結果 (`isError` / tool payload) に基づきます。
+
 ## ディレクトリ構造
 
 ```

--- a/scripts/benchmark/scenarios/mcp.py
+++ b/scripts/benchmark/scenarios/mcp.py
@@ -12,7 +12,9 @@ Scenarios:
 
 from __future__ import annotations
 
+import io
 import json
+import select
 import subprocess
 import tempfile
 import time
@@ -22,44 +24,189 @@ from pathlib import Path
 # scenario, BenchResult, find_tool, measure_command
 
 
-def send_mcp_request(pybun_path: str, request: dict, timeout: int = 30) -> tuple[dict | None, float]:
-    """
-    Send a JSON-RPC request to MCP server and measure response time.
-    Returns (response, elapsed_ms).
-    """
-    request_json = json.dumps(request)
-    
-    start = time.perf_counter()
+def _response_key(request_id: object) -> str:
+    return json.dumps(request_id, sort_keys=True)
+
+
+def _extract_tool_text(result: dict) -> str | None:
+    content = result.get("content")
+    if not isinstance(content, list):
+        return None
+    for item in content:
+        if isinstance(item, dict) and isinstance(item.get("text"), str):
+            return item["text"]
+    return None
+
+
+def tool_response_error(response: dict | None) -> str | None:
+    """Return an error string when the MCP response represents a failed tool call."""
+    if response is None:
+        return "No response from MCP server"
+
+    if isinstance(response.get("error"), dict):
+        return response["error"].get("message", "Unknown JSON-RPC error")
+
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return None
+
+    text = _extract_tool_text(result)
+    if result.get("isError"):
+        return text or "MCP tool call failed"
+
+    if not text:
+        return None
+
     try:
-        proc = subprocess.Popen(
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    if payload.get("status") == "error":
+        return payload.get("stderr") or payload.get("message") or "Tool returned status=error"
+
+    exit_code = payload.get("exit_code")
+    if isinstance(exit_code, int) and exit_code != 0:
+        return payload.get("stderr") or f"Tool exited with code {exit_code}"
+
+    return None
+
+
+class McpStdioSession:
+    """Line-oriented stdio client for a single MCP server process."""
+
+    def __init__(self, pybun_path: str) -> None:
+        self._proc = subprocess.Popen(
             [pybun_path, "mcp", "serve", "--stdio"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            bufsize=1,
         )
-        
-        # Send request
-        stdout, stderr = proc.communicate(input=request_json + "\n", timeout=timeout)
-        
-        end = time.perf_counter()
-        elapsed_ms = (end - start) * 1000
-        
-        # Parse response
-        if stdout:
+        self._pending: dict[str, dict] = {}
+
+    def __enter__(self) -> "McpStdioSession":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        stdin_closed = getattr(self._proc.stdin, "closed", False)
+        if self._proc.stdin and not stdin_closed:
+            self._proc.stdin.close()
+        try:
+            self._proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            self._proc.terminate()
             try:
-                response = json.loads(stdout.strip().split("\n")[-1])
-                return response, elapsed_ms
+                self._proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=1)
+
+    def send_request(self, request: dict, timeout: int = 30) -> tuple[dict | None, float]:
+        """Send one request and wait for the matching response id."""
+        expected_id = request.get("id")
+        key = _response_key(expected_id)
+        start = time.perf_counter()
+
+        if self._proc.stdin is None:
+            return None, 0.0
+
+        self._proc.stdin.write(json.dumps(request) + "\n")
+        self._proc.stdin.flush()
+
+        if key in self._pending:
+            response = self._pending.pop(key)
+            return response, (time.perf_counter() - start) * 1000
+
+        response = self._read_response(expected_id, timeout)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        return response, elapsed_ms
+
+    def _read_response(self, expected_id: object, timeout: int) -> dict | None:
+        expected_key = _response_key(expected_id)
+        deadline = time.perf_counter() + timeout
+
+        if expected_key in self._pending:
+            return self._pending.pop(expected_key)
+
+        while time.perf_counter() < deadline:
+            remaining = deadline - time.perf_counter()
+            line = self._readline_with_timeout(remaining)
+            if line is None:
+                continue
+
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            try:
+                response = json.loads(stripped)
             except json.JSONDecodeError:
-                return None, elapsed_ms
-        
-        return None, elapsed_ms
-        
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        return None, timeout * 1000
-    except Exception as e:
+                continue
+
+            if not isinstance(response, dict) or "id" not in response:
+                continue
+
+            response_key = _response_key(response.get("id"))
+            if response_key == expected_key:
+                return response
+            self._pending[response_key] = response
+
+        return None
+
+    def _readline_with_timeout(self, timeout: float) -> str | None:
+        if self._proc.stdout is None:
+            return None
+
+        fileno = getattr(self._proc.stdout, "fileno", None)
+        if callable(fileno):
+            try:
+                ready, _, _ = select.select([self._proc.stdout], [], [], timeout)
+            except (OSError, ValueError, io.UnsupportedOperation):
+                ready = None
+            if ready == []:
+                return None
+
+        line = self._proc.stdout.readline()
+        if line == "":
+            if self._proc.poll() is not None:
+                return None
+        return line
+
+
+def send_mcp_request(pybun_path: str, request: dict, timeout: int = 30) -> tuple[dict | None, float]:
+    """
+    Send a single JSON-RPC request in a fresh MCP stdio session.
+    Kept for compatibility with tests/helpers that only need one round-trip.
+    """
+    try:
+        with McpStdioSession(pybun_path) as session:
+            return session.send_request(request, timeout=timeout)
+    except Exception:
         return None, 0.0
+
+
+def measure_mcp_round(
+    pybun_path: str,
+    init_request: dict,
+    call_request: dict,
+    timeout: int = 30,
+) -> tuple[dict | None, dict | None, float]:
+    """
+    Measure one MCP benchmark sample using a single stdio server session.
+    Returns (initialize_response, tool_response, tool_call_elapsed_ms).
+    """
+    with McpStdioSession(pybun_path) as session:
+        init_response, _ = session.send_request(init_request, timeout=timeout)
+        call_response, call_time = session.send_request(call_request, timeout=timeout)
+    return init_response, call_response, call_time
 
 
 def measure_mcp_tool(
@@ -99,22 +246,36 @@ def measure_mcp_tool(
     
     # Warmup
     for _ in range(warmup):
-        send_mcp_request(pybun_path, init_request)
-        send_mcp_request(pybun_path, call_request)
-    
+        try:
+            measure_mcp_round(pybun_path, init_request, call_request)
+        except Exception:
+            pass
+
     # Timed runs
     for _ in range(iterations):
-        _, init_time = send_mcp_request(pybun_path, init_request)
-        response, call_time = send_mcp_request(pybun_path, call_request)
-        
-        if response is None:
+        try:
+            init_response, response, total_time = measure_mcp_round(
+                pybun_path,
+                init_request,
+                call_request,
+            )
+        except Exception as exc:
+            init_response = None
+            response = None
+            total_time = 0.0
             success = False
-            last_error = "No response from MCP server"
-        elif "error" in response:
-            success = False
-            last_error = response.get("error", {}).get("message", "Unknown error")
-        
-        times.append(init_time + call_time)
+            last_error = str(exc)
+        else:
+            init_error = tool_response_error(init_response)
+            call_error = tool_response_error(response)
+            if init_error is not None:
+                success = False
+                last_error = init_error
+            elif call_error is not None:
+                success = False
+                last_error = call_error
+
+        times.append(total_time)
     
     import statistics
     avg = statistics.mean(times) if times else 0

--- a/scripts/benchmark/tests/test_mcp.py
+++ b/scripts/benchmark/tests/test_mcp.py
@@ -1,0 +1,208 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import bench
+from scenarios import mcp as mcp_scenario
+
+
+mcp_scenario.BenchResult = bench.BenchResult
+
+
+class FakeStdout:
+    def __init__(self) -> None:
+        self._lines: list[str] = []
+
+    def push(self, line: str) -> None:
+        if not line.endswith("\n"):
+            line = f"{line}\n"
+        self._lines.append(line)
+
+    def readline(self) -> str:
+        if self._lines:
+            return self._lines.pop(0)
+        return ""
+
+
+class FakeStdin:
+    def __init__(self, process: "FakeProcess") -> None:
+        self._process = process
+        self._buffer = ""
+        self.closed = False
+
+    def write(self, data: str) -> int:
+        self._buffer += data
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            if line.strip():
+                self._process.handle_request(line)
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+        self._process.closed = True
+
+
+class FakeProcess:
+    def __init__(self, response_builder) -> None:
+        self.stdin = FakeStdin(self)
+        self.stdout = FakeStdout()
+        self.stderr = FakeStdout()
+        self._response_builder = response_builder
+        self.requests: list[dict] = []
+        self.closed = False
+        self.returncode: int | None = None
+
+    def handle_request(self, line: str) -> None:
+        request = json.loads(line)
+        self.requests.append(request)
+        for response_line in self._response_builder(request):
+            self.stdout.push(response_line)
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+class TestMcpScenario(unittest.TestCase):
+    def test_session_ignores_noise_and_matches_response_ids(self) -> None:
+        def build_response(request: dict) -> list[str]:
+            if request["method"] == "initialize":
+                return [
+                    "PyBun MCP server starting (stdio mode)...",
+                    json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"content": []}}),
+                    json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05"}}),
+                ]
+            return []
+
+        fake_process = FakeProcess(build_response)
+
+        with mock.patch.object(mcp_scenario.subprocess, "Popen", return_value=fake_process):
+            with mcp_scenario.McpStdioSession("pybun") as session:
+                init_response, _ = session.send_request({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+                call_response, _ = session.send_request({"jsonrpc": "2.0", "id": 2, "method": "tools/call"})
+
+        self.assertEqual(init_response["id"], 1)
+        self.assertEqual(call_response["id"], 2)
+        self.assertEqual([req["method"] for req in fake_process.requests], ["initialize", "tools/call"])
+
+    def test_measure_mcp_tool_uses_one_session_per_sample(self) -> None:
+        launched_processes: list[FakeProcess] = []
+
+        def fake_popen(*args, **kwargs):
+            def build_response(request: dict) -> list[str]:
+                if request["method"] == "initialize":
+                    return [json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": {"protocolVersion": "2024-11-05"}})]
+                return [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request["id"],
+                            "result": {
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": json.dumps({"status": "success", "exit_code": 0}),
+                                    }
+                                ]
+                            },
+                        }
+                    )
+                ]
+
+            process = FakeProcess(build_response)
+            launched_processes.append(process)
+            return process
+
+        with mock.patch.object(mcp_scenario.subprocess, "Popen", side_effect=fake_popen):
+            result = mcp_scenario.measure_mcp_tool(
+                "pybun",
+                "pybun_run",
+                {"code": "print('hello')"},
+                iterations=2,
+                warmup=1,
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(launched_processes), 3)
+        for process in launched_processes:
+            self.assertEqual(
+                [request["method"] for request in process.requests],
+                ["initialize", "tools/call"],
+            )
+
+    def test_measure_mcp_round_reports_only_tool_call_latency(self) -> None:
+        init_response = {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05"}}
+        call_response = {"jsonrpc": "2.0", "id": 2, "result": {"content": []}}
+
+        session = mock.MagicMock()
+        session.send_request.side_effect = [
+            (init_response, 12.5),
+            (call_response, 34.0),
+        ]
+
+        session_factory = mock.MagicMock()
+        session_factory.__enter__.return_value = session
+        session_factory.__exit__.return_value = None
+
+        with mock.patch.object(mcp_scenario, "McpStdioSession", return_value=session_factory):
+            actual_init, actual_call, elapsed_ms = mcp_scenario.measure_mcp_round(
+                "pybun",
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                {"jsonrpc": "2.0", "id": 2, "method": "tools/call"},
+            )
+
+        self.assertEqual(actual_init, init_response)
+        self.assertEqual(actual_call, call_response)
+        self.assertEqual(elapsed_ms, 34.0)
+
+    def test_measure_mcp_tool_marks_real_tool_failures(self) -> None:
+        def fake_popen(*args, **kwargs):
+            def build_response(request: dict) -> list[str]:
+                if request["method"] == "initialize":
+                    return [json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": {"protocolVersion": "2024-11-05"}})]
+                return [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request["id"],
+                            "result": {
+                                "content": [{"type": "text", "text": json.dumps({"status": "error", "stderr": "boom"})}]
+                            },
+                        }
+                    )
+                ]
+
+            return FakeProcess(build_response)
+
+        with mock.patch.object(mcp_scenario.subprocess, "Popen", side_effect=fake_popen):
+            result = mcp_scenario.measure_mcp_tool(
+                "pybun",
+                "pybun_run",
+                {"code": "print('hello')"},
+                iterations=1,
+                warmup=0,
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("boom", result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1542,10 +1542,18 @@ fn emit_lockfile_verification_drift(lockfile: &Lockfile, collector: &mut EventCo
 }
 
 async fn lock_dependencies(args: &LockArgs, collector: &mut EventCollector) -> Result<LockOutcome> {
-    let script_path = args
-        .script
-        .as_ref()
-        .ok_or_else(|| eyre!("--script is required for locking"))?;
+    let Some(script_path) = args.script.as_ref() else {
+        collector.diagnostic(Diagnostic {
+            level: crate::schema::DiagnosticLevel::Error,
+            code: Some("E_LOCK_SCRIPT_REQUIRED".to_string()),
+            message: "--script is required for locking".to_string(),
+            file: None,
+            line: None,
+            suggestion: Some("Usage: pybun lock --script <path/to/script.py>".to_string()),
+            context: None,
+        });
+        return Err(eyre!("--script is required for locking"));
+    };
 
     if !script_path.exists() {
         return Err(eyre!("script not found: {}", script_path.display()));

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -213,6 +213,40 @@ fn install_missing_hash_outputs_verification_diagnostic_in_json() {
 }
 
 #[test]
+fn lock_missing_script_outputs_diagnostics_in_json() {
+    let output = bin()
+        .args(["--format=json", "lock"])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let parsed: Value = serde_json::from_str(&stdout).expect("json output");
+
+    assert_eq!(parsed["status"], "error");
+    assert_eq!(
+        parsed["detail"]["error"],
+        "--script is required for locking"
+    );
+    let diags = parsed["diagnostics"].as_array().expect("diagnostics array");
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.get("code") == Some(&Value::from("E_LOCK_SCRIPT_REQUIRED"))),
+        "expected E_LOCK_SCRIPT_REQUIRED diagnostic code"
+    );
+    assert!(
+        diags.iter().any(|d| d
+            .get("suggestion")
+            .and_then(Value::as_str)
+            .is_some_and(|hint| hint.contains("--script"))),
+        "expected usage suggestion for missing --script"
+    );
+}
+
+#[test]
 fn upgrade_outputs_drift_warning_for_placeholder_hash_lockfiles() {
     let temp = tempdir().unwrap();
     let index_path = temp.path().join("index.json");


### PR DESCRIPTION
## Summary

- fixes Issue #132 by emitting a structured `E_LOCK_SCRIPT_REQUIRED` diagnostic when `pybun lock --format=json` is called without `--script`
- fixes Issue #137 by measuring MCP benchmark samples inside a single stdio session and by judging success from the actual `tools/call` result
- adds regression coverage for the JSON diagnostic path and the benchmark MCP request flow, and documents the updated B8 benchmark model

## Validation

- `cargo fmt --all`
- `cargo test --test json_output lock_missing_script_outputs_diagnostics_in_json`
- `python3 -m unittest scripts/benchmark/tests/test_mcp.py -v`
- `cargo audit` (warnings only: existing unmaintained dependencies `async-std`, `bincode`, `instant`)
