### PR TITLE
fix(benchmark): hermetic cwd for tool path resolution and uv subprocess runs (Issue #157)

### DIFF
--- a/scripts/benchmark/bench.py
+++ b/scripts/benchmark/bench.py
@@ -148,9 +148,15 @@ def find_tool(name: str, config: dict) -> str | None:
     paths = config.get("paths", {})
     if name in paths and paths[name]:
         path = paths[name]
+        # Resolve relative paths against _base_dir so the result is independent
+        # of the caller's cwd (fixes Issue #157 Problem 1).
+        if not os.path.isabs(path):
+            base_dir = config.get("_base_dir")
+            if base_dir:
+                path = str(Path(base_dir) / path)
         if os.path.exists(path):
             return path
-    
+
     # Check PATH
     path = shutil.which(name)
     return path
@@ -645,7 +651,11 @@ def main():
     else:
         print(f"Warning: Config file not found: {config_path}")
         config = {}
-    
+
+    # Store benchmark base dir so find_tool() can resolve relative tool paths
+    # against it rather than the caller's cwd (fixes Issue #157 Problem 1).
+    config["_base_dir"] = str(base_dir)
+
     # Override from args
     general = config.setdefault("general", {})
     if args.iterations:

--- a/scripts/benchmark/scenarios/run.py
+++ b/scripts/benchmark/scenarios/run.py
@@ -205,12 +205,13 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     warmup=warmup,
                     iterations=iterations,
                     trim_ratio=trim_ratio,
+                    cwd=str(tmp),
                 )
                 result.scenario = "B3.1_simple_startup"
                 result.tool = "python"
                 results.append(result)
                 print(f"  python: {result.duration_ms:.2f}ms")
-        
+
         # PyBun
         if pybun_path:
             if dry_run:
@@ -224,13 +225,15 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     iterations=iterations,
                     env=pybun_env,
                     trim_ratio=trim_ratio,
+                    cwd=str(tmp),
                 )
                 result.scenario = "B3.1_simple_startup"
                 result.tool = "pybun"
                 results.append(result)
                 print(f"  pybun: {result.duration_ms:.2f}ms")
-        
-        # uv
+
+        # uv — pass cwd=tmp so uv doesn't walk up to a parent pyproject.toml
+        # (fixes Issue #157 Problem 2).
         if uv_path:
             if dry_run:
                 print(f"  Would run: {uv_path} run {simple_script}")
@@ -242,6 +245,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     warmup=warmup,
                     iterations=iterations,
                     trim_ratio=trim_ratio,
+                    cwd=str(tmp),
                 )
                 result.scenario = "B3.1_simple_startup"
                 result.tool = "uv"
@@ -365,12 +369,13 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     warmup=warmup,
                     iterations=iterations,
                     trim_ratio=trim_ratio,
+                    cwd=str(tmp),
                 )
                 result.scenario = "B3.3_heavy_import"
                 result.tool = "python"
                 results.append(result)
                 print(f"  python: {result.duration_ms:.2f}ms")
-        
+
         # PyBun
         if pybun_path:
             if dry_run:
@@ -382,13 +387,15 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     iterations=iterations,
                     env=pybun_env,
                     trim_ratio=trim_ratio,
+                    cwd=str(tmp),
                 )
                 result.scenario = "B3.3_heavy_import"
                 result.tool = "pybun"
                 results.append(result)
                 print(f"  pybun: {result.duration_ms:.2f}ms")
-        
-        # uv
+
+        # uv — pass cwd=tmp so uv doesn't walk up to a parent pyproject.toml
+        # (fixes Issue #157 Problem 2).
         if uv_path:
             if dry_run:
                 print(f"  Would run: {uv_path} run {heavy_script}")
@@ -398,6 +405,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     warmup=warmup,
                     iterations=iterations,
                     trim_ratio=trim_ratio,
+                    cwd=str(tmp),
                 )
                 result.scenario = "B3.3_heavy_import"
                 result.tool = "uv"
@@ -423,6 +431,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                             iterations=iterations,
                             env={**pybun_env, "PYBUN_PROFILE": profile},
                             trim_ratio=trim_ratio,
+                            cwd=str(tmp),
                         )
                         result.scenario = f"B3.4_profile_{profile}"
                         result.tool = "pybun"

--- a/scripts/benchmark/scenarios/run.py
+++ b/scripts/benchmark/scenarios/run.py
@@ -278,6 +278,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                         iterations=1,
                         env=pybun_env,
                         trim_ratio=trim_ratio,
+                        cwd=str(tmp),
                     )
                     result.scenario = "B3.2_pep723_cold"
                     result.tool = "pybun"
@@ -286,7 +287,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     result.metadata["pep723_fixture"] = str(pep723_script)
                     results.append(result)
                     print(f"  pybun (cold): {result.duration_ms:.2f}ms")
-                    
+
                     # Warm runs
                     cache_state = {
                         "pep723_envs": "kept",
@@ -298,6 +299,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                         iterations=iterations,
                         env=pybun_env,
                         trim_ratio=trim_ratio,
+                        cwd=str(tmp),
                     )
                     result.scenario = "B3.2_pep723_warm"
                     result.tool = "pybun"
@@ -318,13 +320,15 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                         "uv_cache": clear_dir(shared_uv_cache),
                         "fs_cache": clear_fs_cache() if pep723_clear_fs_cache else "kept",
                     }
-                    # Cold run
+                    # Cold run — pass cwd=tmp so uv doesn't walk up to a parent
+                    # pyproject.toml (fixes Issue #157 Problem 2).
                     result = measure_command(
                         [uv_path, "run", str(pep723_script)],
                         warmup=0,
                         iterations=1,
                         env=uv_env,
                         trim_ratio=trim_ratio,
+                        cwd=str(tmp),
                     )
                     result.scenario = "B3.2_pep723_cold"
                     result.tool = "uv"
@@ -333,7 +337,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                     result.metadata["pep723_fixture"] = str(pep723_script)
                     results.append(result)
                     print(f"  uv (cold): {result.duration_ms:.2f}ms")
-                    
+
                     # Warm runs
                     cache_state = {
                         "fs_cache": clear_fs_cache() if pep723_clear_fs_cache else "kept",
@@ -344,6 +348,7 @@ def run_benchmark(config: dict, scenario_config: dict, base_dir: Path) -> list:
                         iterations=iterations,
                         env=uv_env,
                         trim_ratio=trim_ratio,
+                        cwd=str(tmp),
                     )
                     result.scenario = "B3.2_pep723_warm"
                     result.tool = "uv"

--- a/scripts/benchmark/tests/test_bench.py
+++ b/scripts/benchmark/tests/test_bench.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -28,29 +29,24 @@ class TestComputeStats(unittest.TestCase):
 
 
 class TestFindToolRelativePath(unittest.TestCase):
-    """Test that find_tool resolves relative paths against _base_dir, not cwd."""
+    """find_tool must resolve relative paths against _base_dir, not cwd."""
 
     def test_relative_path_resolved_against_base_dir(self) -> None:
         import tempfile
-        import os
-        from pathlib import Path
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
-            # Create a fake pybun binary in a subdirectory
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
-            fake_pybun = bin_dir / "pybun"
-            fake_pybun.write_text("#!/bin/sh\necho pybun")
+            fake_pybun = tmp / "bin" / "pybun"
+            fake_pybun.write_text("#!/bin/sh\nexit 0")
             fake_pybun.chmod(0o755)
 
-            # Config with relative path from a different base_dir
             config = {
                 "_base_dir": str(tmp),
                 "paths": {"pybun": "bin/pybun"},
             }
 
-            # Call from a different cwd (not tmp)
             original_cwd = os.getcwd()
             try:
                 os.chdir("/tmp")
@@ -61,22 +57,20 @@ class TestFindToolRelativePath(unittest.TestCase):
             self.assertEqual(result, str(fake_pybun))
 
     def test_relative_path_without_base_dir_falls_through_to_which(self) -> None:
-        """Without _base_dir, relative path that doesn't exist returns PATH lookup."""
+        """Without _base_dir, a relative path that doesn't exist returns PATH lookup (None)."""
         config = {
             "paths": {"nonexistent_tool_xyz": "../../target/release/nonexistent_xyz"},
         }
         result = bench.find_tool("nonexistent_tool_xyz", config)
-        # Should be None since neither path nor PATH entry exists
         self.assertIsNone(result)
 
     def test_absolute_path_still_works(self) -> None:
         import tempfile
-        from pathlib import Path
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             fake_pybun = tmp / "pybun"
-            fake_pybun.write_text("#!/bin/sh\necho pybun")
+            fake_pybun.write_text("#!/bin/sh\nexit 0")
             fake_pybun.chmod(0o755)
 
             config = {
@@ -85,23 +79,6 @@ class TestFindToolRelativePath(unittest.TestCase):
             }
             result = bench.find_tool("pybun", config)
             self.assertEqual(result, str(fake_pybun))
-
-    def test_base_dir_stored_in_config_after_load(self) -> None:
-        """Verify that _base_dir ends up in config after main() config loading."""
-        # Simulate the config loading logic from main()
-        import tempfile
-        from pathlib import Path
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp = Path(tmpdir)
-            config_file = tmp / "config.toml"
-            config_file.write_text("[general]\niterations = 1\n")
-
-            # Replicate the logic from main() that sets _base_dir
-            config: dict = {}
-            config["_base_dir"] = str(tmp)
-
-            self.assertEqual(config["_base_dir"], str(tmp))
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark/tests/test_bench.py
+++ b/scripts/benchmark/tests/test_bench.py
@@ -27,5 +27,82 @@ class TestComputeStats(unittest.TestCase):
         self.assertEqual(stats[4], 8)
 
 
+class TestFindToolRelativePath(unittest.TestCase):
+    """Test that find_tool resolves relative paths against _base_dir, not cwd."""
+
+    def test_relative_path_resolved_against_base_dir(self) -> None:
+        import tempfile
+        import os
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            # Create a fake pybun binary in a subdirectory
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            fake_pybun = bin_dir / "pybun"
+            fake_pybun.write_text("#!/bin/sh\necho pybun")
+            fake_pybun.chmod(0o755)
+
+            # Config with relative path from a different base_dir
+            config = {
+                "_base_dir": str(tmp),
+                "paths": {"pybun": "bin/pybun"},
+            }
+
+            # Call from a different cwd (not tmp)
+            original_cwd = os.getcwd()
+            try:
+                os.chdir("/tmp")
+                result = bench.find_tool("pybun", config)
+            finally:
+                os.chdir(original_cwd)
+
+            self.assertEqual(result, str(fake_pybun))
+
+    def test_relative_path_without_base_dir_falls_through_to_which(self) -> None:
+        """Without _base_dir, relative path that doesn't exist returns PATH lookup."""
+        config = {
+            "paths": {"nonexistent_tool_xyz": "../../target/release/nonexistent_xyz"},
+        }
+        result = bench.find_tool("nonexistent_tool_xyz", config)
+        # Should be None since neither path nor PATH entry exists
+        self.assertIsNone(result)
+
+    def test_absolute_path_still_works(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            fake_pybun = tmp / "pybun"
+            fake_pybun.write_text("#!/bin/sh\necho pybun")
+            fake_pybun.chmod(0o755)
+
+            config = {
+                "_base_dir": "/some/other/dir",
+                "paths": {"pybun": str(fake_pybun)},
+            }
+            result = bench.find_tool("pybun", config)
+            self.assertEqual(result, str(fake_pybun))
+
+    def test_base_dir_stored_in_config_after_load(self) -> None:
+        """Verify that _base_dir ends up in config after main() config loading."""
+        # Simulate the config loading logic from main()
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_file = tmp / "config.toml"
+            config_file.write_text("[general]\niterations = 1\n")
+
+            # Replicate the logic from main() that sets _base_dir
+            config: dict = {}
+            config["_base_dir"] = str(tmp)
+
+            self.assertEqual(config["_base_dir"], str(tmp))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/benchmark/tests/test_run.py
+++ b/scripts/benchmark/tests/test_run.py
@@ -1,16 +1,15 @@
 import os
 import sys
-import shutil
 import unittest
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 # scenarios/run.py depends on bench.py injecting these names at load time.
 # Inject stubs before importing so the module is importable in tests.
 import bench
-import importlib
-import types
+import importlib.util
 
 # Load run module with injected bench exports (mirrors bench.load_scenarios)
 run_spec = importlib.util.spec_from_file_location(
@@ -43,11 +42,12 @@ def _make_fake_binary(path: Path) -> Path:
     return path
 
 
-def _collect_calls(config: dict, scenario_config: dict, base_dir: Path) -> list[dict]:
+def _collect_calls(config: dict[str, Any], scenario_config: dict[str, Any], base_dir: Path) -> list[dict[str, Any]]:
     """Run run_benchmark with patched measure_command and return captured calls."""
-    calls: list[dict] = []
+    calls: list[dict[str, Any]] = []
 
-    def fake_measure(cmd, warmup=1, iterations=5, timeout=300, env=None, cwd=None, trim_ratio=0.0):
+    def fake_measure(cmd: list[str], warmup: int = 1, iterations: int = 5, timeout: int = 300,
+                     env: dict | None = None, cwd: str | None = None, trim_ratio: float = 0.0) -> bench.BenchResult:
         calls.append({"cmd": list(cmd), "cwd": cwd})
         return bench.BenchResult(
             scenario="",
@@ -81,8 +81,8 @@ class TestRunCwdHermetic(unittest.TestCase):
     def tearDown(self) -> None:
         self._bindir_ctx.__exit__(None, None, None)
 
-    def _make_config(self, *, pep723: bool = False, profiles: list | None = None) -> tuple[dict, dict]:
-        config = {
+    def _make_config(self, *, pep723: bool = False, profiles: list[str] | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
+        config: dict[str, Any] = {
             "_base_dir": str(self.base_dir),
             "paths": {
                 "pybun": str(self.fake_pybun),
@@ -94,7 +94,7 @@ class TestRunCwdHermetic(unittest.TestCase):
             "dry_run": False,
             "verbose": False,
         }
-        scenario_config = {
+        scenario_config: dict[str, Any] = {
             "pep723": pep723,
             "profiles": profiles if profiles is not None else [],
             "pep723_clear_envs": False,
@@ -117,14 +117,26 @@ class TestRunCwdHermetic(unittest.TestCase):
         config, scenario_config = self._make_config()
         calls = _collect_calls(config, scenario_config, self.base_dir)
 
-        # B3.3 uses heavy_imports.py — collect all uv calls
         uv_calls = [c for c in calls if "uv" in c["cmd"][0]]
         self.assertTrue(len(uv_calls) > 0)
         for call in uv_calls:
             self.assertIsNotNone(call["cwd"], f"uv call missing cwd: {call['cmd']}")
 
+    def test_b32_pep723_calls_have_cwd(self) -> None:
+        """B3.2: all four pybun/uv PEP 723 measure_command calls must pass cwd."""
+        config, scenario_config = self._make_config(pep723=True)
+        calls = _collect_calls(config, scenario_config, self.base_dir)
+
+        # B3.2 produces at least pybun-cold, pybun-warm, uv-cold, uv-warm
+        self.assertGreaterEqual(len(calls), 4, f"Expected >=4 calls with pep723=True, got: {calls}")
+        for call in calls:
+            self.assertIsNotNone(
+                call["cwd"],
+                f"measure_command missing cwd for cmd: {call['cmd']}"
+            )
+
     def test_all_measure_command_calls_have_cwd(self) -> None:
-        """Every single measure_command call must specify cwd."""
+        """Every single measure_command call in non-pep723 paths must specify cwd."""
         config, scenario_config = self._make_config()
         calls = _collect_calls(config, scenario_config, self.base_dir)
 
@@ -154,63 +166,6 @@ class TestRunCwdHermetic(unittest.TestCase):
         self.assertTrue(len(python_calls) > 0, f"No python calls found. All: {calls}")
         for call in python_calls:
             self.assertIsNotNone(call["cwd"], f"python call missing cwd: {call['cmd']}")
-
-
-class TestFindToolRelativePath(unittest.TestCase):
-    """find_tool must resolve relative paths against _base_dir, not cwd."""
-
-    def test_relative_path_resolved_against_base_dir(self) -> None:
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp = Path(tmpdir)
-            bin_dir = tmp / "bin"
-            bin_dir.mkdir()
-            fake_pybun = _make_fake_binary(bin_dir / "pybun")
-
-            config = {
-                "_base_dir": str(tmp),
-                "paths": {"pybun": "bin/pybun"},
-            }
-
-            original_cwd = os.getcwd()
-            try:
-                os.chdir("/tmp")
-                result = bench.find_tool("pybun", config)
-            finally:
-                os.chdir(original_cwd)
-
-            self.assertEqual(result, str(fake_pybun))
-
-    def test_relative_path_without_base_dir_falls_through_to_which(self) -> None:
-        config = {
-            "paths": {"nonexistent_tool_xyz": "../../target/release/nonexistent_xyz"},
-        }
-        result = bench.find_tool("nonexistent_tool_xyz", config)
-        self.assertIsNone(result)
-
-    def test_absolute_path_still_works(self) -> None:
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp = Path(tmpdir)
-            fake_pybun = _make_fake_binary(tmp / "pybun")
-
-            config = {
-                "_base_dir": "/some/other/dir",
-                "paths": {"pybun": str(fake_pybun)},
-            }
-            result = bench.find_tool("pybun", config)
-            self.assertEqual(result, str(fake_pybun))
-
-    def test_base_dir_stored_in_config_after_load(self) -> None:
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp = Path(tmpdir)
-            config: dict = {}
-            config["_base_dir"] = str(tmp)
-            self.assertEqual(config["_base_dir"], str(tmp))
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark/tests/test_run.py
+++ b/scripts/benchmark/tests/test_run.py
@@ -1,10 +1,32 @@
+import os
 import sys
+import shutil
 import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scenarios import run as run_scenario
+# scenarios/run.py depends on bench.py injecting these names at load time.
+# Inject stubs before importing so the module is importable in tests.
+import bench
+import importlib
+import types
+
+# Load run module with injected bench exports (mirrors bench.load_scenarios)
+run_spec = importlib.util.spec_from_file_location(
+    "scenarios.run",
+    Path(__file__).resolve().parents[1] / "scenarios" / "run.py",
+)
+run_module = importlib.util.module_from_spec(run_spec)  # type: ignore[arg-type]
+run_module.scenario = lambda name: (lambda fn: fn)  # noqa: E731
+run_module.BenchResult = bench.BenchResult
+run_module.find_tool = bench.find_tool
+run_module.is_tool_enabled = bench.is_tool_enabled
+run_module.measure_command = bench.measure_command
+run_module.measure_with_hyperfine = bench.measure_with_hyperfine
+run_spec.loader.exec_module(run_module)  # type: ignore[union-attr]
+
+run_scenario = run_module
 
 
 class TestRunScenario(unittest.TestCase):
@@ -13,6 +35,182 @@ class TestRunScenario(unittest.TestCase):
         script = run_scenario.resolve_pep723_script(base_dir, {})
         self.assertTrue(script.exists())
         self.assertTrue(str(script).endswith("fixtures/pep723.py"))
+
+
+def _make_fake_binary(path: Path) -> Path:
+    path.write_text("#!/bin/sh\nexit 0")
+    path.chmod(0o755)
+    return path
+
+
+def _collect_calls(config: dict, scenario_config: dict, base_dir: Path) -> list[dict]:
+    """Run run_benchmark with patched measure_command and return captured calls."""
+    calls: list[dict] = []
+
+    def fake_measure(cmd, warmup=1, iterations=5, timeout=300, env=None, cwd=None, trim_ratio=0.0):
+        calls.append({"cmd": list(cmd), "cwd": cwd})
+        return bench.BenchResult(
+            scenario="",
+            tool=cmd[0] if cmd else "unknown",
+            duration_ms=1.0,
+            success=True,
+        )
+
+    original = run_scenario.measure_command
+    run_scenario.measure_command = fake_measure
+    try:
+        run_scenario.run_benchmark(config, scenario_config, base_dir)
+    finally:
+        run_scenario.measure_command = original
+
+    return calls
+
+
+class TestRunCwdHermetic(unittest.TestCase):
+    """All measure_command calls in run_benchmark must specify cwd."""
+
+    def setUp(self) -> None:
+        import tempfile
+        self._bindir_ctx = tempfile.TemporaryDirectory()
+        self.bindir = Path(self._bindir_ctx.__enter__())
+        self.fake_pybun = _make_fake_binary(self.bindir / "pybun")
+        self.fake_uv = _make_fake_binary(self.bindir / "uv")
+        self.fake_python = _make_fake_binary(self.bindir / "python3")
+        self.base_dir = Path(__file__).resolve().parents[1]
+
+    def tearDown(self) -> None:
+        self._bindir_ctx.__exit__(None, None, None)
+
+    def _make_config(self, *, pep723: bool = False, profiles: list | None = None) -> tuple[dict, dict]:
+        config = {
+            "_base_dir": str(self.base_dir),
+            "paths": {
+                "pybun": str(self.fake_pybun),
+                "uv": str(self.fake_uv),
+                "python3": str(self.fake_python),
+            },
+            "tools": {"uv": True, "python": True},
+            "general": {"iterations": 1, "warmup": 0},
+            "dry_run": False,
+            "verbose": False,
+        }
+        scenario_config = {
+            "pep723": pep723,
+            "profiles": profiles if profiles is not None else [],
+            "pep723_clear_envs": False,
+            "pep723_clear_fs_cache": False,
+        }
+        return config, scenario_config
+
+    def test_b31_uv_run_has_cwd(self) -> None:
+        """B3.1: uv run must pass cwd so it doesn't walk up to a parent pyproject.toml."""
+        config, scenario_config = self._make_config()
+        calls = _collect_calls(config, scenario_config, self.base_dir)
+
+        uv_run_calls = [c for c in calls if "uv" in c["cmd"][0] and "run" in c["cmd"]]
+        self.assertTrue(len(uv_run_calls) > 0, f"No uv run calls found. All calls: {calls}")
+        for call in uv_run_calls:
+            self.assertIsNotNone(call["cwd"], f"uv run missing cwd: {call['cmd']}")
+
+    def test_b33_uv_run_has_cwd(self) -> None:
+        """B3.3: uv run for heavy import script must pass cwd."""
+        config, scenario_config = self._make_config()
+        calls = _collect_calls(config, scenario_config, self.base_dir)
+
+        # B3.3 uses heavy_imports.py — collect all uv calls
+        uv_calls = [c for c in calls if "uv" in c["cmd"][0]]
+        self.assertTrue(len(uv_calls) > 0)
+        for call in uv_calls:
+            self.assertIsNotNone(call["cwd"], f"uv call missing cwd: {call['cmd']}")
+
+    def test_all_measure_command_calls_have_cwd(self) -> None:
+        """Every single measure_command call must specify cwd."""
+        config, scenario_config = self._make_config()
+        calls = _collect_calls(config, scenario_config, self.base_dir)
+
+        self.assertGreater(len(calls), 0, "Expected at least one measure_command call")
+        for call in calls:
+            self.assertIsNotNone(
+                call["cwd"],
+                f"measure_command missing cwd for cmd: {call['cmd']}"
+            )
+
+    def test_pybun_run_has_cwd(self) -> None:
+        """pybun run calls must also pass cwd."""
+        config, scenario_config = self._make_config()
+        calls = _collect_calls(config, scenario_config, self.base_dir)
+
+        pybun_calls = [c for c in calls if "pybun" in c["cmd"][0]]
+        self.assertTrue(len(pybun_calls) > 0, f"No pybun calls found. All: {calls}")
+        for call in pybun_calls:
+            self.assertIsNotNone(call["cwd"], f"pybun call missing cwd: {call['cmd']}")
+
+    def test_python_run_has_cwd(self) -> None:
+        """python run calls must also pass cwd."""
+        config, scenario_config = self._make_config()
+        calls = _collect_calls(config, scenario_config, self.base_dir)
+
+        python_calls = [c for c in calls if "python" in c["cmd"][0]]
+        self.assertTrue(len(python_calls) > 0, f"No python calls found. All: {calls}")
+        for call in python_calls:
+            self.assertIsNotNone(call["cwd"], f"python call missing cwd: {call['cmd']}")
+
+
+class TestFindToolRelativePath(unittest.TestCase):
+    """find_tool must resolve relative paths against _base_dir, not cwd."""
+
+    def test_relative_path_resolved_against_base_dir(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            fake_pybun = _make_fake_binary(bin_dir / "pybun")
+
+            config = {
+                "_base_dir": str(tmp),
+                "paths": {"pybun": "bin/pybun"},
+            }
+
+            original_cwd = os.getcwd()
+            try:
+                os.chdir("/tmp")
+                result = bench.find_tool("pybun", config)
+            finally:
+                os.chdir(original_cwd)
+
+            self.assertEqual(result, str(fake_pybun))
+
+    def test_relative_path_without_base_dir_falls_through_to_which(self) -> None:
+        config = {
+            "paths": {"nonexistent_tool_xyz": "../../target/release/nonexistent_xyz"},
+        }
+        result = bench.find_tool("nonexistent_tool_xyz", config)
+        self.assertIsNone(result)
+
+    def test_absolute_path_still_works(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            fake_pybun = _make_fake_binary(tmp / "pybun")
+
+            config = {
+                "_base_dir": "/some/other/dir",
+                "paths": {"pybun": str(fake_pybun)},
+            }
+            result = bench.find_tool("pybun", config)
+            self.assertEqual(result, str(fake_pybun))
+
+    def test_base_dir_stored_in_config_after_load(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config: dict = {}
+            config["_base_dir"] = str(tmp)
+            self.assertEqual(config["_base_dir"], str(tmp))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes two cwd-sensitivity bugs in the benchmark runner, making all measurements independent of the directory from which the script is invoked.

### Problem 1: relative `paths.pybun` resolved against caller's cwd

`config.toml` contains `pybun = "../../target/release/pybun"`. Previously `find_tool()` called `os.path.exists(path)` on the raw relative string, so it only worked when the script was invoked from `scripts/benchmark/`. From the repo root, the path resolved outside the repo and `pybun not found` was silently printed.

**Fix:** store `config["_base_dir"] = str(base_dir)` immediately after loading the config file in `main()`, then in `find_tool()` resolve relative paths against `_base_dir` before testing existence.

### Problem 2: `uv run` comparisons inherit parent `pyproject.toml`

`measure_command` calls for B3.1, B3.3, and B3.4 had no `cwd` argument. When a parent directory contained a `pyproject.toml` with a `[project]` table but no `project.name`, `uv` walked up and failed:

```
error: Failed to parse: `.../pyproject.toml`
Caused by: `project.name` field is not set
```

**Fix:** pass `cwd=str(tmp)` to every `measure_command` call in `run_benchmark()` so subprocesses run inside the isolated temp directory and never discover parent project files.

## Changes

| File | Change |
|------|--------|
| `bench.py` | `find_tool()`: resolve relative paths against `_base_dir`; `main()`: set `config["_base_dir"]` after loading config |
| `scenarios/run.py` | Add `cwd=str(tmp)` to all `measure_command` calls in B3.1, B3.3, B3.4 |
| `tests/test_bench.py` | 4 new tests for `find_tool()` relative-path resolution |
| `tests/test_run.py` | 5 new tests verifying `cwd` propagation for all tools |

## Test plan

- [x] `python3 -m pytest tests/test_bench.py tests/test_run.py -v` → 17 passed
- [x] `cargo test --test '*'` → all Rust E2E tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean

Closes #157