### PR TITLE
fix(schema): default pybun schema to print subcommand (Issue #138)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,8 +87,7 @@ pub enum Commands {
     /// Show or configure launch profiles.
     Profile(ProfileArgs),
     /// Print or validate the CLI JSON schema.
-    #[command(subcommand)]
-    Schema(SchemaCommands),
+    Schema(SchemaArgs),
     /// Manage telemetry settings (opt-in/opt-out).
     #[command(subcommand)]
     Telemetry(TelemetryCommands),
@@ -290,6 +289,12 @@ pub struct DoctorArgs {
 pub enum McpCommands {
     /// Start MCP server for programmatic control.
     Serve(McpServeArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SchemaArgs {
+    #[command(subcommand)]
+    pub command: Option<SchemaCommands>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,8 @@
 use crate::build::{BuildBackend, BuildCache};
 use crate::cli::{
     Cli, Commands, InitArgs, InitTemplate, LazyImportArgs, LockArgs, McpCommands, ModuleFindArgs,
-    OutdatedArgs, OutputFormat, ProfileArgs, ProgressMode, PythonCommands, SchemaCommands,
-    SelfCommands, TelemetryCommands, UpgradeArgs, WatchArgs,
+    OutdatedArgs, OutputFormat, ProfileArgs, ProgressMode, PythonCommands, SchemaArgs,
+    SchemaCommands, SelfCommands, TelemetryCommands, UpgradeArgs, WatchArgs,
 };
 use crate::env::{EnvSource, find_python_env};
 use crate::index::load_index_from_path;
@@ -584,8 +584,8 @@ pub async fn execute(cli: Cli) -> Result<()> {
                 }
             }
         }
-        Commands::Schema(cmd) => match cmd {
-            SchemaCommands::Print(_args) => {
+        Commands::Schema(SchemaArgs { command }) => match command {
+            None | Some(SchemaCommands::Print(_)) => {
                 let schema_json = crate::schema::schema_v1_json();
                 let schema_text = crate::schema::schema_v1_pretty();
                 let detail = if matches!(cli.format, OutputFormat::Text) {
@@ -607,7 +607,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
                 };
                 ("schema print".to_string(), detail)
             }
-            SchemaCommands::Check(args) => {
+            Some(SchemaCommands::Check(args)) => {
                 let detail = run_schema_check(args);
                 ("schema check".to_string(), detail)
             }

--- a/tests/json_schema.rs
+++ b/tests/json_schema.rs
@@ -429,7 +429,7 @@ mod schema_default {
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Should print the JSON schema, not a help message
         assert!(
-            stdout.contains("$schema") || stdout.contains("\"schema\""),
+            stdout.contains("$schema"),
             "`pybun schema` output should contain JSON schema content, got:\n{stdout}"
         );
     }

--- a/tests/json_schema.rs
+++ b/tests/json_schema.rs
@@ -402,6 +402,76 @@ if __name__ == "__main__":
     }
 }
 
+/// Schema command default-to-print tests (Issue #138)
+mod schema_default {
+    use super::*;
+
+    #[test]
+    fn schema_without_subcommand_exits_zero() {
+        let output = Command::new(env!("CARGO_BIN_EXE_pybun"))
+            .arg("schema")
+            .output()
+            .expect("failed to execute pybun");
+        assert!(
+            output.status.success(),
+            "`pybun schema` should exit 0, got {:?}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn schema_without_subcommand_outputs_json_schema() {
+        let output = Command::new(env!("CARGO_BIN_EXE_pybun"))
+            .arg("schema")
+            .output()
+            .expect("failed to execute pybun");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Should print the JSON schema, not a help message
+        assert!(
+            stdout.contains("$schema") || stdout.contains("\"schema\""),
+            "`pybun schema` output should contain JSON schema content, got:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn schema_without_subcommand_json_format_is_parseable() {
+        let output = Command::new(env!("CARGO_BIN_EXE_pybun"))
+            .args(["--format=json", "schema"])
+            .output()
+            .expect("failed to execute pybun");
+        assert!(
+            output.status.success(),
+            "`pybun --format=json schema` should exit 0"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value = serde_json::from_str(&stdout)
+            .expect("`pybun --format=json schema` must output valid JSON");
+        assert_eq!(json["status"], "ok");
+        assert!(
+            json["detail"]["schema"].is_object() || json["detail"]["schema"].is_string(),
+            "detail.schema should be present"
+        );
+    }
+
+    #[test]
+    fn schema_without_subcommand_matches_schema_print() {
+        let bare = Command::new(env!("CARGO_BIN_EXE_pybun"))
+            .arg("schema")
+            .output()
+            .expect("failed to execute pybun");
+        let with_print = Command::new(env!("CARGO_BIN_EXE_pybun"))
+            .args(["schema", "print"])
+            .output()
+            .expect("failed to execute pybun");
+        assert_eq!(
+            String::from_utf8_lossy(&bare.stdout),
+            String::from_utf8_lossy(&with_print.stdout),
+            "`pybun schema` and `pybun schema print` should produce identical output"
+        );
+    }
+}
+
 /// Schema versioning tests
 mod schema_version {
     use super::*;

--- a/tests/snapshots/compat/help_schema.txt
+++ b/tests/snapshots/compat/help_schema.txt
@@ -1,6 +1,6 @@
 Print or validate the CLI JSON schema
 
-Usage: pybun schema [OPTIONS] <COMMAND>
+Usage: pybun schema [OPTIONS] [COMMAND]
 
 Commands:
   print  Print the JSON schema for CLI output


### PR DESCRIPTION
## Summary

- `pybun schema` without a subcommand now defaults to `pybun schema print`, outputting the JSON schema
- `pybun schema --format=json` now produces valid, parseable JSON (previously produced unparseable help text)
- `pybun schema print` continues to work unchanged
- Snapshot updated: `Usage: pybun schema [OPTIONS] [COMMAND]` (subcommand is now optional)

## Changes

- `src/cli.rs`: Introduced `SchemaArgs` wrapper struct with `Option<SchemaCommands>` to make the subcommand optional
- `src/commands.rs`: Updated dispatch — `None | Some(Print)` arm both run the print logic
- `tests/json_schema.rs`: Added 4 new tests in `schema_default` module covering exit code, output content, JSON parseability, and output parity with `schema print`
- `tests/snapshots/compat/help_schema.txt`: Updated `<COMMAND>` → `[COMMAND]`

## Test plan

- [x] `schema_without_subcommand_exits_zero` — exits 0
- [x] `schema_without_subcommand_outputs_json_schema` — stdout contains `$schema`
- [x] `schema_without_subcommand_json_format_is_parseable` — `--format=json` output is valid JSON with `status: ok`
- [x] `schema_without_subcommand_matches_schema_print` — output identical to `pybun schema print`
- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #138