### PR TITLE
refactor(commands): extract maintenance commands (Issue #186)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -169,7 +169,9 @@
   - Tests: `cargo build` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt -- --check` / `cargo test --lib`（351 passed）/ `cargo test --lib commands::test::`（8/8 passed）/ `cargo test`（フルスイート、E2E含む全テストパス）。JSON/CLI の公開挙動・schema に変更なし。
   - Current: `pybun module-find` / `pybun lazy-import` / `pybun watch` / `pybun profile` の実装（`run_module_find` / `run_lazy_import` / `run_watch` / `run_profile`、約715行、関連する `module_finder` / `hot_reload` / `lazy_import` / `profiles` の局所 `use` を含む）を `src/commands/tooling.rs` へ抽出し、`mod tooling;` を宣言。`mod.rs` 側の呼び出しを `tooling::run_module_find(...)` 等に更新し、`ModuleFindArgs` / `LazyImportArgs` / `WatchArgs` / `ProfileArgs` の import を `mod.rs` から削除して `tooling.rs` 側に移動。`RenderDetail`（コンストラクタ含む）は `super::RenderDetail` 経由で参照。`mod.rs` は 5957行 → 5241行に縮小。
   - Tests: `cargo build` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt -- --check` / `cargo test --lib`（354 passed）/ `cargo test`（フルスイート、E2E含む全テストパス）。JSON/CLI の公開挙動・schema に変更なし。
-  - Remaining: `install.rs` / `lock.rs` / `run.rs` / `build.rs` / `x.rs` / `maintenance.rs`（gc/doctor）/ `python_env.rs` / `project.rs`（init/outdated/upgrade）への抽出は follow-up PR で対応する。
+  - Current: `pybun doctor` / `pybun gc` の実装（`run_doctor` / `run_gc`、support bundle / PyPI cache stale check / PEP 723 cache GC 連携を含む）を `src/commands/maintenance.rs` へ抽出し、`mod.rs` 側の dispatcher を `maintenance::run_doctor(...)` / `maintenance::run_gc(...)` 呼び出しへ更新。`support_bundle` と cache size formatting の局所 import を新モジュール側へ移動し、JSON detail / diagnostics / summary は変更なし。`mod.rs` は 5241行 → 4903行に縮小。
+  - Tests: `cargo check` / `cargo fmt -- --check` / `just lint` / `cargo test --test gc`（10 passed）/ `cargo test --test support_bundle`（2 passed）/ `cargo test --test self_update doctor`（4 passed, 10 filtered）/ `cargo test`（フルスイートパス）/ `cargo audit` で `gc` / `doctor` / support bundle 経路が継続動作することを確認。
+  - Remaining: `install.rs` / `lock.rs` / `run.rs` / `build.rs` / `x.rs` / `python_env.rs` / `project.rs`（init/outdated/upgrade）への抽出は follow-up PR で対応する。
 
 ### P2 (Post-GA Improvement)
 - PR-A8: Runtime catalog hardening（実チェックサム管理 + 3.13 preview）

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -1,0 +1,353 @@
+use super::RenderDetail;
+use crate::cache::{Cache, format_size, parse_size};
+use crate::env::find_python_env;
+use crate::pep723_cache::Pep723Cache;
+use crate::project::Project;
+use crate::schema::EventCollector;
+use crate::support_bundle::{BundleContext, BundleReport, build_support_bundle, upload_bundle};
+use color_eyre::eyre::{Result, eyre};
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// pybun doctor
+// ---------------------------------------------------------------------------
+
+pub(super) fn run_doctor(
+    args: &crate::cli::DoctorArgs,
+    collector: &mut EventCollector,
+) -> RenderDetail {
+    let mut checks: Vec<Value> = Vec::new();
+    let mut all_ok = true;
+    let mut bundle_report: Option<BundleReport> = None;
+
+    // Check pybun binary
+    if let Ok(exe) = std::env::current_exe() {
+        checks.push(json!({
+            "name": "pybun_binary",
+            "status": "ok",
+            "path": exe.display().to_string(),
+        }));
+    }
+
+    // Check Python availability
+    let working_dir = std::env::current_dir().unwrap_or_default();
+    match find_python_env(&working_dir) {
+        Ok(env) => {
+            checks.push(json!({
+                "name": "python",
+                "status": "ok",
+                "message": format!("Python found at {}", env.python_path.display()),
+                "source": format!("{}", env.source),
+                "version": env.version,
+            }));
+            collector.info(format!("Python found: {}", env.python_path.display()));
+        }
+        Err(e) => {
+            checks.push(json!({
+                "name": "python",
+                "status": "error",
+                "message": format!("Python not found: {}", e),
+            }));
+            collector.warning(format!("Python not found: {}", e));
+            all_ok = false;
+        }
+    }
+
+    // Check cache directory
+    match crate::cache::Cache::new() {
+        Ok(cache) => {
+            let cache_dir = cache.root();
+            checks.push(json!({
+                "name": "cache",
+                "status": "ok",
+                "message": format!("Cache directory: {}", cache_dir.display()),
+                "path": cache_dir.display().to_string(),
+            }));
+        }
+        Err(e) => {
+            checks.push(json!({
+                "name": "cache",
+                "status": "error",
+                "message": format!("Cache initialization failed: {}", e),
+            }));
+            collector.warning(format!("Cache initialization failed: {}", e));
+            all_ok = false;
+        }
+    }
+
+    // Check PyPI metadata cache directory (separate from the main cache
+    // root above - see issue #202). Flag stale entries written by
+    // incompatible older pybun versions.
+    if let Some(pypi_cache_dir) = crate::pypi::pypi_cache_dir() {
+        let stats = crate::pypi::pypi_cache_stats(&pypi_cache_dir);
+        let status = if stats.stale_count > 0 { "info" } else { "ok" };
+        checks.push(json!({
+            "name": "pypi_cache",
+            "status": status,
+            "message": format!(
+                "PyPI metadata cache: {} ({} entries, {} stale)",
+                pypi_cache_dir.display(),
+                stats.entry_count,
+                stats.stale_count,
+            ),
+            "path": pypi_cache_dir.display().to_string(),
+            "entry_count": stats.entry_count,
+            "total_bytes": stats.total_bytes,
+            "stale_count": stats.stale_count,
+        }));
+        if stats.stale_count > 0 {
+            collector.info(format!(
+                "{} stale PyPI cache entries found in {} - run `pybun gc` to remove them",
+                stats.stale_count,
+                pypi_cache_dir.display(),
+            ));
+        }
+    }
+
+    // Check for pyproject.toml
+    match Project::discover(&working_dir) {
+        Ok(project) => {
+            checks.push(json!({
+                "name": "project",
+                "status": "ok",
+                "message": format!("Project found at {}", project.path().display()),
+                "path": project.path().display().to_string(),
+                "dependencies": project.dependencies(),
+            }));
+        }
+        Err(_) => {
+            checks.push(json!({
+                "name": "project",
+                "status": "info",
+                "message": "No pyproject.toml found in current directory",
+            }));
+            collector.info("No pyproject.toml found");
+        }
+    }
+
+    let status = if all_ok { "healthy" } else { "issues_found" };
+    let summary = if all_ok {
+        "All checks passed".to_string()
+    } else {
+        "Some issues found".to_string()
+    };
+
+    if args.verbose {
+        collector.info("Verbose diagnostics enabled");
+    }
+
+    if args.bundle.is_some() || args.upload {
+        let trace_id = collector.trace_id().map(|value| value.to_string());
+        let context = BundleContext {
+            checks: checks.clone(),
+            verbose_logs: args.verbose,
+            trace_id,
+            command: "pybun doctor".to_string(),
+        };
+
+        let mut temp_bundle: Option<tempfile::TempDir> = None;
+        let bundle_path = if let Some(path) = args.bundle.clone() {
+            path
+        } else if let Ok(temp) = tempfile::TempDir::new() {
+            let path = temp.path().join("bundle");
+            temp_bundle = Some(temp);
+            path
+        } else {
+            std::env::temp_dir().join("pybun-support-bundle")
+        };
+
+        match build_support_bundle(&bundle_path, &context) {
+            Ok(collection) => {
+                let mut upload_outcome = None;
+                let mut bundle_path_out = args.bundle.clone();
+
+                if args.upload {
+                    let upload_url = args
+                        .upload_url
+                        .clone()
+                        .or_else(|| std::env::var("PYBUN_SUPPORT_UPLOAD_URL").ok());
+                    match upload_url {
+                        Some(url) => {
+                            let outcome = upload_bundle(&collection, &url);
+                            if outcome.status != "uploaded"
+                                && bundle_path_out.is_none()
+                                && let Some(temp) = temp_bundle.take()
+                            {
+                                let _ = temp.keep();
+                                bundle_path_out = Some(collection.path.clone());
+                            }
+                            upload_outcome = Some(outcome);
+                        }
+                        None => {
+                            upload_outcome = Some(crate::support_bundle::UploadOutcome {
+                                url: "".to_string(),
+                                status: "failed".to_string(),
+                                http_status: None,
+                                error: Some("upload endpoint not configured".to_string()),
+                            });
+                            if bundle_path_out.is_none()
+                                && let Some(temp) = temp_bundle.take()
+                            {
+                                let _ = temp.keep();
+                                bundle_path_out = Some(collection.path.clone());
+                            }
+                        }
+                    }
+                }
+
+                bundle_report = Some(BundleReport {
+                    bundle_path: bundle_path_out,
+                    files: collection.files,
+                    redactions: collection.redactions,
+                    logs_included: collection.logs_included,
+                    upload: upload_outcome,
+                });
+            }
+            Err(err) => {
+                collector.error_with_code(
+                    "E_DOCTOR_BUNDLE_FAILED",
+                    format!("Support bundle failed: {:?}", err),
+                    "Check that the bundle output path (or system temp directory) is writable, then re-run `pybun doctor --bundle <path>`.",
+                );
+                return RenderDetail::error(
+                    "Support bundle failed".to_string(),
+                    json!({
+                        "status": status,
+                        "checks": checks,
+                        "verbose": args.verbose,
+                        "bundle_error": format!("{:?}", err),
+                    }),
+                );
+            }
+        }
+    }
+
+    let mut detail = json!({
+        "status": status,
+        "checks": checks,
+        "verbose": args.verbose,
+    });
+
+    if let Some(bundle) = &bundle_report {
+        detail["bundle"] = bundle.to_json();
+    }
+
+    let summary = if bundle_report.is_some() {
+        format!("{}. Support bundle captured", summary)
+    } else {
+        summary
+    };
+
+    RenderDetail::with_json(summary, detail)
+}
+
+// ---------------------------------------------------------------------------
+// pybun gc (garbage collection)
+// ---------------------------------------------------------------------------
+
+pub(super) fn run_gc(
+    args: &crate::cli::GcArgs,
+    collector: &mut EventCollector,
+) -> Result<RenderDetail> {
+    let cache = Cache::new().map_err(|e| eyre!("failed to initialize cache: {}", e))?;
+
+    // Parse max size if provided
+    let max_bytes = if let Some(size_str) = &args.max_size {
+        Some(parse_size(size_str).map_err(|e| eyre!("invalid size format: {}", e))?)
+    } else {
+        None
+    };
+
+    collector.info(format!("Running GC on cache at {}", cache.root().display()));
+
+    // Ensure cache directories exist
+    cache
+        .ensure_dirs()
+        .map_err(|e| eyre!("failed to ensure cache dirs: {}", e))?;
+
+    // Run garbage collection on packages/build cache
+    let gc_result = cache
+        .gc(max_bytes, args.dry_run)
+        .map_err(|e| eyre!("GC failed: {}", e))?;
+
+    // Also run GC on PEP 723 venv cache
+    let pep723_cache =
+        Pep723Cache::new().map_err(|e| eyre!("failed to initialize pep723 cache: {}", e))?;
+    let pep723_gc_result = pep723_cache
+        .gc(max_bytes, args.dry_run)
+        .map_err(|e| eyre!("PEP 723 GC failed: {}", e))?;
+
+    // Remove stale/corrupt PyPI metadata cache entries (see issue #202).
+    // This directory is separate from `cache.root()` and is not covered by
+    // `cache.gc()` above.
+    let pypi_cache_gc = crate::pypi::pypi_cache_dir()
+        .map(|dir| crate::pypi::gc_stale_pypi_cache(&dir, args.dry_run))
+        .unwrap_or_default();
+
+    // Combine results
+    let total_freed =
+        gc_result.freed_bytes + pep723_gc_result.freed_bytes + pypi_cache_gc.freed_bytes;
+    let total_removed =
+        gc_result.files_removed + pep723_gc_result.envs_removed + pypi_cache_gc.files_removed;
+    let total_size_before = gc_result.size_before + pep723_gc_result.size_before;
+    let total_size_after = gc_result.size_after + pep723_gc_result.size_after;
+
+    let summary = if args.dry_run {
+        let would_remove_count = gc_result.would_remove.len()
+            + pep723_gc_result.would_remove.len()
+            + pypi_cache_gc.would_remove.len();
+        if would_remove_count == 0 {
+            format!(
+                "Cache is within limits ({} used)",
+                format_size(total_size_before)
+            )
+        } else {
+            format!(
+                "Would free {} ({} files/envs)",
+                format_size(total_freed),
+                would_remove_count
+            )
+        }
+    } else if total_removed == 0 {
+        format!(
+            "Cache is within limits ({} used)",
+            format_size(total_size_after)
+        )
+    } else {
+        format!(
+            "Freed {} ({} files/envs removed)",
+            format_size(total_freed),
+            total_removed
+        )
+    };
+
+    let json_detail = json!({
+        "freed_bytes": total_freed,
+        "freed_human": format_size(total_freed),
+        "files_removed": gc_result.files_removed,
+        "envs_removed": pep723_gc_result.envs_removed,
+        "size_before": total_size_before,
+        "size_before_human": format_size(total_size_before),
+        "size_after": total_size_after,
+        "size_after_human": format_size(total_size_after),
+        "dry_run": args.dry_run,
+        "max_size": args.max_size,
+        "would_remove": gc_result.would_remove.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        "would_remove_pep723_envs": pep723_gc_result.would_remove,
+        "cache_root": cache.root().display().to_string(),
+        "pep723_cache": {
+            "freed_bytes": pep723_gc_result.freed_bytes,
+            "envs_removed": pep723_gc_result.envs_removed,
+            "size_before": pep723_gc_result.size_before,
+            "size_after": pep723_gc_result.size_after,
+        },
+        "pypi_cache": {
+            "path": crate::pypi::pypi_cache_dir().map(|p| p.display().to_string()),
+            "freed_bytes": pypi_cache_gc.freed_bytes,
+            "files_removed": pypi_cache_gc.files_removed,
+            "would_remove": pypi_cache_gc.would_remove,
+        },
+    });
+
+    Ok(RenderDetail::with_json(summary, json_detail))
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,7 +26,6 @@ use crate::schema::{
     Diagnostic, DiagnosticLevel, Event, EventCollector, EventType, JsonEnvelope, Status,
 };
 use crate::self_update::apply_update_for_asset;
-use crate::support_bundle::{BundleContext, BundleReport, build_support_bundle, upload_bundle};
 use crate::wheel_cache::WheelCache;
 use crate::workspace::Workspace;
 use color_eyre::eyre::{Result, eyre};
@@ -47,6 +46,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+mod maintenance;
 mod test;
 mod tooling;
 
@@ -498,7 +498,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
         }
         Commands::Doctor(args) => {
             collector.info("Running environment diagnostics");
-            let detail = run_doctor(args, &mut collector);
+            let detail = maintenance::run_doctor(args, &mut collector);
             ("doctor".to_string(), detail)
         }
         Commands::Mcp(cmd) => match cmd {
@@ -544,7 +544,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
         },
         Commands::Gc(args) => {
             collector.event(EventType::CacheHit); // Reuse cache event
-            let result = run_gc(args, &mut collector);
+            let result = maintenance::run_gc(args, &mut collector);
             match result {
                 Ok(detail) => ("gc".to_string(), detail),
                 Err(e) => {
@@ -1088,236 +1088,6 @@ fn run_telemetry(cmd: &TelemetryCommands) -> Result<RenderDetail> {
             ))
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// pybun doctor
-// ---------------------------------------------------------------------------
-
-fn run_doctor(args: &crate::cli::DoctorArgs, collector: &mut EventCollector) -> RenderDetail {
-    let mut checks: Vec<Value> = Vec::new();
-    let mut all_ok = true;
-    let mut bundle_report: Option<BundleReport> = None;
-
-    // Check pybun binary
-    if let Ok(exe) = std::env::current_exe() {
-        checks.push(json!({
-            "name": "pybun_binary",
-            "status": "ok",
-            "path": exe.display().to_string(),
-        }));
-    }
-
-    // Check Python availability
-    let working_dir = std::env::current_dir().unwrap_or_default();
-    match find_python_env(&working_dir) {
-        Ok(env) => {
-            checks.push(json!({
-                "name": "python",
-                "status": "ok",
-                "message": format!("Python found at {}", env.python_path.display()),
-                "source": format!("{}", env.source),
-                "version": env.version,
-            }));
-            collector.info(format!("Python found: {}", env.python_path.display()));
-        }
-        Err(e) => {
-            checks.push(json!({
-                "name": "python",
-                "status": "error",
-                "message": format!("Python not found: {}", e),
-            }));
-            collector.warning(format!("Python not found: {}", e));
-            all_ok = false;
-        }
-    }
-
-    // Check cache directory
-    match crate::cache::Cache::new() {
-        Ok(cache) => {
-            let cache_dir = cache.root();
-            checks.push(json!({
-                "name": "cache",
-                "status": "ok",
-                "message": format!("Cache directory: {}", cache_dir.display()),
-                "path": cache_dir.display().to_string(),
-            }));
-        }
-        Err(e) => {
-            checks.push(json!({
-                "name": "cache",
-                "status": "error",
-                "message": format!("Cache initialization failed: {}", e),
-            }));
-            collector.warning(format!("Cache initialization failed: {}", e));
-            all_ok = false;
-        }
-    }
-
-    // Check PyPI metadata cache directory (separate from the main cache
-    // root above - see issue #202). Flag stale entries written by
-    // incompatible older pybun versions.
-    if let Some(pypi_cache_dir) = crate::pypi::pypi_cache_dir() {
-        let stats = crate::pypi::pypi_cache_stats(&pypi_cache_dir);
-        let status = if stats.stale_count > 0 { "info" } else { "ok" };
-        checks.push(json!({
-            "name": "pypi_cache",
-            "status": status,
-            "message": format!(
-                "PyPI metadata cache: {} ({} entries, {} stale)",
-                pypi_cache_dir.display(),
-                stats.entry_count,
-                stats.stale_count,
-            ),
-            "path": pypi_cache_dir.display().to_string(),
-            "entry_count": stats.entry_count,
-            "total_bytes": stats.total_bytes,
-            "stale_count": stats.stale_count,
-        }));
-        if stats.stale_count > 0 {
-            collector.info(format!(
-                "{} stale PyPI cache entries found in {} - run `pybun gc` to remove them",
-                stats.stale_count,
-                pypi_cache_dir.display(),
-            ));
-        }
-    }
-
-    // Check for pyproject.toml
-    match Project::discover(&working_dir) {
-        Ok(project) => {
-            checks.push(json!({
-                "name": "project",
-                "status": "ok",
-                "message": format!("Project found at {}", project.path().display()),
-                "path": project.path().display().to_string(),
-                "dependencies": project.dependencies(),
-            }));
-        }
-        Err(_) => {
-            checks.push(json!({
-                "name": "project",
-                "status": "info",
-                "message": "No pyproject.toml found in current directory",
-            }));
-            collector.info("No pyproject.toml found");
-        }
-    }
-
-    let status = if all_ok { "healthy" } else { "issues_found" };
-    let summary = if all_ok {
-        "All checks passed".to_string()
-    } else {
-        "Some issues found".to_string()
-    };
-
-    if args.verbose {
-        collector.info("Verbose diagnostics enabled");
-    }
-
-    if args.bundle.is_some() || args.upload {
-        let trace_id = collector.trace_id().map(|value| value.to_string());
-        let context = BundleContext {
-            checks: checks.clone(),
-            verbose_logs: args.verbose,
-            trace_id,
-            command: "pybun doctor".to_string(),
-        };
-
-        let mut temp_bundle: Option<tempfile::TempDir> = None;
-        let bundle_path = if let Some(path) = args.bundle.clone() {
-            path
-        } else if let Ok(temp) = tempfile::TempDir::new() {
-            let path = temp.path().join("bundle");
-            temp_bundle = Some(temp);
-            path
-        } else {
-            std::env::temp_dir().join("pybun-support-bundle")
-        };
-
-        match build_support_bundle(&bundle_path, &context) {
-            Ok(collection) => {
-                let mut upload_outcome = None;
-                let mut bundle_path_out = args.bundle.clone();
-
-                if args.upload {
-                    let upload_url = args
-                        .upload_url
-                        .clone()
-                        .or_else(|| std::env::var("PYBUN_SUPPORT_UPLOAD_URL").ok());
-                    match upload_url {
-                        Some(url) => {
-                            let outcome = upload_bundle(&collection, &url);
-                            if outcome.status != "uploaded"
-                                && bundle_path_out.is_none()
-                                && let Some(temp) = temp_bundle.take()
-                            {
-                                let _ = temp.keep();
-                                bundle_path_out = Some(collection.path.clone());
-                            }
-                            upload_outcome = Some(outcome);
-                        }
-                        None => {
-                            upload_outcome = Some(crate::support_bundle::UploadOutcome {
-                                url: "".to_string(),
-                                status: "failed".to_string(),
-                                http_status: None,
-                                error: Some("upload endpoint not configured".to_string()),
-                            });
-                            if bundle_path_out.is_none()
-                                && let Some(temp) = temp_bundle.take()
-                            {
-                                let _ = temp.keep();
-                                bundle_path_out = Some(collection.path.clone());
-                            }
-                        }
-                    }
-                }
-
-                bundle_report = Some(BundleReport {
-                    bundle_path: bundle_path_out,
-                    files: collection.files,
-                    redactions: collection.redactions,
-                    logs_included: collection.logs_included,
-                    upload: upload_outcome,
-                });
-            }
-            Err(err) => {
-                collector.error_with_code(
-                    "E_DOCTOR_BUNDLE_FAILED",
-                    format!("Support bundle failed: {:?}", err),
-                    "Check that the bundle output path (or system temp directory) is writable, then re-run `pybun doctor --bundle <path>`.",
-                );
-                return RenderDetail::error(
-                    "Support bundle failed".to_string(),
-                    json!({
-                        "status": status,
-                        "checks": checks,
-                        "verbose": args.verbose,
-                        "bundle_error": format!("{:?}", err),
-                    }),
-                );
-            }
-        }
-    }
-
-    let mut detail = json!({
-        "status": status,
-        "checks": checks,
-        "verbose": args.verbose,
-    });
-
-    if let Some(bundle) = &bundle_report {
-        detail["bundle"] = bundle.to_json();
-    }
-
-    let summary = if bundle_report.is_some() {
-        format!("{}. Support bundle captured", summary)
-    } else {
-        summary
-    };
-
-    RenderDetail::with_json(summary, detail)
 }
 
 /// Resolve dependency specifiers scoped by `--member` (optionally narrowed by
@@ -3825,7 +3595,7 @@ fn find_python_interpreter() -> Result<(String, EnvSource)> {
 // pybun python
 // ---------------------------------------------------------------------------
 
-use crate::cache::{Cache, format_size, parse_size};
+use crate::cache::Cache;
 use crate::runtime::{RuntimeManager, supported_versions};
 
 fn handle_python_command(
@@ -4360,114 +4130,6 @@ fn release_url_for_version(version: &str) -> String {
         "https://github.com/VOID-TECHNOLOGY-INC/PyBun/releases/tag/v{}",
         trimmed
     )
-}
-
-// ---------------------------------------------------------------------------
-// pybun gc (garbage collection)
-// ---------------------------------------------------------------------------
-
-fn run_gc(args: &crate::cli::GcArgs, collector: &mut EventCollector) -> Result<RenderDetail> {
-    let cache = Cache::new().map_err(|e| eyre!("failed to initialize cache: {}", e))?;
-
-    // Parse max size if provided
-    let max_bytes = if let Some(size_str) = &args.max_size {
-        Some(parse_size(size_str).map_err(|e| eyre!("invalid size format: {}", e))?)
-    } else {
-        None
-    };
-
-    collector.info(format!("Running GC on cache at {}", cache.root().display()));
-
-    // Ensure cache directories exist
-    cache
-        .ensure_dirs()
-        .map_err(|e| eyre!("failed to ensure cache dirs: {}", e))?;
-
-    // Run garbage collection on packages/build cache
-    let gc_result = cache
-        .gc(max_bytes, args.dry_run)
-        .map_err(|e| eyre!("GC failed: {}", e))?;
-
-    // Also run GC on PEP 723 venv cache
-    let pep723_cache =
-        Pep723Cache::new().map_err(|e| eyre!("failed to initialize pep723 cache: {}", e))?;
-    let pep723_gc_result = pep723_cache
-        .gc(max_bytes, args.dry_run)
-        .map_err(|e| eyre!("PEP 723 GC failed: {}", e))?;
-
-    // Remove stale/corrupt PyPI metadata cache entries (see issue #202).
-    // This directory is separate from `cache.root()` and is not covered by
-    // `cache.gc()` above.
-    let pypi_cache_gc = crate::pypi::pypi_cache_dir()
-        .map(|dir| crate::pypi::gc_stale_pypi_cache(&dir, args.dry_run))
-        .unwrap_or_default();
-
-    // Combine results
-    let total_freed =
-        gc_result.freed_bytes + pep723_gc_result.freed_bytes + pypi_cache_gc.freed_bytes;
-    let total_removed =
-        gc_result.files_removed + pep723_gc_result.envs_removed + pypi_cache_gc.files_removed;
-    let total_size_before = gc_result.size_before + pep723_gc_result.size_before;
-    let total_size_after = gc_result.size_after + pep723_gc_result.size_after;
-
-    let summary = if args.dry_run {
-        let would_remove_count = gc_result.would_remove.len()
-            + pep723_gc_result.would_remove.len()
-            + pypi_cache_gc.would_remove.len();
-        if would_remove_count == 0 {
-            format!(
-                "Cache is within limits ({} used)",
-                format_size(total_size_before)
-            )
-        } else {
-            format!(
-                "Would free {} ({} files/envs)",
-                format_size(total_freed),
-                would_remove_count
-            )
-        }
-    } else if total_removed == 0 {
-        format!(
-            "Cache is within limits ({} used)",
-            format_size(total_size_after)
-        )
-    } else {
-        format!(
-            "Freed {} ({} files/envs removed)",
-            format_size(total_freed),
-            total_removed
-        )
-    };
-
-    let json_detail = json!({
-        "freed_bytes": total_freed,
-        "freed_human": format_size(total_freed),
-        "files_removed": gc_result.files_removed,
-        "envs_removed": pep723_gc_result.envs_removed,
-        "size_before": total_size_before,
-        "size_before_human": format_size(total_size_before),
-        "size_after": total_size_after,
-        "size_after_human": format_size(total_size_after),
-        "dry_run": args.dry_run,
-        "max_size": args.max_size,
-        "would_remove": gc_result.would_remove.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
-        "would_remove_pep723_envs": pep723_gc_result.would_remove,
-        "cache_root": cache.root().display().to_string(),
-        "pep723_cache": {
-            "freed_bytes": pep723_gc_result.freed_bytes,
-            "envs_removed": pep723_gc_result.envs_removed,
-            "size_before": pep723_gc_result.size_before,
-            "size_after": pep723_gc_result.size_after,
-        },
-        "pypi_cache": {
-            "path": crate::pypi::pypi_cache_dir().map(|p| p.display().to_string()),
-            "freed_bytes": pypi_cache_gc.freed_bytes,
-            "files_removed": pypi_cache_gc.files_removed,
-            "would_remove": pypi_cache_gc.would_remove,
-        },
-    });
-
-    Ok(RenderDetail::with_json(summary, json_detail))
 }
 
 fn python_which(args: &crate::cli::PythonWhichArgs) -> Result<(String, RenderDetail)> {


### PR DESCRIPTION
## Description
Extracts `pybun doctor` and `pybun gc` command implementations from `src/commands/mod.rs` into `src/commands/maintenance.rs`.

The dispatcher now calls `maintenance::run_doctor(...)` and `maintenance::run_gc(...)`; command output, JSON detail, diagnostics, and behavior are intended to remain unchanged.

## Motivation and Context
Continues the incremental `commands` module split tracked in Issue #186. This moves another cohesive command domain out of the large dispatcher and reduces `src/commands/mod.rs` from 5241 lines to 4903 lines.

Fixes #186

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/Build changes

## How Has This Been Tested?

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manually tested on macOS

Commands run:

- `cargo check`
- `cargo fmt -- --check`
- `just lint`
- `cargo test --test gc`
- `cargo test --test support_bundle`
- `cargo test --test self_update doctor`
- `cargo test`
- `cargo audit`

## Checklist

- [x] My code follows the code style of this project (`cargo fmt`)
- [x] My code passes all lint checks (`cargo clippy`)
- [x] All tests pass (`cargo test`)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass

## Screenshots (if applicable)

N/A

## Additional Notes

No new tests were added because this is a pure code movement. Existing `gc`, `doctor`, support bundle, MCP, JSON schema, E2E, and full-suite coverage were used as regression coverage.
