### PR TITLE
fix(init): return actionable diagnostic when stdin is not a terminal (#133)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -59,6 +59,11 @@
   - Goal: プロジェクト検出時に system Python へ直接入る経路を避け、`.pybun/venv` を既定化。
   - Tests: 既存venv無しプロジェクトでの install E2E（system汚染しないことを確認）。
 
+- [DONE] PR-UX1: `pybun init` non-TTY actionable error (Issue #133)
+  - Goal: non-TTY 環境で `pybun init`（`--yes` なし）を実行した際、"IO error: not a terminal" の代わりに `--yes` フラグを案内する actionable diagnostic を返す。
+  - Current: `init_project()` に `&mut EventCollector` を追加し、stdin が TTY でない場合は `E_INIT_NOT_INTERACTIVE` diagnostic（`suggestion` フィールドに `pybun init --yes` 案内）を push してから早期 return。テキストモードの stderr にも `--yes` を含むメッセージを出力。
+  - Tests: `tests/cli_init.rs` に3件追加 — `init_non_tty_without_yes_fails_with_hint`（テキスト出力に --yes 含む）、`init_non_tty_without_yes_json_fails_with_hint`（JSON diagnostics に suggestion フィールド含む）、`init_non_tty_with_yes_succeeds`（--yes 指定時は非 TTY でも成功）。
+
 ### P2 (Post-GA Improvement)
 - PR-A8: Runtime catalog hardening（実チェックサム管理 + 3.13 preview）
   - Goal: 埋め込み runtime metadata の完全性・更新性を強化し、3.13 preview を段階導入。

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -21,7 +21,9 @@ use crate::resolver::{
 };
 use crate::sandbox;
 use crate::sbom;
-use crate::schema::{Diagnostic, Event, EventCollector, EventType, JsonEnvelope, Status};
+use crate::schema::{
+    Diagnostic, DiagnosticLevel, Event, EventCollector, EventType, JsonEnvelope, Status,
+};
 use crate::self_update::apply_update_for_asset;
 use crate::support_bundle::{BundleContext, BundleReport, build_support_bundle, upload_bundle};
 use crate::wheel_cache::WheelCache;
@@ -620,11 +622,16 @@ pub async fn execute(cli: Cli) -> Result<()> {
             }
         }
         Commands::Init(args) => {
+            let pre_diag_count = collector.diagnostic_count();
             let result = init_project(args, &mut collector);
             match result {
                 Ok(detail) => ("init".to_string(), detail),
                 Err(e) => {
-                    collector.error(e.to_string());
+                    // Only push a generic fallback error if init_project did not
+                    // already record a structured diagnostic (e.g. E_INIT_NOT_INTERACTIVE).
+                    if collector.diagnostic_count() == pre_diag_count {
+                        collector.error(e.to_string());
+                    }
                     (
                         "init".to_string(),
                         RenderDetail::error(
@@ -5086,7 +5093,7 @@ fn init_project(args: &InitArgs, collector: &mut EventCollector) -> Result<Rende
         // Interactive mode — requires a terminal
         if !std::io::stdin().is_terminal() {
             collector.diagnostic(Diagnostic {
-                level: crate::schema::DiagnosticLevel::Error,
+                level: DiagnosticLevel::Error,
                 code: Some("E_INIT_NOT_INTERACTIVE".to_string()),
                 message: "Interactive prompt requires a terminal".to_string(),
                 file: None,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -620,7 +620,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
             }
         }
         Commands::Init(args) => {
-            let result = init_project(args);
+            let result = init_project(args, &mut collector);
             match result {
                 Ok(detail) => ("init".to_string(), detail),
                 Err(e) => {
@@ -5059,7 +5059,7 @@ fn sanitize_project_name(name: &str) -> String {
     }
 }
 
-fn init_project(args: &InitArgs) -> Result<RenderDetail> {
+fn init_project(args: &InitArgs, collector: &mut EventCollector) -> Result<RenderDetail> {
     let cwd =
         std::env::current_dir().map_err(|e| eyre!("failed to get current directory: {}", e))?;
     let pyproject_path = cwd.join("pyproject.toml");
@@ -5083,7 +5083,25 @@ fn init_project(args: &InitArgs) -> Result<RenderDetail> {
             args.template,
         )
     } else {
-        // Interactive mode
+        // Interactive mode — requires a terminal
+        if !std::io::stdin().is_terminal() {
+            collector.diagnostic(Diagnostic {
+                level: crate::schema::DiagnosticLevel::Error,
+                code: Some("E_INIT_NOT_INTERACTIVE".to_string()),
+                message: "Interactive prompt requires a terminal".to_string(),
+                file: None,
+                line: None,
+                suggestion: Some(
+                    "Run with --yes to accept defaults non-interactively: pybun init --yes"
+                        .to_string(),
+                ),
+                context: None,
+            });
+            return Err(eyre!(
+                "Interactive prompt requires a terminal. Run with --yes to accept defaults non-interactively: pybun init --yes"
+            ));
+        }
+
         let theme = ColorfulTheme::default();
 
         // Name

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -429,6 +429,11 @@ impl EventCollector {
         self.diagnostics.push(diagnostic);
     }
 
+    /// Return the number of diagnostics recorded so far.
+    pub fn diagnostic_count(&self) -> usize {
+        self.diagnostics.len()
+    }
+
     /// Record an error diagnostic
     pub fn error(&mut self, message: impl Into<String>) {
         self.diagnostics.push(Diagnostic::error(message));

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -213,6 +213,91 @@ fn init_help_shows_options() {
         .stdout(predicate::str::contains("--template"));
 }
 
+// Issue #133: non-TTY without --yes should produce an actionable hint
+#[test]
+fn init_non_tty_without_yes_fails_with_hint() {
+    let temp = tempdir().unwrap();
+
+    // Pipe empty stdin to simulate non-TTY
+    let output = bin()
+        .current_dir(temp.path())
+        .args(["init"])
+        .write_stdin("")
+        .output()
+        .expect("command runs");
+
+    assert!(
+        !output.status.success(),
+        "should fail in non-TTY without --yes"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(
+        combined.contains("--yes") || combined.contains("-y"),
+        "error output should mention --yes flag, got: {}",
+        combined
+    );
+}
+
+#[test]
+fn init_non_tty_without_yes_json_fails_with_hint() {
+    let temp = tempdir().unwrap();
+
+    let output = bin()
+        .current_dir(temp.path())
+        .args(["--format=json", "init"])
+        .write_stdin("")
+        .output()
+        .expect("command runs");
+
+    assert!(
+        !output.status.success(),
+        "should fail in non-TTY without --yes"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("expected JSON output, got: {}", stdout));
+
+    assert_eq!(json["status"], "error", "JSON status should be error");
+
+    let diagnostics = json["diagnostics"].as_array().expect("diagnostics array");
+    assert!(
+        !diagnostics.is_empty(),
+        "should have at least one diagnostic"
+    );
+
+    let hint_found = diagnostics.iter().any(|d| {
+        d["suggestion"]
+            .as_str()
+            .map(|h| h.contains("--yes") || h.contains("-y"))
+            .unwrap_or(false)
+    });
+    assert!(
+        hint_found,
+        "at least one diagnostic should contain --yes suggestion, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn init_non_tty_with_yes_succeeds() {
+    let temp = tempdir().unwrap();
+
+    // With --yes flag, non-TTY should succeed even with piped stdin
+    bin()
+        .current_dir(temp.path())
+        .args(["init", "--yes"])
+        .write_stdin("")
+        .assert()
+        .success();
+
+    assert!(temp.path().join("pyproject.toml").exists());
+}
+
 #[test]
 fn init_with_python_version() {
     let temp = tempdir().unwrap();

--- a/tests/cli_init.rs
+++ b/tests/cli_init.rs
@@ -265,9 +265,11 @@ fn init_non_tty_without_yes_json_fails_with_hint() {
     assert_eq!(json["status"], "error", "JSON status should be error");
 
     let diagnostics = json["diagnostics"].as_array().expect("diagnostics array");
-    assert!(
-        !diagnostics.is_empty(),
-        "should have at least one diagnostic"
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "should have exactly one diagnostic (no duplicates), got: {}",
+        stdout
     );
 
     let hint_found = diagnostics.iter().any(|d| {
@@ -278,9 +280,14 @@ fn init_non_tty_without_yes_json_fails_with_hint() {
     });
     assert!(
         hint_found,
-        "at least one diagnostic should contain --yes suggestion, got: {}",
+        "diagnostic should contain --yes suggestion, got: {}",
         stdout
     );
+
+    // Verify structured diagnostic fields
+    let diag = &diagnostics[0];
+    assert_eq!(diag["level"], "error");
+    assert_eq!(diag["code"], "E_INIT_NOT_INTERACTIVE");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `pybun init` (without `--yes`) in non-TTY environments (CI, pipes, AI agents) previously crashed with the unhelpful error `"IO error: not a terminal"`
- Now emits a structured `E_INIT_NOT_INTERACTIVE` diagnostic with a `suggestion` field
- Text-mode stderr also includes the `--yes` hint for human-readable output

## Changes

- `src/commands.rs`: Added `&mut EventCollector` param to `init_project()`. Added stdin TTY check before entering interactive mode — pushes `E_INIT_NOT_INTERACTIVE` diagnostic with `suggestion: "Run with --yes to accept defaults non-interactively: pybun init --yes"` on non-TTY stdin, then fails with an `eyre!` message that includes the hint for text output.
- `tests/cli_init.rs`: Added 3 new tests covering non-TTY text output, non-TTY JSON output, and `--yes` success in non-TTY.
- `docs/PLAN.md`: Marked PR-UX1 as DONE.

## Before / After

**Before:**
```json
{"status":"error","diagnostics":[{"level":"error","message":"IO error: not a terminal"}]}
```

**After:**
```json
{"status":"error","diagnostics":[{"level":"error","code":"E_INIT_NOT_INTERACTIVE","message":"Interactive prompt requires a terminal","suggestion":"Run with --yes to accept defaults non-interactively: pybun init --yes"}]}
```

## Test plan

- [x] `cargo test --test cli_init` — 16 tests pass (3 new)
- [x] `cargo test --test e2e_general` — 9 tests pass
- [x] `cargo test` — full suite passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — clean

Closes #133