### PR TITLE
fix(run): bypass uv backend when PyBun script lockfile exists (Issue #234)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2509,7 +2509,15 @@ async fn run_script(
             }
         }
 
-        if !dry_run && !no_cache && !args.sandbox && pep723_backend_setting != "pybun" {
+        // When a PyBun binary lockfile exists next to the script, bypass uv entirely.
+        // uv would detect the .lock file, attempt to parse it as TOML, and crash
+        // because the file uses PyBun's binary format (Issue #234).
+        if !dry_run
+            && !no_cache
+            && !args.sandbox
+            && pep723_backend_setting != "pybun"
+            && script_lock.is_none()
+        {
             if let Some(uv_path) = crate::env::find_uv_executable() {
                 let (base_python, env_source) = find_python_interpreter()?;
                 eprintln!("info: using Python from {} for uv run backend", env_source);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2512,6 +2512,12 @@ async fn run_script(
         // When a PyBun binary lockfile exists next to the script, bypass uv entirely.
         // uv would detect the .lock file, attempt to parse it as TOML, and crash
         // because the file uses PyBun's binary format (Issue #234).
+        if pep723_backend_setting == "uv" && script_lock.is_some() {
+            eprintln!(
+                "warning: PYBUN_PEP723_BACKEND=uv is set but a PyBun script lockfile exists; \
+                 uv cannot parse the binary .lock file — falling back to the pybun backend"
+            );
+        }
         if !dry_run
             && !no_cache
             && !args.sandbox

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -773,3 +773,116 @@ fn run_with_dev_profile_no_lazy_imports() {
         "expected no LazyFinder in sys.meta_path for dev profile, got: {stdout}"
     );
 }
+
+// =============================================================================
+// Issue #234: PEP 723 script lockfile collides with uv run backend
+// When a PyBun script lockfile (<script>.lock) exists, the uv backend must be
+// bypassed to prevent uv from attempting to parse the binary lockfile as TOML.
+// =============================================================================
+
+#[test]
+fn run_pep723_with_script_lock_bypasses_uv_backend() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("locked.py");
+    let content = r#"# /// script
+# dependencies = ["cowsay"]
+# ///
+print("hello locked")
+"#;
+    fs::write(&script, content).unwrap();
+
+    // Create a fake uv that would fail if invoked with our binary lockfile.
+    let uv_dir = temp.path().join("uv-bin");
+    fs::create_dir_all(&uv_dir).unwrap();
+    let uv_path = if cfg!(windows) {
+        uv_dir.join("uv.bat")
+    } else {
+        uv_dir.join("uv")
+    };
+
+    // This fake uv writes a marker to stderr so we can detect if it was called.
+    if cfg!(windows) {
+        fs::write(
+            &uv_path,
+            "@echo off\r\necho UV_WAS_CALLED_UNEXPECTEDLY 1>&2\r\nexit /b 1\r\n",
+        )
+        .unwrap();
+    } else {
+        fs::write(
+            &uv_path,
+            "#!/usr/bin/env sh\necho UV_WAS_CALLED_UNEXPECTEDLY >&2\nexit 1\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&uv_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&uv_path, perms).unwrap();
+        }
+    }
+
+    let mut path_entries = vec![uv_dir.clone()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        path_entries.extend(std::env::split_paths(&existing));
+    }
+    let new_path = std::env::join_paths(path_entries).unwrap();
+
+    // Create a PyBun script lockfile next to the script (binary format).
+    // We use `pybun lock --script` with a local index to generate a real lockfile.
+    let index_path = std::path::PathBuf::from("tests/fixtures/index.json");
+    let lock_script_content = r#"# /// script
+# dependencies = ["app==1.0.0"]
+# ///
+print("hello locked")
+"#;
+    // Rewrite the script to use our indexed dependency so lock succeeds.
+    fs::write(&script, lock_script_content).unwrap();
+
+    bin()
+        .env("PATH", &new_path)
+        .args([
+            "--format=json",
+            "lock",
+            "--script",
+            script.to_str().unwrap(),
+            "--index",
+            index_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock_path = {
+        let mut p = script.as_os_str().to_os_string();
+        p.push(".lock");
+        std::path::PathBuf::from(p)
+    };
+    assert!(lock_path.exists(), "lockfile must exist before running");
+
+    // Now run the script. Even though fake uv is on PATH and PYBUN_PEP723_BACKEND=auto,
+    // pybun must NOT delegate to uv because a PyBun lockfile is present.
+    // Use dry-run to avoid actually resolving/installing packages.
+    let output = bin()
+        .env("PYBUN_PEP723_DRY_RUN", "1")
+        .env("PATH", new_path)
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("UV_WAS_CALLED_UNEXPECTEDLY"),
+        "uv backend must not be invoked when a PyBun script lockfile exists, stderr: {stderr}"
+    );
+
+    let value: Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|_| panic!("valid JSON, got: {stdout}"));
+    assert_eq!(value["status"], "ok");
+    // Backend must be "pybun" (built-in), not "uv_run".
+    assert_ne!(
+        value["detail"]["pep723_backend"], "uv_run",
+        "pep723_backend must not be uv_run when a script lockfile exists, output: {stdout}"
+    );
+}

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -784,14 +784,18 @@ fn run_with_dev_profile_no_lazy_imports() {
 fn run_pep723_with_script_lock_bypasses_uv_backend() {
     let temp = tempdir().unwrap();
     let script = temp.path().join("locked.py");
-    let content = r#"# /// script
-# dependencies = ["cowsay"]
+
+    // Script with a dep from the fixture index so the lock step succeeds.
+    let lock_script_content = r#"# /// script
+# dependencies = ["app==1.0.0"]
 # ///
 print("hello locked")
 "#;
-    fs::write(&script, content).unwrap();
+    fs::write(&script, lock_script_content).unwrap();
 
-    // Create a fake uv that would fail if invoked with our binary lockfile.
+    // Fake uv that fails only when called as "uv run" (the collision case).
+    // It must succeed for "uv pip install" so the pybun backend can use it for
+    // fast package installation after bypassing the uv run backend.
     let uv_dir = temp.path().join("uv-bin");
     fs::create_dir_all(&uv_dir).unwrap();
     let uv_path = if cfg!(windows) {
@@ -800,17 +804,16 @@ print("hello locked")
         uv_dir.join("uv")
     };
 
-    // This fake uv writes a marker to stderr so we can detect if it was called.
     if cfg!(windows) {
         fs::write(
             &uv_path,
-            "@echo off\r\necho UV_WAS_CALLED_UNEXPECTEDLY 1>&2\r\nexit /b 1\r\n",
+            "@echo off\r\nif \"%1\"==\"run\" (\r\n  echo UV_RUN_WAS_CALLED_UNEXPECTEDLY 1>&2\r\n  exit /b 1\r\n)\r\nexit /b 0\r\n",
         )
         .unwrap();
     } else {
         fs::write(
             &uv_path,
-            "#!/usr/bin/env sh\necho UV_WAS_CALLED_UNEXPECTEDLY >&2\nexit 1\n",
+            "#!/usr/bin/env sh\nif [ \"$1\" = \"run\" ]; then\n  echo UV_RUN_WAS_CALLED_UNEXPECTEDLY >&2\n  exit 1\nfi\nexit 0\n",
         )
         .unwrap();
         #[cfg(unix)]
@@ -828,17 +831,8 @@ print("hello locked")
     }
     let new_path = std::env::join_paths(path_entries).unwrap();
 
-    // Create a PyBun script lockfile next to the script (binary format).
-    // We use `pybun lock --script` with a local index to generate a real lockfile.
+    // Create the PyBun binary lockfile next to the script.
     let index_path = std::path::PathBuf::from("tests/fixtures/index.json");
-    let lock_script_content = r#"# /// script
-# dependencies = ["app==1.0.0"]
-# ///
-print("hello locked")
-"#;
-    // Rewrite the script to use our indexed dependency so lock succeeds.
-    fs::write(&script, lock_script_content).unwrap();
-
     bin()
         .env("PATH", &new_path)
         .args([
@@ -859,12 +853,11 @@ print("hello locked")
     };
     assert!(lock_path.exists(), "lockfile must exist before running");
 
-    // Now run the script. Even though fake uv is on PATH and PYBUN_PEP723_BACKEND=auto,
-    // pybun must NOT delegate to uv because a PyBun lockfile is present.
-    // Use dry-run to avoid actually resolving/installing packages.
+    // Run the script WITHOUT dry-run so the uv-selection path is fully exercised.
+    // With the fix, pybun must choose the built-in backend (lockfile present) and
+    // must NOT call "uv run" even though fake uv is on PATH with PYBUN_PEP723_BACKEND=auto.
     let output = bin()
-        .env("PYBUN_PEP723_DRY_RUN", "1")
-        .env("PATH", new_path)
+        .env("PATH", &new_path)
         .args(["--format=json", "run", script.to_str().unwrap()])
         .output()
         .expect("run pybun");
@@ -873,16 +866,107 @@ print("hello locked")
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
-        !stderr.contains("UV_WAS_CALLED_UNEXPECTEDLY"),
-        "uv backend must not be invoked when a PyBun script lockfile exists, stderr: {stderr}"
+        !stderr.contains("UV_RUN_WAS_CALLED_UNEXPECTEDLY"),
+        "uv run must not be invoked when a PyBun script lockfile exists, stderr: {stderr}"
     );
 
     let value: Value =
         serde_json::from_str(&stdout).unwrap_or_else(|_| panic!("valid JSON, got: {stdout}"));
-    assert_eq!(value["status"], "ok");
-    // Backend must be "pybun" (built-in), not "uv_run".
+    assert_eq!(
+        value["status"], "ok",
+        "run should succeed; stdout: {stdout}"
+    );
     assert_ne!(
         value["detail"]["pep723_backend"], "uv_run",
-        "pep723_backend must not be uv_run when a script lockfile exists, output: {stdout}"
+        "pep723_backend must not be uv_run when a script lockfile exists; output: {stdout}"
     );
+}
+
+#[test]
+fn run_pep723_explicit_uv_backend_with_lockfile_emits_warning() {
+    // When PYBUN_PEP723_BACKEND=uv is explicitly set but a PyBun lockfile exists,
+    // pybun must warn the user and fall back to the pybun backend (Issue #234).
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("locked_explicit_uv.py");
+    let content = r#"# /// script
+# dependencies = ["app==1.0.0"]
+# ///
+print("hello explicit uv lockfile")
+"#;
+    fs::write(&script, content).unwrap();
+
+    // Fake uv: succeeds for all subcommands (install), fails only for run.
+    let uv_dir = temp.path().join("uv-bin");
+    fs::create_dir_all(&uv_dir).unwrap();
+    let uv_path = if cfg!(windows) {
+        uv_dir.join("uv.bat")
+    } else {
+        uv_dir.join("uv")
+    };
+    if cfg!(windows) {
+        fs::write(
+            &uv_path,
+            "@echo off\r\nif \"%1\"==\"run\" (\r\n  echo UV_RUN_WAS_CALLED_UNEXPECTEDLY 1>&2\r\n  exit /b 1\r\n)\r\nexit /b 0\r\n",
+        )
+        .unwrap();
+    } else {
+        fs::write(
+            &uv_path,
+            "#!/usr/bin/env sh\nif [ \"$1\" = \"run\" ]; then\n  echo UV_RUN_WAS_CALLED_UNEXPECTEDLY >&2\n  exit 1\nfi\nexit 0\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&uv_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&uv_path, perms).unwrap();
+        }
+    }
+
+    let mut path_entries = vec![uv_dir];
+    if let Some(existing) = std::env::var_os("PATH") {
+        path_entries.extend(std::env::split_paths(&existing));
+    }
+    let new_path = std::env::join_paths(path_entries).unwrap();
+
+    let index_path = std::path::PathBuf::from("tests/fixtures/index.json");
+    bin()
+        .env("PATH", &new_path)
+        .args([
+            "--format=json",
+            "lock",
+            "--script",
+            script.to_str().unwrap(),
+            "--index",
+            index_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let output = bin()
+        .env("PYBUN_PEP723_BACKEND", "uv")
+        .env("PATH", new_path)
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun with explicit uv backend and lockfile");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Must NOT invoke uv run.
+    assert!(
+        !stderr.contains("UV_RUN_WAS_CALLED_UNEXPECTEDLY"),
+        "uv run must not be called when a lockfile exists; stderr: {stderr}"
+    );
+    // Must emit a warning so the user knows their setting was overridden.
+    assert!(
+        stderr.contains("warning:") && stderr.contains("lockfile"),
+        "expected a warning about uv being bypassed due to lockfile; stderr: {stderr}"
+    );
+    // Must succeed.
+    let value: Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|_| panic!("valid JSON, got: {stdout}"));
+    assert_eq!(value["status"], "ok", "stdout: {stdout}");
+    assert_ne!(value["detail"]["pep723_backend"], "uv_run");
 }


### PR DESCRIPTION
## Summary

- When `pybun lock --script <script>.py` creates a `<script>.py.lock` in PyBun's binary (`PYBUNLK`) format and the user then runs `pybun run <script>.py`, the `uv` run backend is auto-selected if `uv` is on PATH
- `uv` detects the `.lock` file next to the script, tries to parse it as TOML, and crashes with a confusing parse error
- Fix: add `&& script_lock.is_none()` to the uv-backend selection guard in `src/commands/mod.rs:2512` so scripts with an existing PyBun lockfile always use the built-in pybun backend

## Test plan

- [x] New test `run_pep723_with_script_lock_bypasses_uv_backend` in `tests/cli_run.rs` — places a fake uv that prints a sentinel to stderr if called, creates a real script lockfile via `pybun lock --script`, then asserts uv is NOT invoked and `pep723_backend != "uv_run"`
- [x] All 34 `cli_run` tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

Closes #234