### PR TITLE
fix(run): propagate child Python process exit code to shell (#148)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -315,6 +315,9 @@ pub async fn execute(cli: Cli) -> Result<()> {
                     cleanup,
                 }) => (
                     "x".to_string(),
+                    // TODO: propagate exit_code for `pybun x` the same way
+                    // `pybun run` does (with_process_exit_code). Tracked
+                    // separately to keep this PR scoped to issue #148.
                     RenderDetail::with_json(
                         summary,
                         json!({
@@ -704,13 +707,20 @@ pub async fn execute(cli: Cli) -> Result<()> {
         println!("{output}");
     }
 
-    // Exit with error code if command failed
+    // Flush stdout before any std::process::exit call. std::process::exit
+    // skips destructors, so a BufWriter around stdout (common on Windows)
+    // would otherwise silently discard buffered output.
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
+    // `is_error` and `process_exit_code` are mutually exclusive: the Err
+    // arm of every command sets is_error via RenderDetail::error() which
+    // leaves process_exit_code = None, while the Ok arm uses with_json()
+    // and may call with_process_exit_code(). is_error always takes priority.
     if is_error {
         std::process::exit(1);
     }
 
     // Propagate the child process exit code (e.g. from `pybun run`).
-    // Output has already been flushed above, so it is safe to exit now.
     if let Some(code) = process_exit_code
         && code != 0
     {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -268,24 +268,23 @@ pub async fn execute(cli: Cli) -> Result<()> {
                             "audit": s.audit,
                         })
                     });
-                    (
-                        "run".to_string(),
-                        RenderDetail::with_json(
-                            summary,
-                            json!({
-                                "target": target,
-                                "exit_code": exit_code,
-                                "pep723_dependencies": pep723_deps,
-                                "pep723_backend": pep723_backend,
-                                "temp_env": temp_env,
-                                "cleanup": cleanup,
-                                "cache_hit": cache_hit,
-                                "stdout": stdout,
-                                "stderr": stderr,
-                                "sandbox": sandbox_detail,
-                            }),
-                        ),
+                    let detail = RenderDetail::with_json(
+                        summary,
+                        json!({
+                            "target": target,
+                            "exit_code": exit_code,
+                            "pep723_dependencies": pep723_deps,
+                            "pep723_backend": pep723_backend,
+                            "temp_env": temp_env,
+                            "cleanup": cleanup,
+                            "cache_hit": cache_hit,
+                            "stdout": stdout,
+                            "stderr": stderr,
+                            "sandbox": sandbox_detail,
+                        }),
                     )
+                    .with_process_exit_code(exit_code);
+                    ("run".to_string(), detail)
                 }
                 Err(e) => {
                     collector.error(e.to_string());
@@ -689,6 +688,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
     let (events, diagnostics, trace_id) = collector.into_parts();
 
     let is_error = detail.is_error;
+    let process_exit_code = detail.process_exit_code;
     let rendered = render(
         &command,
         detail,
@@ -707,6 +707,14 @@ pub async fn execute(cli: Cli) -> Result<()> {
     // Exit with error code if command failed
     if is_error {
         std::process::exit(1);
+    }
+
+    // Propagate the child process exit code (e.g. from `pybun run`).
+    // Output has already been flushed above, so it is safe to exit now.
+    if let Some(code) = process_exit_code
+        && code != 0
+    {
+        std::process::exit(code);
     }
 
     Ok(())
@@ -1701,6 +1709,10 @@ struct RenderDetail {
     /// where stdout is the protocol channel and must not be polluted after
     /// the session ends.
     silent: bool,
+    /// Exit code to propagate from a child process (e.g. `pybun run`).
+    /// When set and non-zero, `execute` calls `std::process::exit` with this
+    /// code after flushing output, so the shell sees the script's own code.
+    process_exit_code: Option<i32>,
 }
 
 impl RenderDetail {
@@ -1711,6 +1723,7 @@ impl RenderDetail {
             is_error: false,
             raw_text: false,
             silent: false,
+            process_exit_code: None,
         }
     }
 
@@ -1721,6 +1734,7 @@ impl RenderDetail {
             is_error: true,
             raw_text: false,
             silent: false,
+            process_exit_code: None,
         }
     }
 
@@ -1731,6 +1745,7 @@ impl RenderDetail {
             is_error: false,
             raw_text: true,
             silent: false,
+            process_exit_code: None,
         }
     }
 
@@ -1744,7 +1759,15 @@ impl RenderDetail {
             is_error: false,
             raw_text: false,
             silent: true,
+            process_exit_code: None,
         }
+    }
+
+    /// Attach a child-process exit code that `execute` will propagate via
+    /// `std::process::exit` after flushing output.
+    fn with_process_exit_code(mut self, code: i32) -> Self {
+        self.process_exit_code = Some(code);
+        self
     }
 }
 

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -100,11 +100,77 @@ fn run_script_with_exit_code() {
     let script = temp.path().join("exit_nonzero.py");
     fs::write(&script, "import sys; sys.exit(42)").unwrap();
 
-    bin()
+    // pybun propagates the script's exit code; JSON output is still emitted
+    let output = bin()
         .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun");
+    assert_eq!(output.status.code(), Some(42));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"exit_code\":42"), "stdout: {stdout}");
+}
+
+// Issue #148: pybun run must propagate the child Python process exit code.
+
+#[test]
+fn run_script_propagates_nonzero_exit_code() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("fail.py");
+    fs::write(&script, "import sys; sys.exit(42)").unwrap();
+
+    let output = bin()
+        .args(["run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun");
+    assert_eq!(
+        output.status.code(),
+        Some(42),
+        "pybun must exit with the script's exit code"
+    );
+}
+
+#[test]
+fn run_inline_code_propagates_nonzero_exit_code() {
+    let output = bin()
+        .args(["run", "-c", "--", "import sys; sys.exit(7)"])
+        .output()
+        .expect("run pybun");
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "pybun must exit with the inline code's exit code"
+    );
+}
+
+#[test]
+fn run_script_exit_zero_still_succeeds() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("ok.py");
+    fs::write(&script, "print('ok')").unwrap();
+
+    bin()
+        .args(["run", script.to_str().unwrap()])
         .assert()
-        .success() // pybun itself succeeds, reports script exit code
-        .stdout(predicate::str::contains("\"exit_code\":42"));
+        .success();
+}
+
+#[test]
+fn run_script_propagates_exit_code_json_mode() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("fail_json.py");
+    fs::write(&script, "import sys; sys.exit(5)").unwrap();
+
+    let output = bin()
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun");
+    // JSON output must be valid and contain exit_code
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {stdout}"));
+    assert_eq!(value["detail"]["exit_code"], 5);
+    // pybun process must exit with the script's code
+    assert_eq!(output.status.code(), Some(5));
 }
 
 #[test]

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -33,7 +33,7 @@ subprocess.run(["echo", "hello from child"])
             script.to_str().unwrap(),
         ])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains("\"sandbox\""))
         .stdout(predicate::str::contains("\"allow_network\":false"))
         .stdout(predicate::str::contains("\"exit_code\":1"))
@@ -63,7 +63,7 @@ print("network allowed")
             script.to_str().unwrap(),
         ])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains("\"exit_code\":1"));
 
     // With opt-in, the script should run successfully and report the sandbox policy in JSON.
@@ -108,7 +108,7 @@ fn sandbox_allow_read_blocks_unauthorized_path() {
         &format!("--allow-read={}", allowed_dir.path().display()),
         script.to_str().unwrap(),
     ])
-    .success()
+    .code(1)
     .stdout(predicate::str::contains("\"exit_code\":1"));
 }
 
@@ -138,7 +138,7 @@ fn sandbox_allow_read_blocks_sibling_prefix_bypass() {
         &format!("--allow-read={}", allowed_dir.display()),
         script.to_str().unwrap(),
     ])
-    .success()
+    .code(1)
     .stdout(predicate::str::contains("\"exit_code\":1"))
     .stdout(predicate::str::contains("\"blocked_file_reads\":"));
 }
@@ -199,7 +199,7 @@ fn sandbox_allow_read_blocks_update_mode_bypass() {
         &format!("--allow-read={}", allowed_dir.path().display()),
         script.to_str().unwrap(),
     ])
-    .success()
+    .code(1)
     .stdout(predicate::str::contains("\"exit_code\":1"))
     .stdout(predicate::str::contains("\"blocked_file_reads\":"));
 }
@@ -226,7 +226,7 @@ fn sandbox_allow_write_blocks_unauthorized_path() {
         &format!("--allow-write={}", temp.path().display()),
         script.to_str().unwrap(),
     ])
-    .success()
+    .code(1)
     .stdout(predicate::str::contains("\"exit_code\":1"));
 }
 


### PR DESCRIPTION
## Summary

Fixes #148.

`pybun run` was always exiting with code `0` even when the spawned Python process exited with a non-zero code. This broke CI/CD pipelines and wrapper scripts that rely on the exit code to detect failures.

**Root cause**: `RenderDetail` had no mechanism to carry a child-process exit code. `execute()` only called `std::process::exit(1)` on internal command errors, never on the script's own exit code.

**Fix**:
- Add `process_exit_code: Option<i32>` field to `RenderDetail`
- Add `with_process_exit_code(code: i32) -> Self` builder method
- In the `Commands::Run` match arm, attach the `RunOutcome.exit_code` to `RenderDetail` via `with_process_exit_code()`
- In `execute()`, after flushing output, call `std::process::exit(code)` when `process_exit_code` is `Some(non-zero)`

This correctly handles all run modes: script file, inline `-c`, and sandboxed execution.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Script exits 0 | pybun exits 0 ✅ | pybun exits 0 ✅ |
| Script exits 42 (text mode) | pybun exits 0 ❌ | pybun exits 42 ✅ |
| Script exits 42 (json mode) | pybun exits 0 ❌ | pybun exits 42 ✅ |
| Sandbox blocks script (exit 1) | pybun exits 0 ❌ | pybun exits 1 ✅ |

JSON output (`--format=json`) is emitted **before** `std::process::exit`, so structured output is never lost.

## Test plan

- [x] `run_script_propagates_nonzero_exit_code` — text mode, script exit 42
- [x] `run_inline_code_propagates_nonzero_exit_code` — `-c` mode, exit 7
- [x] `run_script_exit_zero_still_succeeds` — exit 0 regression guard
- [x] `run_script_propagates_exit_code_json_mode` — JSON mode, exit 5, JSON still valid
- [x] `run_script_with_exit_code` — updated to assert `code(42)` (was `.success()`)
- [x] `sandbox` tests updated to assert `code(1)` where script fails due to policy
- [x] All 262+ existing tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] E2E tests (`cargo test --test e2e_general`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)