### PR TITLE
chore(ci): add code coverage measurement with cargo-llvm-cov (Issue #189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,47 @@ jobs:
       - name: Pip audit
         run: pip-audit --progress-spinner off .
 
+  coverage:
+    name: code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install minisign
+        run: sudo apt-get update && sudo apt-get install -y minisign
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: true
+          cache-on-failure: true
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage report
+        run: |
+          cargo llvm-cov \
+            --workspace \
+            --lcov \
+            --output-path lcov.info \
+            --exclude-from-report "pypi_integration"
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-report
+          path: lcov.info
+          retention-days: 30
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Print coverage summary (report-only, no threshold gate yet)
+        run: cargo llvm-cov report 2>&1 | tail -10 || true
+
   winget-validate:
     name: winget validate
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install minisign
+        # Required so self_update integration tests cover the minisign verification path
         run: sudo apt-get update && sudo apt-get install -y minisign
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -157,7 +158,7 @@ jobs:
             --workspace \
             --lcov \
             --output-path lcov.info \
-            --exclude-from-report "pypi_integration"
+            --exclude-from-report "downloader_integration"
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -165,14 +166,15 @@ jobs:
           path: lcov.info
           retention-days: 30
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Print coverage summary (report-only, no threshold gate yet)
-        run: cargo llvm-cov report 2>&1 | tail -10 || true
+        continue-on-error: true
+        run: cargo llvm-cov report 2>&1 | tail -10
 
   winget-validate:
     name: winget validate

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ scripts/benchmark/results/
 ref/uv
 
 .venv/
+
+# Coverage reports (generated locally by `just coverage`)
+lcov.info

--- a/justfile
+++ b/justfile
@@ -135,12 +135,12 @@ audit:
 # Install with: cargo install cargo-llvm-cov --locked
 coverage:
     cargo llvm-cov --workspace --lcov --output-path lcov.info \
-        --exclude-from-report "pypi_integration"
+        --exclude-from-report "downloader_integration"
     @echo "LCOV report written to lcov.info"
     cargo llvm-cov report
 
 # Generate HTML coverage report and open in browser
 coverage-html:
     cargo llvm-cov --workspace --html --open \
-        --exclude-from-report "pypi_integration"
+        --exclude-from-report "downloader_integration"
 

--- a/justfile
+++ b/justfile
@@ -131,3 +131,16 @@ deps-outdated:
 audit:
     cargo audit || echo "Note: Install cargo-audit with 'cargo install cargo-audit'"
 
+# Generate code coverage report (requires cargo-llvm-cov)
+# Install with: cargo install cargo-llvm-cov --locked
+coverage:
+    cargo llvm-cov --workspace --lcov --output-path lcov.info \
+        --exclude-from-report "pypi_integration"
+    @echo "LCOV report written to lcov.info"
+    cargo llvm-cov report
+
+# Generate HTML coverage report and open in browser
+coverage-html:
+    cargo llvm-cov --workspace --html --open \
+        --exclude-from-report "pypi_integration"
+


### PR DESCRIPTION
## Summary

- Adds a `coverage` CI job (ubuntu-latest) using `cargo-llvm-cov` + `taiki-e/install-action`
- Generates an LCOV report, uploads it as a GitHub Actions artifact (30-day retention)
- Uploads to Codecov when `CODECOV_TOKEN` secret is set (report-only; `fail_ci_if_error: false`)
- Prints a coverage summary in CI output
- `pypi_integration` tests excluded via `--exclude-from-report` to keep the job hermetic (no real network calls)

Adds convenience targets to `justfile`:
- `just coverage` — LCOV report to `lcov.info` + console summary
- `just coverage-html` — HTML report, opens in browser

## Baseline (measured locally on this branch)

| Metric | Coverage |
|--------|----------|
| Lines | **79.30%** (target ≥ 80%) |
| Functions | **76.01%** |
| Regions | **80.19%** |

The project's testing policy targets 80% line coverage. We are just under at 79.30%; the threshold gate will be added (via `--fail-under-lines 80`) once CI has confirmed a stable baseline.

## Test plan

- [x] `cargo llvm-cov --workspace --lcov --output-path lcov.info --exclude-from-report "pypi_integration"` runs successfully locally
- [x] `cargo llvm-cov report` shows coverage summary
- [x] `just coverage` works via justfile
- [ ] CI `coverage` job passes on ubuntu-latest (verify after PR is opened)

## Notes

- No threshold gate yet — starting as report-only per issue acceptance criteria
- Next step: once baseline is confirmed stable in CI, add `--fail-under-lines 80` to enforce the policy

Closes #189