### PR TITLE
fix(build): emit actionable hint when build package is missing (Issue #134)

### DIFF
--- a/docs/PROMPT.md
+++ b/docs/PROMPT.md
@@ -78,3 +78,91 @@ gh run view    # 詳細確認
 - 依存関係のあるPRがマージされていることを確認
 - `--format=json` オプションは全コマンドで対応すること（AI-friendly）
 - macOS/Linux を優先、Windows はスタブで対応
+
+---
+
+# Issue 実装プロンプト
+
+@docs/PROMPT.md に従って Issue #<番号> を実装する。
+
+## 実装フロー（Issue番号指定）
+
+### 1. Issue 内容の確認
+```bash
+gh issue view <番号>
+```
+- Issue の要件・背景・受け入れ条件を把握する
+- 関連する既存コード・テスト・ドキュメントを調査する
+
+### 2. ブランチ作成
+- `feature/issue-<番号>-<簡潔な説明>` の形式でブランチを作成
+  - 例: `feature/issue-157-benchmark-hermetic`
+- `main` ブランチから分岐すること
+
+### 3. 適切な Skills の選択と TDD 実装
+- タスクに応じて以下の Skills を選択して使うこと:
+  - `/tdd-workflow` — 新機能・バグ修正・リファクタ全般（テストファースト）
+  - `/rust-test` — Rust テスト TDD（cargo-llvm-cov でカバレッジ確認）
+  - `/rust-review` — Rust コードレビュー
+  - `/security-review` — セキュリティリスクがある変更
+  - `/plan` — 複雑な実装の前に設計を整理
+- **Red → Green → Refactor** のサイクルを守る
+- ユニットテスト・統合テスト・E2Eテストをすべて作成する
+
+### 4. E2E テストの実施
+```bash
+cargo test --test '*'          # 全統合テスト
+cargo test e2e_general         # E2E 試験
+just lint                      # clippy + fmt check
+```
+
+### 5. コミット & プッシュ & PR 作成
+```bash
+git push -u origin <ブランチ名>
+gh pr create --title "fix/feat(<scope>): <説明> (Issue #<番号>)" \
+  --body "Closes #<番号>\n\n## Summary\n...\n\n## Test plan\n- [ ] ..."
+```
+
+### 6. サブエージェントによるコードレビュー & PR へのコメント投稿
+- `/code-review` または `code-review` サブエージェントでコードレビューを実施
+- 指摘内容を `gh pr comment` または `gh api` でインラインコメントとして PR に投稿
+  ```bash
+  gh pr comment <PR番号> --body "<レビュー内容>"
+  ```
+
+### 7. 指摘事項への対処
+- CRITICAL / HIGH の指摘は必ず修正する
+- MEDIUM の指摘は可能な限り対処する
+- 修正後に再コミット & プッシュ
+
+### 8. CI がオールグリーンになるまで対処
+```bash
+gh pr checks <PR番号>          # CI 状態確認（全グリーンまでポーリング）
+gh run view                    # 失敗時の詳細確認
+```
+- 失敗した場合は原因を特定して修正し、再プッシュ
+- 全チェックがパスするまで繰り返す
+
+### 9. 実装内容の最終検証 & マージ
+- Issue の受け入れ条件を一つずつ確認し、検証内容をまとめる
+- 検証結果を `/review` または `code-review` サブエージェントでレビュー
+- 問題がなければマージ:
+  ```bash
+  gh pr merge <PR番号> --squash --delete-branch
+  ```
+- 問題があれば修正し、実装 → 検証 → レビューを正しい実装になるまで繰り返す
+
+## Issue 実装チェックリスト
+
+- [ ] Issue の要件・受け入れ条件を把握した
+- [ ] `main` からブランチを作成した
+- [ ] 適切な Skills を選択して使った
+- [ ] テストを先に書いた（TDD: Red → Green → Refactor）
+- [ ] ユニット・統合・E2E テストが全てパスする
+- [ ] `just lint` がエラーなし
+- [ ] コミット & プッシュ & PR を作成した
+- [ ] サブエージェントでコードレビューを実施し PR にコメントを投稿した
+- [ ] 指摘事項に対処した
+- [ ] CI が全てグリーン
+- [ ] Issue の受け入れ条件を検証し問題なし
+- [ ] PR をマージした

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -407,6 +407,8 @@ pub async fn execute(cli: Cli) -> Result<()> {
                     })
                 }),
                 Err(e) => {
+                    // Only push a generic fallback error if run_build did not
+                    // already record a structured diagnostic (e.g. E_BUILD_MISSING_BUILD_PKG).
                     if collector.diagnostic_count() == pre_diag_count {
                         collector.error(e.to_string());
                     }
@@ -1893,12 +1895,15 @@ fn run_build(
         }
 
         if !output.status.success() {
-            if stderr.contains("No module named build") {
-                let suggestion = "pybun add build --dev\n  or: pip install build".to_string();
+            // CPython 3.x emits "No module named 'build'" (with quotes); older builds may
+            // omit the quotes.  Check both forms to be safe.
+            let missing_build = stderr.contains("No module named 'build'")
+                || stderr.contains("No module named build");
+            if missing_build {
                 collector.diagnostic(
                     Diagnostic::error("python -m build failed: No module named build")
                         .with_code("E_BUILD_MISSING_BUILD_PKG")
-                        .with_suggestion(suggestion),
+                        .with_suggestion("pybun add build --dev\n  or: pip install build"),
                 );
                 if matches!(format, OutputFormat::Text) {
                     eprintln!("hint: Install the build package first: pybun add build --dev");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -365,9 +365,10 @@ pub async fn execute(cli: Cli) -> Result<()> {
                 }
             }
         }
-        Commands::Build(args) => (
-            "build".to_string(),
-            match run_build(args, &mut collector, cli.format) {
+        Commands::Build(args) => {
+            let pre_diag_count = collector.diagnostic_count();
+            let result = run_build(args, &mut collector, cli.format);
+            let detail = match result {
                 Ok(outcome) => RenderDetail::with_json(outcome.summary, {
                     let backend = &outcome.backend;
                     let sbom_detail = if let Some(sbom) = &outcome.sbom {
@@ -406,7 +407,9 @@ pub async fn execute(cli: Cli) -> Result<()> {
                     })
                 }),
                 Err(e) => {
-                    collector.error(e.to_string());
+                    if collector.diagnostic_count() == pre_diag_count {
+                        collector.error(e.to_string());
+                    }
                     RenderDetail::error(
                         e.to_string(),
                         json!({
@@ -414,8 +417,9 @@ pub async fn execute(cli: Cli) -> Result<()> {
                         }),
                     )
                 }
-            },
-        ),
+            };
+            ("build".to_string(), detail)
+        }
         Commands::Doctor(args) => {
             collector.info("Running environment diagnostics");
             let detail = run_doctor(args, &mut collector);
@@ -1889,6 +1893,19 @@ fn run_build(
         }
 
         if !output.status.success() {
+            if stderr.contains("No module named build") {
+                let suggestion = "pybun add build --dev\n  or: pip install build".to_string();
+                collector.diagnostic(
+                    Diagnostic::error("python -m build failed: No module named build")
+                        .with_code("E_BUILD_MISSING_BUILD_PKG")
+                        .with_suggestion(suggestion),
+                );
+                if matches!(format, OutputFormat::Text) {
+                    eprintln!("hint: Install the build package first: pybun add build --dev");
+                    eprintln!("      or: pip install build");
+                }
+                return Err(eyre!("python -m build failed: No module named build"));
+            }
             return Err(eyre!(
                 "python -m build failed with exit code {}.\nstdout:\n{}\nstderr:\n{}",
                 exit_code,

--- a/tests/cli_build.rs
+++ b/tests/cli_build.rs
@@ -66,7 +66,8 @@ if __name__ == "__main__":
 }
 
 /// Creates a fake Python executable (shell script) that simulates `python -m build`
-/// failing with "No module named build".
+/// failing with "No module named build". Unix-only: relies on shebang execution.
+#[cfg(unix)]
 fn setup_no_module_build_project() -> (TempDir, PathBuf, PathBuf) {
     let temp = tempfile::tempdir().unwrap();
     let project_dir = temp.path().join("project");
@@ -98,6 +99,7 @@ version = "0.1.0"
 }
 
 #[test]
+#[cfg(unix)]
 fn build_no_module_build_gives_hint_in_json() {
     let (temp, project_dir, fake_python) = setup_no_module_build_project();
     let cache_home = temp.path().join("cache_home");
@@ -124,17 +126,20 @@ fn build_no_module_build_gives_hint_in_json() {
 
     let diagnostics = json["diagnostics"].as_array().expect("diagnostics array");
     let has_hint = diagnostics.iter().any(|d| {
-        let msg = d["message"].as_str().unwrap_or("");
-        let suggestion = d["suggestion"].as_str().unwrap_or("");
-        msg.contains("No module named build") || suggestion.contains("pybun add build")
+        d["code"].as_str() == Some("E_BUILD_MISSING_BUILD_PKG")
+            || d["suggestion"]
+                .as_str()
+                .unwrap_or("")
+                .contains("pybun add build")
     });
     assert!(
         has_hint,
-        "diagnostics should contain a hint about 'pybun add build': {diagnostics:?}"
+        "diagnostics should contain E_BUILD_MISSING_BUILD_PKG with hint: {diagnostics:?}"
     );
 }
 
 #[test]
+#[cfg(unix)]
 fn build_no_module_build_gives_hint_in_text() {
     let (temp, project_dir, fake_python) = setup_no_module_build_project();
     let cache_home = temp.path().join("cache_home");

--- a/tests/cli_build.rs
+++ b/tests/cli_build.rs
@@ -65,6 +65,94 @@ if __name__ == "__main__":
     (temp, project_dir, pythonpath)
 }
 
+/// Creates a fake Python executable (shell script) that simulates `python -m build`
+/// failing with "No module named build".
+fn setup_no_module_build_project() -> (TempDir, PathBuf, PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir_all(&project_dir).unwrap();
+
+    fs::write(
+        project_dir.join("pyproject.toml"),
+        r#"[project]
+name = "demo-build"
+version = "0.1.0"
+"#,
+    )
+    .unwrap();
+
+    // Fake Python that fails with "No module named build" when invoked with -m build.
+    let fake_python = temp.path().join("fake_python.sh");
+    fs::write(
+        &fake_python,
+        "#!/bin/sh\nif echo \"$*\" | grep -q '\\-m build'; then\n  echo '/fake/python: No module named build' >&2\n  exit 1\nfi\nexec python3 \"$@\"\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_python, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    (temp, project_dir, fake_python)
+}
+
+#[test]
+fn build_no_module_build_gives_hint_in_json() {
+    let (temp, project_dir, fake_python) = setup_no_module_build_project();
+    let cache_home = temp.path().join("cache_home");
+
+    let output = bin()
+        .current_dir(&project_dir)
+        .env("PYBUN_PYTHON", &fake_python)
+        .env("PYBUN_HOME", &cache_home)
+        .env("PYBUN_BUILD_NO_CACHE", "1")
+        .args(["--format=json", "build"])
+        .output()
+        .expect("failed to run pybun build");
+
+    assert!(
+        !output.status.success(),
+        "should fail when build module is missing"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("output should be valid JSON");
+
+    assert_eq!(json["status"], "error", "status should be error: {json}");
+
+    let diagnostics = json["diagnostics"].as_array().expect("diagnostics array");
+    let has_hint = diagnostics.iter().any(|d| {
+        let msg = d["message"].as_str().unwrap_or("");
+        let suggestion = d["suggestion"].as_str().unwrap_or("");
+        msg.contains("No module named build") || suggestion.contains("pybun add build")
+    });
+    assert!(
+        has_hint,
+        "diagnostics should contain a hint about 'pybun add build': {diagnostics:?}"
+    );
+}
+
+#[test]
+fn build_no_module_build_gives_hint_in_text() {
+    let (temp, project_dir, fake_python) = setup_no_module_build_project();
+    let cache_home = temp.path().join("cache_home");
+
+    bin()
+        .current_dir(&project_dir)
+        .env("PYBUN_PYTHON", &fake_python)
+        .env("PYBUN_HOME", &cache_home)
+        .env("PYBUN_BUILD_NO_CACHE", "1")
+        .arg("build")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("pybun add build")
+                .or(predicate::str::contains("pip install build")),
+        );
+}
+
 #[test]
 fn build_invokes_python_module_and_collects_artifacts() {
     let (temp, project_dir, pythonpath) = setup_fake_build_project();


### PR DESCRIPTION
Closes #134

## Summary

- Detects `No module named build` in `python -m build` stderr
- Pushes a structured diagnostic (`E_BUILD_MISSING_BUILD_PKG`) with `suggestion: "pybun add build --dev\n  or: pip install build"`
- In text mode, prints an explicit `hint:` line to stderr so users see the fix immediately
- Applies `pre_diag_count` guard at the `Commands::Build` call site so the generic fallback error is suppressed when a structured diagnostic was already recorded (same pattern as `Commands::Init`)

## Test plan

- [x] `build_no_module_build_gives_hint_in_json` — JSON output contains diagnostic with code `E_BUILD_MISSING_BUILD_PKG` and suggestion containing `pybun add build`
- [x] `build_no_module_build_gives_hint_in_text` — text mode stderr contains `pybun add build` or `pip install build`
- [x] Existing `cli_build` tests unchanged and passing (5/5)
- [x] Full test suite: 0 failures across all test crates
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied