### PR TITLE
fix(run): report status "error" in JSON mode when child exits non-zero (#155)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -68,6 +68,11 @@
   - Current: `RenderDetail` に `process_exit_code: Option<i32>` フィールドと `with_process_exit_code()` ビルダーを追加。`Commands::Run` が `RunOutcome.exit_code` を `with_process_exit_code()` で設定し、`execute()` がアウトプット flush 後に `std::process::exit(code)` で伝播。stdout flush を `std::process::exit` 前に明示追加（Windows CRT バッファ対策）。
   - Tests: `tests/cli_run.rs` に4件追加 — `run_script_propagates_nonzero_exit_code`（スクリプトファイル、exit 42）、`run_inline_code_propagates_nonzero_exit_code`（-c モード、exit 7）、`run_script_exit_zero_still_succeeds`（exit 0 のリグレッションガード）、`run_script_propagates_exit_code_json_mode`（JSON モード、exit 5、JSON 出力が有効かつ終了コード伝播）。既存テスト `run_script_with_exit_code` を `.code(42)` アサーションに更新。`tests/sandbox.rs` の6件を `.code(1)` に更新（sandbox ポリシー違反で Python が exit 1 する場合）。
 
+- [DONE] PR-UX3: `pybun run --format=json` reports `status: "error"` on child failure (Issue #155)
+  - Goal: JSON モードで子プロセスが非ゼロで終了した場合、JSON エンベロープの `status` を `"error"` にし、pybun プロセスも子の終了コードで終了する。サンドボックス違反も同様。
+  - Current: `render()` 関数内（`src/commands.rs`）の JSON ステータス決定ロジックを修正。`detail.is_error` に加え `detail.process_exit_code.is_some_and(|c| c != 0)` を OR 条件として追加することで、子プロセス失敗時も `Status::Error` を返すよう変更。
+  - Tests: `tests/cli_run.rs` に3件追加 — `run_json_mode_nonzero_exit_reports_error_status`（スクリプトファイル、exit 3、status == "error"）、`run_json_mode_inline_nonzero_reports_error_status`（-c モード、exit 7、status == "error"）、`run_json_mode_zero_exit_reports_ok_status`（exit 0 のリグレッションガード、status == "ok"）。既存テスト `run_script_propagates_exit_code_json_mode` に `value["status"] == "error"` アサーションを追加。
+
 - [DONE] PR-UX1: `pybun init` non-TTY actionable error (Issue #133)
   - Goal: non-TTY 環境で `pybun init`（`--yes` なし）を実行した際、"IO error: not a terminal" の代わりに `--yes` フラグを案内する actionable diagnostic を返す。
   - Current: `init_project()` に `&mut EventCollector` を追加し、stdin が TTY でない場合は `E_INIT_NOT_INTERACTIVE` diagnostic（`suggestion` フィールドに `pybun init --yes` 案内）を push してから早期 return。テキストモードの stderr にも `--yes` を含むメッセージを出力。

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -752,7 +752,8 @@ fn render(
             }
         }
         OutputFormat::Json => {
-            let status = if detail.is_error {
+            let child_failed = detail.process_exit_code.is_some_and(|c| c != 0);
+            let status = if detail.is_error || child_failed {
                 Status::Error
             } else {
                 Status::Ok

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -752,6 +752,7 @@ fn render(
             }
         }
         OutputFormat::Json => {
+            // child_failed is only set on the Ok arm; is_error covers the Err arm (see execute()).
             let child_failed = detail.process_exit_code.is_some_and(|c| c != 0);
             let status = if detail.is_error || child_failed {
                 Status::Error

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -169,6 +169,8 @@ fn run_script_propagates_exit_code_json_mode() {
     let value: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|_| panic!("expected valid JSON, got: {stdout}"));
     assert_eq!(value["detail"]["exit_code"], 5);
+    // JSON envelope status must be "error" when child exits non-zero (#155)
+    assert_eq!(value["status"], "error");
     // pybun process must exit with the script's code
     assert_eq!(output.status.code(), Some(5));
 }
@@ -391,4 +393,79 @@ print("test cleanup field")
         .success()
         // cleanup should be false with caching (venv not cleaned up)
         .stdout(predicate::str::contains("\"cleanup\":false"));
+}
+
+// =============================================================================
+// Issue #155: --format=json must report status "error" when child exits non-zero
+// =============================================================================
+
+#[test]
+fn run_json_mode_nonzero_exit_reports_error_status() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("fail155.py");
+    fs::write(&script, "import sys; sys.exit(3)").unwrap();
+
+    let output = bin()
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {stdout}"));
+
+    assert_eq!(
+        value["status"], "error",
+        "JSON status must be 'error' when child exits non-zero"
+    );
+    assert_eq!(value["detail"]["exit_code"], 3);
+    assert_eq!(output.status.code(), Some(3));
+}
+
+#[test]
+fn run_json_mode_inline_nonzero_reports_error_status() {
+    let output = bin()
+        .args([
+            "--format=json",
+            "run",
+            "-c",
+            "--",
+            "import sys; sys.exit(7)",
+        ])
+        .output()
+        .expect("run pybun");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {stdout}"));
+
+    assert_eq!(
+        value["status"], "error",
+        "JSON status must be 'error' for -c mode with non-zero exit"
+    );
+    assert_eq!(value["detail"]["exit_code"], 7);
+    assert_eq!(output.status.code(), Some(7));
+}
+
+#[test]
+fn run_json_mode_zero_exit_reports_ok_status() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("ok155.py");
+    fs::write(&script, "print('success')").unwrap();
+
+    let output = bin()
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {stdout}"));
+
+    assert_eq!(
+        value["status"], "ok",
+        "JSON status must be 'ok' when child exits 0"
+    );
+    assert_eq!(value["detail"]["exit_code"], 0);
+    assert!(output.status.success());
 }


### PR DESCRIPTION
## Summary

- Fixed `pybun run --format=json` to set `status: "error"` in the JSON envelope when the child Python process exits non-zero
- The wrapper process already propagated the child exit code correctly; this PR fixes the inconsistent `status: "ok"` in the JSON response
- Sandbox policy violations (child exit 1) are also covered by this fix

## Root cause

In `render()` (`src/commands.rs`), the JSON status was determined solely by `detail.is_error`, which is only set when the Rust-side execution fails. Child process non-zero exits use `detail.process_exit_code` (set via `with_process_exit_code()`), which was not consulted for the JSON status.

## Fix

One-line change in `render()`:
```rust
let child_failed = detail.process_exit_code.is_some_and(|c| c != 0);
let status = if detail.is_error || child_failed {
    Status::Error
} else {
    Status::Ok
};
```

## Test plan

- [ ] `run_json_mode_nonzero_exit_reports_error_status` — script exits 3, JSON status == "error", wrapper exits 3
- [ ] `run_json_mode_inline_nonzero_reports_error_status` — `-c` mode exits 7, JSON status == "error", wrapper exits 7  
- [ ] `run_json_mode_zero_exit_reports_ok_status` — regression guard: exit 0 still reports status == "ok"
- [ ] `run_script_propagates_exit_code_json_mode` — updated to assert `status == "error"` in addition to exit code propagation
- [ ] All existing tests pass (`cargo test`: 0 failures)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [ ] E2E tests pass

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)