### PR TITLE
chore(ci): add Dependabot automation (Issue #188)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -128,6 +128,11 @@
   - Current: `rustls-webpki` を `Cargo.lock` で `0.103.13` に固定（RUSTSEC-2026-0104/0098/0099/0049 をクリア）。`Cargo.toml` に `rustls-webpki = { version = ">=0.103.13", optional = true }` を追加してバージョン floor を明示。`tests/security_features.rs` に `rustls_webpki_version_is_at_least_patched_floor` テストを追加（Cargo.lock を parse してバージョンを検証するリグレッションガード）。
   - Tests: `rustls_webpki_version_is_at_least_patched_floor` — Cargo.lock の `rustls-webpki` バージョンが `>= 0.103.13` であることをアサート。`cargo audit` exit 0 確認。`cargo clippy --all-targets --all-features -- -D warnings` 0 エラー。
 
+- [DONE] PR-CI1: Dependabot dependency update automation (Issue #188)
+  - Goal: Cargo / Python packaging / GitHub Actions の依存更新を手動追跡から週次の自動PRへ移し、`cargo audit` / `cargo deny` が失敗する前にパッチ更新を取り込めるようにする。
+  - Current: `.github/dependabot.yml` を追加し、`cargo` / `pip` / `github-actions` の3 ecosystemを `directory: "/"` で監視。各更新は weekly schedule、`open-pull-requests-limit: 5`、minor/patch grouping を設定し、更新PRのノイズを抑えながらセキュリティ・パッチ更新を継続的に拾える構成にした。
+  - Tests: `tests/dependabot_config.rs` を追加し、Dependabot設定が3 ecosystemを含むこと、weekly schedule、open PR上限、minor/patch grouping を持つことを検証。Red確認後、`cargo test --test dependabot_config` がパス。`ruby -e 'require "yaml"; ...'` で `.github/dependabot.yml` をYAMLとして読み込み、3 ecosystem が解決されることも確認。
+
 - [DONE] PR-UX1: `pybun init` non-TTY actionable error (Issue #133)
   - Goal: non-TTY 環境で `pybun init`（`--yes` なし）を実行した際、"IO error: not a terminal" の代わりに `--yes` フラグを案内する actionable diagnostic を返す。
   - Current: `init_project()` に `&mut EventCollector` を追加し、stdin が TTY でない場合は `E_INIT_NOT_INTERACTIVE` diagnostic（`suggestion` フィールドに `pybun init --yes` 案内）を push してから早期 return。テキストモードの stderr にも `--yes` を含むメッセージを出力。

--- a/tests/dependabot_config.rs
+++ b/tests/dependabot_config.rs
@@ -1,0 +1,36 @@
+use std::fs;
+
+fn dependabot_config() -> String {
+    fs::read_to_string(".github/dependabot.yml")
+        .expect("Dependabot config should exist at .github/dependabot.yml")
+}
+
+#[test]
+fn dependabot_config_covers_project_dependency_ecosystems() {
+    let config = dependabot_config();
+
+    for ecosystem in ["cargo", "pip", "github-actions"] {
+        assert!(
+            config.contains(&format!("package-ecosystem: \"{ecosystem}\"")),
+            "Dependabot config should include {ecosystem} updates"
+        );
+    }
+}
+
+#[test]
+fn dependabot_config_limits_noise_and_groups_patch_updates() {
+    let config = dependabot_config();
+
+    assert!(
+        config.contains("open-pull-requests-limit: 5"),
+        "Dependabot should cap concurrent update PRs"
+    );
+    assert!(
+        config.contains("interval: \"weekly\""),
+        "Dependabot should run weekly"
+    );
+    assert!(
+        config.contains("patterns:\n          - \"*\""),
+        "Dependabot should group minor and patch updates"
+    );
+}


### PR DESCRIPTION
Closes #188

## Summary
- add `.github/dependabot.yml` for Cargo, Python packaging, and GitHub Actions updates
- configure weekly minor/patch grouping with an open PR cap to reduce update noise
- document the completed issue track in `docs/PLAN.md`

## Test plan
- [x] `cargo test --test dependabot_config`
- [x] `ruby -e 'require "yaml"; cfg = YAML.load_file(".github/dependabot.yml"); raise "version" unless cfg["version"] == 2; updates = cfg.fetch("updates"); raise "updates" unless updates.is_a?(Array) && updates.size == 3; puts updates.map { |u| u.fetch("package-ecosystem") }.join(",")'`\n- [x] `cargo fmt -- --check`\n- [x] `just lint`\n- [x] `cargo test`\n- [x] `cargo audit`\n- [x] `cargo deny check licenses`\n- [x] `python3 -m unittest discover -s pybun/tests -v`\n- [x] `uvx --python 3.12 pip-audit .`