### PR TITLE
fix(cli): support multiple packages in pybun add/remove (Issue #264)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,9 +183,10 @@ pub struct LockArgs {
 
 #[derive(Args, Debug)]
 pub struct PackageArgs {
-    /// Package name (optionally with version).
-    #[arg(value_name = "PACKAGE")]
-    pub package: Option<String>,
+    /// Package name(s) (optionally with version). Multiple packages may be
+    /// given in a single invocation.
+    #[arg(value_name = "PACKAGE", required = true)]
+    pub packages: Vec<String>,
     /// Use offline mode when cache is sufficient.
     #[arg(long)]
     pub offline: bool,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -128,12 +128,16 @@ pub async fn execute(cli: Cli) -> Result<()> {
             match result {
                 Ok(AddOutcome {
                     summary,
-                    package,
-                    version,
+                    packages,
                     added_deps,
                 }) => {
                     // Chain install to ensure the environment is up-to-date
-                    collector.info(format!("Installing dependencies including {}...", package));
+                    let names = packages
+                        .iter()
+                        .map(|p| p.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    collector.info(format!("Installing dependencies including {}...", names));
 
                     let install_args = crate::cli::InstallArgs {
                         offline: args.offline,
@@ -145,6 +149,11 @@ pub async fn execute(cli: Cli) -> Result<()> {
                         group: None,
                     };
 
+                    let packages_json: Vec<serde_json::Value> = packages
+                        .iter()
+                        .map(|p| json!({ "name": p.name, "version": p.version }))
+                        .collect();
+
                     let pre_error_count = collector.error_diagnostic_count();
                     match install(&install_args, &mut collector).await {
                         Ok(_) => (
@@ -152,8 +161,9 @@ pub async fn execute(cli: Cli) -> Result<()> {
                             RenderDetail::with_json(
                                 format!("{} and installed dependencies.", summary),
                                 json!({
-                                    "package": package,
-                                    "version": version,
+                                    "package": packages.first().map(|p| p.name.clone()),
+                                    "version": packages.first().and_then(|p| p.version.clone()),
+                                    "packages": packages_json,
                                     "added_dependencies": added_deps,
                                     "installed": true,
                                 }),
@@ -162,7 +172,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
                         Err(e) => {
                             let err_msg = format!(
                                 "Added {} to pyproject.toml but failed to install: {}",
-                                package, e
+                                names, e
                             );
                             // Only push a generic fallback error if install() did not
                             // already record an error-level diagnostic (e.g. resolve errors).
@@ -178,7 +188,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
                                 RenderDetail::error(
                                     err_msg,
                                     json!({
-                                        "package": package,
+                                        "packages": packages_json,
                                         "error": e.to_string(),
                                         "installed": false,
                                     }),
@@ -208,20 +218,23 @@ pub async fn execute(cli: Cli) -> Result<()> {
         Commands::Remove(args) => {
             let result = remove_package(args);
             match result {
-                Ok(RemoveOutcome {
-                    summary,
-                    package,
-                    removed,
-                }) => (
-                    "remove".to_string(),
-                    RenderDetail::with_json(
-                        summary,
-                        json!({
-                            "package": package,
-                            "removed": removed,
-                        }),
-                    ),
-                ),
+                Ok(RemoveOutcome { summary, packages }) => {
+                    let packages_json: Vec<serde_json::Value> = packages
+                        .iter()
+                        .map(|p| json!({ "name": p.name, "removed": p.removed }))
+                        .collect();
+                    (
+                        "remove".to_string(),
+                        RenderDetail::with_json(
+                            summary,
+                            json!({
+                                "package": packages.first().map(|p| p.name.clone()),
+                                "removed": packages.first().map(|p| p.removed),
+                                "packages": packages_json,
+                            }),
+                        ),
+                    )
+                }
                 Err(e) => {
                     collector.error_with_code(
                         "E_REMOVE_FAILED",
@@ -2219,23 +2232,22 @@ fn collect_artifacts(dist_dir: &Path) -> Result<Vec<PathBuf>> {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
+struct AddedPackage {
+    name: String,
+    version: Option<String>,
+}
+
+#[derive(Debug)]
 struct AddOutcome {
     summary: String,
-    package: String,
-    version: Option<String>,
+    packages: Vec<AddedPackage>,
     added_deps: Vec<String>,
 }
 
 fn add_package(args: &crate::cli::PackageArgs) -> Result<AddOutcome> {
-    let package_spec = args
-        .package
-        .as_ref()
-        .ok_or_else(|| eyre!("package name is required"))?;
-
-    // Parse the requirement
-    let req: Requirement = package_spec
-        .parse()
-        .map_err(|e: String| eyre!("invalid package spec: {}", e))?;
+    if args.packages.is_empty() {
+        return Err(eyre!("package name is required"));
+    }
 
     // Find or create pyproject.toml
     let current_dir = std::env::current_dir()?;
@@ -2248,19 +2260,17 @@ fn add_package(args: &crate::cli::PackageArgs) -> Result<AddOutcome> {
         }
     };
 
-    // Format the dependency string
-    let dep_string = package_spec.clone();
+    let mut packages = Vec::with_capacity(args.packages.len());
+    for package_spec in &args.packages {
+        // Parse the requirement
+        let req: Requirement = package_spec
+            .parse()
+            .map_err(|e: String| eyre!("invalid package spec: {}", e))?;
 
-    // Add to pyproject.toml
-    project.add_dependency(&dep_string);
-    project.save()?;
+        // Add to pyproject.toml
+        project.add_dependency(package_spec);
 
-    let added_deps = project.dependencies();
-
-    Ok(AddOutcome {
-        summary: format!("added {} to {}", package_spec, project.path().display()),
-        package: req.name.clone(),
-        version: match req.specs.as_slice() {
+        let version = match req.specs.as_slice() {
             [crate::resolver::VersionSpec::Any] => None,
             [crate::resolver::VersionSpec::Exact(v)] => Some(v.clone()),
             specs => Some(
@@ -2270,7 +2280,23 @@ fn add_package(args: &crate::cli::PackageArgs) -> Result<AddOutcome> {
                     .collect::<Vec<_>>()
                     .join(","),
             ),
-        },
+        };
+
+        packages.push(AddedPackage {
+            name: req.name.clone(),
+            version,
+        });
+    }
+
+    project.save()?;
+    let added_deps = project.dependencies();
+
+    let package_list = args.packages.join(", ");
+    let summary = format!("added {} to {}", package_list, project.path().display());
+
+    Ok(AddOutcome {
+        summary,
+        packages,
         added_deps,
     })
 }
@@ -2280,17 +2306,21 @@ fn add_package(args: &crate::cli::PackageArgs) -> Result<AddOutcome> {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
-struct RemoveOutcome {
-    summary: String,
-    package: String,
+struct RemovedPackage {
+    name: String,
     removed: bool,
 }
 
+#[derive(Debug)]
+struct RemoveOutcome {
+    summary: String,
+    packages: Vec<RemovedPackage>,
+}
+
 fn remove_package(args: &crate::cli::PackageArgs) -> Result<RemoveOutcome> {
-    let package_name = args
-        .package
-        .as_ref()
-        .ok_or_else(|| eyre!("package name is required"))?;
+    if args.packages.is_empty() {
+        return Err(eyre!("package name is required"));
+    }
 
     // Find pyproject.toml
     let current_dir = std::env::current_dir()?;
@@ -2301,24 +2331,46 @@ fn remove_package(args: &crate::cli::PackageArgs) -> Result<RemoveOutcome> {
         )
     })?;
 
-    // Remove from pyproject.toml
-    let removed = project.remove_dependency(package_name);
+    let mut packages = Vec::with_capacity(args.packages.len());
+    let mut removed_names = Vec::new();
+    let mut not_found_names = Vec::new();
+    for package_name in &args.packages {
+        let removed = project.remove_dependency(package_name);
+        if removed {
+            removed_names.push(package_name.clone());
+        } else {
+            not_found_names.push(package_name.clone());
+        }
+        packages.push(RemovedPackage {
+            name: package_name.clone(),
+            removed,
+        });
+    }
 
-    if removed {
+    if !removed_names.is_empty() {
         project.save()?;
     }
 
-    let summary = if removed {
-        format!("removed {} from {}", package_name, project.path().display())
-    } else {
-        format!("{} was not found in dependencies", package_name)
+    let summary = match (removed_names.is_empty(), not_found_names.is_empty()) {
+        (false, true) => format!(
+            "removed {} from {}",
+            removed_names.join(", "),
+            project.path().display()
+        ),
+        (true, false) => format!(
+            "{} was not found in dependencies",
+            not_found_names.join(", ")
+        ),
+        (false, false) => format!(
+            "removed {} from {}; {} was not found in dependencies",
+            removed_names.join(", "),
+            project.path().display(),
+            not_found_names.join(", ")
+        ),
+        (true, true) => unreachable!("at least one package is always processed"),
     };
 
-    Ok(RemoveOutcome {
-        summary,
-        package: package_name.clone(),
-        removed,
-    })
+    Ok(RemoveOutcome { summary, packages })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2282,6 +2282,10 @@ fn add_package(args: &crate::cli::PackageArgs) -> Result<AddOutcome> {
             ),
         };
 
+        // A later spec for the same package name replaces the earlier one in
+        // pyproject.toml (see `Project::add_dependency`), so keep only the
+        // last occurrence here too.
+        packages.retain(|p: &AddedPackage| p.name != req.name);
         packages.push(AddedPackage {
             name: req.name.clone(),
             version,

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -216,3 +216,68 @@ dependencies = ["requests>=2.28.0"]
         .success()
         .stdout(predicate::str::contains("\"removed\":true"));
 }
+
+#[test]
+fn add_accepts_multiple_packages() {
+    if !network_enabled() {
+        eprintln!("Skipping add_accepts_multiple_packages (PYBUN_E2E_NETWORK not set)");
+        return;
+    }
+    let temp = tempdir().unwrap();
+    create_venv(temp.path());
+
+    bin()
+        .current_dir(temp.path())
+        .args(["add", "requests", "click"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("added requests, click"));
+
+    let content = fs::read_to_string(temp.path().join("pyproject.toml")).unwrap();
+    assert!(content.contains("requests"), "should contain requests");
+    assert!(content.contains("click"), "should contain click");
+}
+
+#[test]
+fn remove_accepts_multiple_packages() {
+    let temp = tempdir().unwrap();
+
+    let pyproject = r#"[project]
+name = "test-project"
+dependencies = ["requests>=2.28.0", "click>=2.0.0"]
+"#;
+    fs::write(temp.path().join("pyproject.toml"), pyproject).unwrap();
+
+    bin()
+        .current_dir(temp.path())
+        .args(["remove", "requests", "click"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("removed requests, click"));
+
+    let content = fs::read_to_string(temp.path().join("pyproject.toml")).unwrap();
+    assert!(!content.contains("requests"), "requests should be removed");
+    assert!(!content.contains("click"), "click should be removed");
+}
+
+#[test]
+fn remove_multiple_reports_partial_not_found() {
+    let temp = tempdir().unwrap();
+
+    let pyproject = r#"[project]
+name = "test-project"
+dependencies = ["requests>=2.28.0"]
+"#;
+    fs::write(temp.path().join("pyproject.toml"), pyproject).unwrap();
+
+    bin()
+        .current_dir(temp.path())
+        .args(["remove", "requests", "nonexistent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("removed requests"))
+        .stdout(predicate::str::contains("nonexistent was not found"));
+
+    let content = fs::read_to_string(temp.path().join("pyproject.toml")).unwrap();
+    assert!(!content.contains("requests"), "requests should be removed");
+}

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -238,6 +238,49 @@ fn add_accepts_multiple_packages() {
     assert!(content.contains("click"), "should contain click");
 }
 
+/// Passing the same package name twice with different version specs should
+/// keep only the last occurrence (matching what's actually persisted to
+/// pyproject.toml), both on disk and in the JSON `packages` detail.
+#[test]
+fn add_deduplicates_repeated_package_name() {
+    let temp = tempdir().unwrap();
+
+    let pyproject = r#"[project]
+name = "test-project"
+dependencies = []
+"#;
+    fs::write(temp.path().join("pyproject.toml"), pyproject).unwrap();
+
+    // No venv is created, so the chained install will fail, but pyproject.toml
+    // is saved (and the JSON `packages` detail is emitted) before that happens.
+    let output = bin()
+        .current_dir(temp.path())
+        .args(["--format=json", "add", "numpy>=1.24.0", "numpy==2.0.0"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON output");
+    let packages = json["detail"]["packages"]
+        .as_array()
+        .expect("packages array present");
+    assert_eq!(
+        packages.len(),
+        1,
+        "duplicate package name should collapse to one entry"
+    );
+    assert_eq!(packages[0]["name"], "numpy");
+    assert_eq!(packages[0]["version"], "2.0.0");
+
+    let content = fs::read_to_string(temp.path().join("pyproject.toml")).unwrap();
+    assert_eq!(
+        content.matches("numpy").count(),
+        1,
+        "pyproject.toml should list numpy only once"
+    );
+    assert!(content.contains("numpy==2.0.0"));
+}
+
 #[test]
 fn remove_accepts_multiple_packages() {
     let temp = tempdir().unwrap();

--- a/tests/snapshots/compat/help_add.txt
+++ b/tests/snapshots/compat/help_add.txt
@@ -1,9 +1,9 @@
 Add a package and update lockfile
 
-Usage: pybun add [OPTIONS] [PACKAGE]
+Usage: pybun add [OPTIONS] <PACKAGE>...
 
 Arguments:
-  [PACKAGE]  Package name (optionally with version)
+  <PACKAGE>...  Package name(s) (optionally with version). Multiple packages may be given in a single invocation
 
 Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]

--- a/tests/snapshots/compat/help_remove.txt
+++ b/tests/snapshots/compat/help_remove.txt
@@ -1,9 +1,9 @@
 Remove a package and update lockfile
 
-Usage: pybun remove [OPTIONS] [PACKAGE]
+Usage: pybun remove [OPTIONS] <PACKAGE>...
 
 Arguments:
-  [PACKAGE]  Package name (optionally with version)
+  <PACKAGE>...  Package name(s) (optionally with version). Multiple packages may be given in a single invocation
 
 Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]


### PR DESCRIPTION
Closes #264

## Summary
- `pybun add`/`pybun remove` previously accepted only a single package positional argument (`Option<String>`), so `pybun add requests rich` failed with a clap "unexpected argument" error.
- `PackageArgs.package: Option<String>` is now `PackageArgs.packages: Vec<String>` (required, at least one value), matching pip/uv/npm ergonomics.
- `add_package`/`remove_package` now loop over all provided package specs, updating `pyproject.toml` once and running a single resolve/install pass for `add`.
- JSON output keeps the existing `package`/`version`/`removed` fields (mirroring the first package) for backward compatibility, and adds a new `packages` array with per-package detail.
- `remove` reports partial success when some packages are removed and others are not found (e.g. `removed requests; nonexistent was not found in dependencies`).

## Test plan
- [x] `cargo test --test cli_add_remove` — includes new `add_accepts_multiple_packages`, `remove_accepts_multiple_packages`, `remove_multiple_reports_partial_not_found` tests
- [x] `cargo test --test json_schema`
- [x] `cargo test --test compat_snapshots` (updated `help_add.txt`/`help_remove.txt` snapshots for the new `<PACKAGE>...` usage)
- [x] `cargo test` (full suite) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt`
- [x] Manually reproduced the issue's repro steps (`pybun init -y && pybun add requests rich`) and confirmed both packages are resolved/installed in one invocation; verified `pybun remove requests rich` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)