### PR TITLE
feat(watch): polling fallback for pybun watch (Issue #190)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -93,9 +93,10 @@
   - Current: `src/sandbox.rs::SITECUSTOMIZE_PY` の `_block_subprocesses()` に `os.posix_spawn`/`os.posix_spawnp`/`os.spawnv`/`os.spawnve`/`os.spawnvp`/`os.spawnvpe`/`os.spawnl`/`os.spawnle`/`os.spawnlp`/`os.spawnlpe`/`os.startfile`（Windows）を追加し、いずれも `_deny("process creation", "blocked_subprocesses")` を呼ぶよう `setattr` で上書き。
   - Tests: `tests/sandbox.rs` に2件追加（`sandbox_blocks_posix_spawn` — `os.posix_spawn`/`os.posix_spawnp` が `PermissionError` を発生させ `blocked_subprocesses:2` を記録し、エスケープ証跡ファイルが作成されないことを確認、`sandbox_blocks_spawn_family` — `os.spawnv`/`spawnve`/`spawnvp`/`spawnvpe`/`spawnl`/`spawnle`/`spawnlp`/`spawnlpe` の8系統がすべて `PermissionError` で `blocked_subprocesses:8` を記録することを確認）。全sandboxテスト(29件)・`cargo clippy --all-targets --all-features -- -D warnings`・`cargo fmt -- --check` がパス。
 
-- PR-A6: `pybun watch` の標準ビルド fallback 監視
+- [DONE] PR-A6: `pybun watch` の標準ビルド fallback 監視 (Issue #190)
   - Goal: `native-watch` 無効でも poll-based で監視再実行できるようにする。
-  - Tests: feature無効CIで実監視E2E（previewではなく変更検知→再実行）。
+  - Current: `src/hot_reload.rs` に `scan_watch_paths` / `diff_snapshots` / `run_polling_watch_loop` を追加。include/exclude パターンは既存の `should_watch_path`（旧 `HotReloadWatcher::should_watch` から抽出）で判定し、`debounce_ms`（最小 `MIN_POLL_INTERVAL_MS=100ms`）をポーリング間隔として再利用。`src/commands.rs::run_watch()` の `#[cfg(not(feature = "native-watch"))]` 経路を、従来の "Would watch... (requires native-watch)" プレビュー出力から実際にブロッキングするポーリングループへ置き換え、変更検知時に対象コマンドを再実行する。E2E テスト用に `PYBUN_WATCH_MAX_ITERATIONS` を導入してループを有限回で終了可能にした。`native-watch` 有効時は従来どおり `run_native_watch_loop`（`notify` クレート）を使用。
+  - Tests: `cargo test --lib hot_reload::tests::polling_watch_tests`（9件: include/exclude判定、snapshotスキャン、Created/Modified/Deleted差分検出、ループ動作）。`cargo test --test hot_reload`（polling fallbackのE2E: ファイル変更検知→再実行、不正パスでのエラー）。`cargo test --features native-watch --test hot_reload` / `--lib hot_reload` でnative-watch経路が継続動作することを確認。`cargo test`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt -- --check`。
 - PR-A7: install の安全な既定ターゲット（プロジェクト隔離環境）
   - Goal: プロジェクト検出時に system Python へ直接入る経路を避け、`.pybun/venv` を既定化。
   - Tests: 既存venv無しプロジェクトでの install E2E（system汚染しないことを確認）。

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4434,6 +4434,8 @@ fn run_module_find(args: &ModuleFindArgs, collector: &mut EventCollector) -> Res
 
 #[cfg(feature = "native-watch")]
 use crate::hot_reload::run_native_watch_loop;
+#[cfg(not(feature = "native-watch"))]
+use crate::hot_reload::run_polling_watch_loop;
 use crate::hot_reload::{HotReloadConfig, HotReloadWatcher, generate_shell_watcher_command};
 use crate::lazy_import::{
     LazyImportConfig, LazyImportDecision, generate_lazy_import_python_code_with_module_name,
@@ -4785,13 +4787,17 @@ fn run_watch(args: &WatchArgs, collector: &mut EventCollector) -> Result<RenderD
 
     #[cfg(not(feature = "native-watch"))]
     {
-        // Native watching not available - show preview
+        collector.info("Starting polling file watcher");
+
+        // Build the command to run
+        let run_cmd = format!("pybun run {}", target_script);
+
         let text = format!(
-            "Would watch {} paths for changes to run: {}\n\
+            "Watching {} paths for changes to run: {}\n\
             Patterns: {} include, {} exclude\n\
-            Debounce: {}ms\n\n\
-            Note: Native file watching requires building with --features native-watch.\n\
-            Use --shell-command for external watcher instead.",
+            Debounce: {}ms\n\
+            Native watching: disabled (using polling fallback)\n\
+            Press Ctrl+C to stop.",
             stats.watched_paths,
             target_script,
             stats.include_patterns,
@@ -4799,25 +4805,37 @@ fn run_watch(args: &WatchArgs, collector: &mut EventCollector) -> Result<RenderD
             stats.debounce_ms
         );
 
-        collector.info(&text);
+        eprintln!("{}", text);
 
-        Ok(RenderDetail::with_json(
-            text,
-            json!({
-                "status": "preview",
-                "target": target_script,
-                "watch_paths": config.watch_paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
-                "include_patterns": config.include_patterns,
-                "exclude_patterns": config.exclude_patterns,
-                "debounce_ms": config.debounce_ms,
-                "native_watch_available": false,
-                "stats": {
-                    "watched_paths": stats.watched_paths,
-                    "include_patterns": stats.include_patterns,
-                    "exclude_patterns": stats.exclude_patterns,
-                },
-            }),
-        ))
+        // Test-only escape hatch: bound the loop so E2E tests can observe
+        // change detection without running forever.
+        let max_iterations = std::env::var("PYBUN_WATCH_MAX_ITERATIONS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok());
+
+        match run_polling_watch_loop(&config, &run_cmd, max_iterations) {
+            Ok(outcome) => Ok(RenderDetail::with_json(
+                "File watching stopped".to_string(),
+                json!({
+                    "status": "stopped",
+                    "target": target_script,
+                    "native_watch": false,
+                    "polling": true,
+                    "iterations": outcome.iterations,
+                    "runs": outcome.runs,
+                }),
+            )),
+            Err(e) => {
+                collector.error(&e);
+                Ok(RenderDetail::error(
+                    format!("Watch failed: {}", e),
+                    json!({
+                        "error": e,
+                        "status": "error",
+                    }),
+                ))
+            }
+        }
     }
 }
 

--- a/src/hot_reload.rs
+++ b/src/hot_reload.rs
@@ -11,10 +11,10 @@
 //! - Native file watching with `notify` crate (optional feature: `native-watch`)
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 #[cfg(feature = "native-watch")]
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
@@ -199,27 +199,7 @@ impl HotReloadWatcher {
 
     /// Check if a path should be watched based on include/exclude patterns.
     pub fn should_watch(&self, path: &Path) -> bool {
-        let path_str = path.to_string_lossy();
-
-        // Check exclude patterns first
-        for pattern in &self.config.exclude_patterns {
-            if matches_pattern(&path_str, pattern) {
-                return false;
-            }
-        }
-
-        // Check include patterns
-        if self.config.include_patterns.is_empty() {
-            return true;
-        }
-
-        for pattern in &self.config.include_patterns {
-            if matches_pattern(&path_str, pattern) {
-                return true;
-            }
-        }
-
-        false
+        should_watch_path(&self.config, path)
     }
 
     /// Start watching (stub implementation - actual fs watching would use notify crate).
@@ -506,6 +486,213 @@ fn matches_pattern(path: &str, pattern: &str) -> bool {
 
     // Exact match or contains
     path.contains(pattern)
+}
+
+/// Check if a path should be watched based on the configuration's
+/// include/exclude patterns.
+pub fn should_watch_path(config: &HotReloadConfig, path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+
+    // Check exclude patterns first
+    for pattern in &config.exclude_patterns {
+        if matches_pattern(&path_str, pattern) {
+            return false;
+        }
+    }
+
+    // Check include patterns
+    if config.include_patterns.is_empty() {
+        return true;
+    }
+
+    config
+        .include_patterns
+        .iter()
+        .any(|pattern| matches_pattern(&path_str, pattern))
+}
+
+/// Current time in milliseconds since the Unix epoch.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// A snapshot of watched files: path -> (modification time, size in bytes).
+pub type FileSnapshot = HashMap<PathBuf, (SystemTime, u64)>;
+
+/// Recursively scan the configured watch paths and return a snapshot of
+/// all files that pass the include/exclude pattern filters.
+///
+/// Directories matching an exclude pattern are not descended into.
+pub fn scan_watch_paths(config: &HotReloadConfig) -> FileSnapshot {
+    let mut snapshot = FileSnapshot::new();
+    let mut stack: Vec<PathBuf> = config.watch_paths.clone();
+
+    while let Some(path) = stack.pop() {
+        let metadata = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        if metadata.is_dir() {
+            let dir_str = path.to_string_lossy();
+            if config
+                .exclude_patterns
+                .iter()
+                .any(|pattern| matches_pattern(&dir_str, pattern))
+            {
+                continue;
+            }
+
+            if let Ok(entries) = std::fs::read_dir(&path) {
+                for entry in entries.flatten() {
+                    stack.push(entry.path());
+                }
+            }
+        } else if should_watch_path(config, &path)
+            && let Ok(mtime) = metadata.modified()
+        {
+            snapshot.insert(path, (mtime, metadata.len()));
+        }
+    }
+
+    snapshot
+}
+
+/// Compare two snapshots and return the file change events between them.
+pub fn diff_snapshots(old: &FileSnapshot, new: &FileSnapshot) -> Vec<FileChangeEvent> {
+    let timestamp_ms = now_ms();
+    let mut events = Vec::new();
+
+    for (path, (mtime, size)) in new {
+        match old.get(path) {
+            None => events.push(FileChangeEvent::new(
+                path.clone(),
+                ChangeType::Created,
+                timestamp_ms,
+            )),
+            Some((old_mtime, old_size)) => {
+                if old_mtime != mtime || old_size != size {
+                    events.push(FileChangeEvent::new(
+                        path.clone(),
+                        ChangeType::Modified,
+                        timestamp_ms,
+                    ));
+                }
+            }
+        }
+    }
+
+    for path in old.keys() {
+        if !new.contains_key(path) {
+            events.push(FileChangeEvent::new(
+                path.clone(),
+                ChangeType::Deleted,
+                timestamp_ms,
+            ));
+        }
+    }
+
+    events
+}
+
+/// Minimum interval between polling scans, regardless of configured debounce.
+const MIN_POLL_INTERVAL_MS: u64 = 100;
+
+/// Outcome of a polling watch loop run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PollingWatchOutcome {
+    /// Number of poll iterations performed.
+    pub iterations: u64,
+    /// Number of times the command was run in response to a detected change.
+    pub runs: u64,
+}
+
+/// Run a poll-based watch loop, re-running `command` whenever a watched
+/// file is created, modified, or deleted.
+///
+/// This is the fallback used when the `native-watch` feature is not
+/// compiled in. Unlike [`run_native_watch_loop`], this function works on
+/// all platforms without the `notify` crate.
+///
+/// If `max_iterations` is `Some(n)`, the loop stops after `n` poll
+/// iterations (used by tests). If `None`, it runs until the process is
+/// interrupted (e.g. Ctrl+C).
+pub fn run_polling_watch_loop(
+    config: &HotReloadConfig,
+    command: &str,
+    max_iterations: Option<u64>,
+) -> Result<PollingWatchOutcome, String> {
+    use std::process::Command;
+
+    if config.watch_paths.is_empty() {
+        return Err("No paths to watch".to_string());
+    }
+
+    if !config.watch_paths.iter().any(|p| p.exists()) {
+        return Err("No valid paths to watch".to_string());
+    }
+
+    let poll_interval = Duration::from_millis(config.debounce_ms.max(MIN_POLL_INTERVAL_MS));
+    let mut snapshot = scan_watch_paths(config);
+    let mut outcome = PollingWatchOutcome::default();
+    eprintln!("info: watching for changes...");
+
+    loop {
+        std::thread::sleep(poll_interval);
+        outcome.iterations += 1;
+
+        let new_snapshot = scan_watch_paths(config);
+        let events = diff_snapshots(&snapshot, &new_snapshot);
+        snapshot = new_snapshot;
+
+        if !events.is_empty() {
+            for event in &events {
+                eprintln!("info: {:?} {}", event.change_type, event.path.display());
+            }
+
+            if config.clear_on_reload {
+                // ANSI escape sequence to clear screen
+                print!("\x1B[2J\x1B[1;1H");
+            }
+
+            eprintln!("info: running: {}", command);
+            let status = if cfg!(windows) {
+                Command::new("cmd").args(["/C", command]).status()
+            } else {
+                Command::new("sh").args(["-c", command]).status()
+            };
+
+            match status {
+                Ok(s) => {
+                    if s.success() {
+                        eprintln!("info: command completed successfully");
+                    } else {
+                        eprintln!(
+                            "warning: command exited with code {}",
+                            s.code().unwrap_or(-1)
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: failed to run command: {}", e);
+                }
+            }
+
+            outcome.runs += 1;
+            eprintln!("info: watching for changes...");
+        }
+
+        if let Some(max) = max_iterations
+            && outcome.iterations >= max
+        {
+            break;
+        }
+    }
+
+    Ok(outcome)
 }
 
 impl HotReloadConfig {
@@ -891,6 +1078,179 @@ mod tests {
         assert!(available);
         #[cfg(not(feature = "native-watch"))]
         assert!(!available);
+    }
+
+    mod polling_watch_tests {
+        use super::*;
+        use std::fs::File;
+        use std::io::Write;
+        use std::thread;
+        use tempfile::TempDir;
+
+        #[test]
+        fn test_should_watch_path_respects_include_exclude() {
+            let config = HotReloadConfig::dev();
+            assert!(should_watch_path(&config, Path::new("foo.py")));
+            assert!(!should_watch_path(&config, Path::new("foo.rs")));
+            assert!(!should_watch_path(
+                &config,
+                Path::new("__pycache__/foo.pyc")
+            ));
+        }
+
+        #[test]
+        fn test_scan_watch_paths_finds_python_files_and_ignores_others() {
+            let temp = TempDir::new().unwrap();
+
+            let py_file = temp.path().join("main.py");
+            File::create(&py_file).unwrap();
+
+            let txt_file = temp.path().join("notes.txt");
+            File::create(&txt_file).unwrap();
+
+            let mut config = HotReloadConfig::dev();
+            config.watch_paths = vec![temp.path().to_path_buf()];
+
+            let snapshot = scan_watch_paths(&config);
+
+            assert!(snapshot.contains_key(&py_file));
+            assert!(!snapshot.contains_key(&txt_file));
+        }
+
+        #[test]
+        fn test_scan_watch_paths_excludes_pycache_dir() {
+            let temp = TempDir::new().unwrap();
+
+            let pycache = temp.path().join("__pycache__");
+            std::fs::create_dir(&pycache).unwrap();
+            let pyc_file = pycache.join("main.cpython-311.pyc");
+            File::create(&pyc_file).unwrap();
+
+            let main_py = temp.path().join("main.py");
+            File::create(&main_py).unwrap();
+
+            let mut config = HotReloadConfig::dev();
+            config.watch_paths = vec![temp.path().to_path_buf()];
+
+            let snapshot = scan_watch_paths(&config);
+
+            assert!(snapshot.contains_key(&main_py));
+            assert!(!snapshot.contains_key(&pyc_file));
+        }
+
+        #[test]
+        fn test_diff_snapshots_detects_created_modified_and_deleted() {
+            let now = SystemTime::now();
+            let created = PathBuf::from("created.py");
+            let modified = PathBuf::from("modified.py");
+            let deleted = PathBuf::from("deleted.py");
+
+            let mut old: FileSnapshot = HashMap::new();
+            old.insert(modified.clone(), (now, 10));
+            old.insert(deleted.clone(), (now, 5));
+
+            let mut new: FileSnapshot = HashMap::new();
+            new.insert(modified.clone(), (now, 20));
+            new.insert(created.clone(), (now, 1));
+
+            let events = diff_snapshots(&old, &new);
+
+            let created_event = events
+                .iter()
+                .find(|e| e.path == created)
+                .expect("created event");
+            assert_eq!(created_event.change_type, ChangeType::Created);
+
+            let modified_event = events
+                .iter()
+                .find(|e| e.path == modified)
+                .expect("modified event");
+            assert_eq!(modified_event.change_type, ChangeType::Modified);
+
+            let deleted_event = events
+                .iter()
+                .find(|e| e.path == deleted)
+                .expect("deleted event");
+            assert_eq!(deleted_event.change_type, ChangeType::Deleted);
+        }
+
+        #[test]
+        fn test_diff_snapshots_no_changes_returns_empty() {
+            let now = SystemTime::now();
+            let path = PathBuf::from("stable.py");
+
+            let mut snapshot: FileSnapshot = HashMap::new();
+            snapshot.insert(path, (now, 10));
+
+            let events = diff_snapshots(&snapshot, &snapshot);
+            assert!(events.is_empty());
+        }
+
+        #[test]
+        fn test_run_polling_watch_loop_no_paths_errors() {
+            let mut config = HotReloadConfig::dev();
+            config.watch_paths.clear();
+
+            let result = run_polling_watch_loop(&config, "true", Some(1));
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("No paths to watch"));
+        }
+
+        #[test]
+        fn test_run_polling_watch_loop_no_valid_paths_errors() {
+            let mut config = HotReloadConfig::dev();
+            config.watch_paths = vec![PathBuf::from("/nonexistent/path/for/pybun/tests")];
+
+            let result = run_polling_watch_loop(&config, "true", Some(1));
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("No valid paths to watch"));
+        }
+
+        #[test]
+        fn test_run_polling_watch_loop_detects_change_and_runs_command() {
+            let temp = TempDir::new().unwrap();
+            let py_file = temp.path().join("main.py");
+            File::create(&py_file).unwrap();
+
+            let mut config = HotReloadConfig::dev();
+            config.watch_paths = vec![temp.path().to_path_buf()];
+            config.debounce_ms = 50;
+
+            // Modify the watched file shortly after the loop starts so the
+            // first poll iteration (after debounce) observes the change.
+            let watched_file = py_file.clone();
+            let writer = thread::spawn(move || {
+                thread::sleep(Duration::from_millis(75));
+                let mut file = File::create(&watched_file).unwrap();
+                writeln!(file, "print('changed')").unwrap();
+                file.sync_all().unwrap();
+            });
+
+            let outcome = run_polling_watch_loop(&config, "true", Some(6)).unwrap();
+
+            writer.join().unwrap();
+
+            assert_eq!(outcome.iterations, 6);
+            assert!(
+                outcome.runs >= 1,
+                "expected at least one command run for detected change"
+            );
+        }
+
+        #[test]
+        fn test_run_polling_watch_loop_respects_max_iterations_without_changes() {
+            let temp = TempDir::new().unwrap();
+            File::create(temp.path().join("main.py")).unwrap();
+
+            let mut config = HotReloadConfig::dev();
+            config.watch_paths = vec![temp.path().to_path_buf()];
+            config.debounce_ms = 50;
+
+            let outcome = run_polling_watch_loop(&config, "true", Some(3)).unwrap();
+
+            assert_eq!(outcome.iterations, 3);
+            assert_eq!(outcome.runs, 0);
+        }
     }
 
     #[cfg(feature = "native-watch")]

--- a/tests/hot_reload.rs
+++ b/tests/hot_reload.rs
@@ -152,6 +152,103 @@ fn test_watch_json_shows_native_available() {
         .stdout(predicate::str::contains("\"native_watch_available\""));
 }
 
+// Tests for the polling watch fallback (used when native-watch is disabled).
+#[cfg(not(feature = "native-watch"))]
+mod polling_watch_cli_tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::process::{Command as StdCommand, Stdio};
+
+    #[test]
+    fn test_watch_polling_fallback_detects_file_change_and_reruns() {
+        let temp = TempDir::new().unwrap();
+        let py_file = temp.path().join("main.py");
+        File::create(&py_file).unwrap();
+
+        let mut child = StdCommand::new(env!("CARGO_BIN_EXE_pybun"))
+            .args([
+                "watch",
+                "main.py",
+                "-p",
+                temp.path().to_str().unwrap(),
+                "--debounce",
+                "100",
+            ])
+            .env("PYBUN_WATCH_MAX_ITERATIONS", "20")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to start pybun watch");
+
+        // Wait for the watcher to confirm it has taken its baseline
+        // snapshot and is ready to detect changes, then modify the file so
+        // the change is observed on a later poll. This avoids flakiness
+        // from fixed sleeps when the test suite is under load.
+        let mut reader = BufReader::new(child.stderr.take().unwrap());
+        let mut banner = String::new();
+        loop {
+            let mut line = String::new();
+            let bytes = reader.read_line(&mut line).expect("read stderr");
+            if bytes == 0 {
+                break;
+            }
+            banner.push_str(&line);
+            if line.contains("watching for changes...") {
+                break;
+            }
+        }
+
+        let mut file = File::create(&py_file).unwrap();
+        writeln!(file, "print('changed')").unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let mut rest = String::new();
+        reader.read_to_string(&mut rest).expect("read stderr");
+        let stderr = banner + &rest;
+
+        let status = child.wait().expect("failed to wait on child");
+
+        assert!(
+            status.success(),
+            "watch should exit cleanly after max iterations, stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("Modified") && stderr.contains("main.py"),
+            "expected change detection in stderr, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("running:"),
+            "expected the configured command to be re-run, got: {stderr}"
+        );
+    }
+
+    #[test]
+    fn test_watch_polling_fallback_no_target_directory_errors() {
+        let output = StdCommand::new(env!("CARGO_BIN_EXE_pybun"))
+            .args([
+                "--format=json",
+                "watch",
+                "main.py",
+                "-p",
+                "/nonexistent/path/for/pybun/tests",
+                "--debounce",
+                "50",
+            ])
+            .env("PYBUN_WATCH_MAX_ITERATIONS", "1")
+            .output()
+            .expect("failed to run pybun watch");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("\"status\":\"error\""), "stdout: {stdout}");
+        assert!(
+            stdout.contains("No valid paths to watch"),
+            "stdout: {stdout}"
+        );
+    }
+}
+
 // Tests for native-watch feature CLI output (only run when feature is enabled)
 #[cfg(feature = "native-watch")]
 mod native_watch_cli_tests {


### PR DESCRIPTION
## Summary
- Implements a poll-based file watcher (`scan_watch_paths`, `diff_snapshots`, `run_polling_watch_loop` in `src/hot_reload.rs`) used as the fallback for `pybun watch` when the `native-watch` feature (notify crate) is not compiled in — i.e. for release binaries.
- Replaces the previous `not(feature = "native-watch"))` path in `run_watch()` (which only printed a "Would watch... (requires native-watch)" preview) with a real blocking watch loop that detects file changes (mtime/size) and re-runs the target command.
- Reuses `should_watch_path` (extracted from `HotReloadWatcher::should_watch`) for include/exclude pattern filtering, and `debounce_ms` (min 100ms) as the polling interval.
- Adds `PYBUN_WATCH_MAX_ITERATIONS` test-only env var to bound the otherwise-infinite polling loop for E2E tests.
- Updates `docs/PLAN.md` to mark PR-A6 as `[DONE]`.

Closes #190

## Test plan
- [x] `cargo test --lib hot_reload::tests::polling_watch_tests` — 9 unit tests covering include/exclude filtering, snapshot scanning, diff detection (Created/Modified/Deleted), and loop behavior
- [x] `cargo test --test hot_reload` — E2E: polling fallback detects a file change and re-runs the configured command; invalid watch path produces a structured JSON error
- [x] `cargo test --features native-watch --test hot_reload` and `--lib hot_reload` — native-watch path still works (uses `notify` via `run_native_watch_loop`)
- [x] `cargo test` (full suite)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`

## Acceptance criteria (Issue #190)
- [x] In a default (no-feature) build, editing a watched file triggers a re-run (E2E, not just preview text)
- [x] Debounce + include/exclude patterns honored by the polling path
- [x] Native-watch build still uses `notify`