### PR TITLE
fix(install): select wheels for the target venv's Python, not PATH (Issue #291)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1426,41 +1426,17 @@ async fn install(
         event.progress = Some(40);
     });
 
-    // Resolve the actual install target (PYBUN_ENV / PYBUN_PYTHON / project venv /
-    // system Python) *before* selecting wheels, so artifact selection matches the
-    // Python interpreter packages will actually be installed into. Selecting wheels
-    // against whatever `python3`/`python` happens to resolve on PATH (the previous
-    // behavior) can silently pick wheels for the wrong CPython ABI (Issue #291).
+    // Detect the CPython tag of the actual install target (PYBUN_ENV / PYBUN_PYTHON /
+    // project venv / system Python) *before* selecting wheels, so artifact selection
+    // matches the Python interpreter packages will actually be installed into.
+    // Selecting wheels against whatever `python3`/`python` happens to resolve on PATH
+    // (the previous behavior) can silently pick wheels for the wrong CPython ABI
+    // (Issue #291). This is read-only detection only — creating a project-local venv
+    // (and the associated system-Python safe-install-target guard) is deferred to the
+    // later "Install wheels" step below, so a resolve-only or failed install doesn't
+    // have the side effect of mutating the filesystem.
     let working_dir = std::env::current_dir()?;
-    let mut env = crate::env::find_python_env(&working_dir)?;
-
-    if matches!(env.source, crate::env::EnvSource::System) {
-        if args.system {
-            if let Some(marker) = crate::env::externally_managed_marker(&env.python_path) {
-                let message = format!(
-                    "refusing to install into externally-managed system Python (marker: {})",
-                    marker.display()
-                );
-                collector.error_with_code(
-                    "E_INSTALL_EXTERNALLY_MANAGED",
-                    message.clone(),
-                    "This interpreter is marked externally-managed (PEP 668). Create a virtual environment (e.g. `python3 -m venv .venv`) and re-run, or install with a non-managed interpreter.",
-                );
-                return Err(eyre!(message));
-            }
-
-            let warning =
-                "warning: PyBun is installing into system Python (--system was specified).";
-            eprintln!("{}", warning);
-            collector.warning(warning.to_string());
-        } else {
-            collector.info(
-                "No virtual environment found; creating project-local environment at .pybun/venv"
-                    .to_string(),
-            );
-            env = crate::env::create_project_venv(&working_dir)?;
-        }
-    }
+    let target_env_probe = crate::env::find_python_env(&working_dir)?;
 
     // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
     // bypassing interpreter detection entirely.
@@ -1468,7 +1444,7 @@ async fn install(
         .ok()
         .filter(|v| !v.trim().is_empty())
         .or_else(|| {
-            get_python_version(&env.python_path)
+            get_python_version(&target_env_probe.python_path)
                 .ok()
                 .and_then(|v| python_version_to_cp_tag(&v))
         })
@@ -1621,8 +1597,40 @@ async fn install(
             event.progress = Some(70);
         });
 
-        // Install wheels into the target environment resolved earlier (before wheel
-        // selection), so the interpreter we install into matches the wheels we picked.
+        // Install wheels. Re-resolve the target environment now that we know there is
+        // something to install; this is where venv creation / the system-Python guard
+        // actually mutates the filesystem (deferred from the cp-tag detection above so
+        // a resolve-only or failed install has no such side effect).
+        let mut env = crate::env::find_python_env(&working_dir)?;
+
+        if matches!(env.source, crate::env::EnvSource::System) {
+            if args.system {
+                if let Some(marker) = crate::env::externally_managed_marker(&env.python_path) {
+                    let message = format!(
+                        "refusing to install into externally-managed system Python (marker: {})",
+                        marker.display()
+                    );
+                    collector.error_with_code(
+                        "E_INSTALL_EXTERNALLY_MANAGED",
+                        message.clone(),
+                        "This interpreter is marked externally-managed (PEP 668). Create a virtual environment (e.g. `python3 -m venv .venv`) and re-run, or install with a non-managed interpreter.",
+                    );
+                    return Err(eyre!(message));
+                }
+
+                let warning =
+                    "warning: PyBun is installing into system Python (--system was specified).";
+                eprintln!("{}", warning);
+                collector.warning(warning.to_string());
+            } else {
+                collector.info(
+                    "No virtual environment found; creating project-local environment at .pybun/venv"
+                        .to_string(),
+                );
+                env = crate::env::create_project_venv(&working_dir)?;
+            }
+        }
+
         collector.info(format!(
             "Installing packages into {}",
             env.python_path.display()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::resolver::parse_version_relaxed;
 use crate::resolver::{
     PackageIndex, Requirement, compare_versions, cp_tag_to_dotted_version, current_platform_tags,
     is_wheel_python_compatible, parse_wheel_tags, python_version_to_cp_tag, resolve,
-    select_artifact_for_platform,
+    select_artifact_for_platform, select_artifact_for_platform_with_cp,
 };
 use crate::sandbox;
 use crate::sbom;
@@ -1426,6 +1426,54 @@ async fn install(
         event.progress = Some(40);
     });
 
+    // Resolve the actual install target (PYBUN_ENV / PYBUN_PYTHON / project venv /
+    // system Python) *before* selecting wheels, so artifact selection matches the
+    // Python interpreter packages will actually be installed into. Selecting wheels
+    // against whatever `python3`/`python` happens to resolve on PATH (the previous
+    // behavior) can silently pick wheels for the wrong CPython ABI (Issue #291).
+    let working_dir = std::env::current_dir()?;
+    let mut env = crate::env::find_python_env(&working_dir)?;
+
+    if matches!(env.source, crate::env::EnvSource::System) {
+        if args.system {
+            if let Some(marker) = crate::env::externally_managed_marker(&env.python_path) {
+                let message = format!(
+                    "refusing to install into externally-managed system Python (marker: {})",
+                    marker.display()
+                );
+                collector.error_with_code(
+                    "E_INSTALL_EXTERNALLY_MANAGED",
+                    message.clone(),
+                    "This interpreter is marked externally-managed (PEP 668). Create a virtual environment (e.g. `python3 -m venv .venv`) and re-run, or install with a non-managed interpreter.",
+                );
+                return Err(eyre!(message));
+            }
+
+            let warning =
+                "warning: PyBun is installing into system Python (--system was specified).";
+            eprintln!("{}", warning);
+            collector.warning(warning.to_string());
+        } else {
+            collector.info(
+                "No virtual environment found; creating project-local environment at .pybun/venv"
+                    .to_string(),
+            );
+            env = crate::env::create_project_venv(&working_dir)?;
+        }
+    }
+
+    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
+    // bypassing interpreter detection entirely.
+    let active_cp_tag = std::env::var("PYBUN_FORCE_CP_TAG")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            get_python_version(&env.python_path)
+                .ok()
+                .and_then(|v| python_version_to_cp_tag(&v))
+        })
+        .unwrap_or_else(|| "cp311".to_string());
+
     let platform_tags = current_platform_tags();
     let mut lock = Lockfile::new(
         vec!["3.11".into()],
@@ -1438,7 +1486,7 @@ async fn install(
     );
     let mut verified_artifacts = Vec::new();
     for pkg in resolution.packages.values() {
-        let selection = select_artifact_for_platform(pkg, &platform_tags);
+        let selection = select_artifact_for_platform_with_cp(pkg, &platform_tags, &active_cp_tag);
         if selection.from_source {
             let message = format!(
                 "no compatible pre-built wheel for {} {} on {}; source distributions are not supported for install",
@@ -1480,7 +1528,7 @@ async fn install(
     let mut download_items = Vec::new();
     let mut sdist_only_packages = Vec::new();
     for pkg in resolution.packages.values() {
-        let selection = select_artifact_for_platform(pkg, &platform_tags);
+        let selection = select_artifact_for_platform_with_cp(pkg, &platform_tags, &active_cp_tag);
         if let Some(url) = selection.url {
             // Construct filename from selection
             let filename = PathBuf::from(selection.filename);
@@ -1573,38 +1621,8 @@ async fn install(
             event.progress = Some(70);
         });
 
-        // Install wheels
-        let working_dir = std::env::current_dir()?;
-        let mut env = crate::env::find_python_env(&working_dir)?;
-
-        if matches!(env.source, crate::env::EnvSource::System) {
-            if args.system {
-                if let Some(marker) = crate::env::externally_managed_marker(&env.python_path) {
-                    let message = format!(
-                        "refusing to install into externally-managed system Python (marker: {})",
-                        marker.display()
-                    );
-                    collector.error_with_code(
-                        "E_INSTALL_EXTERNALLY_MANAGED",
-                        message.clone(),
-                        "This interpreter is marked externally-managed (PEP 668). Create a virtual environment (e.g. `python3 -m venv .venv`) and re-run, or install with a non-managed interpreter.",
-                    );
-                    return Err(eyre!(message));
-                }
-
-                let warning =
-                    "warning: PyBun is installing into system Python (--system was specified).";
-                eprintln!("{}", warning);
-                collector.warning(warning.to_string());
-            } else {
-                collector.info(
-                    "No virtual environment found; creating project-local environment at .pybun/venv"
-                        .to_string(),
-                );
-                env = crate::env::create_project_venv(&working_dir)?;
-            }
-        }
-
+        // Install wheels into the target environment resolved earlier (before wheel
+        // selection), so the interpreter we install into matches the wheels we picked.
         collector.info(format!(
             "Installing packages into {}",
             env.python_path.display()

--- a/tests/cli_install.rs
+++ b/tests/cli_install.rs
@@ -789,3 +789,78 @@ fn install_resolves_manylinux_2_28_wheel_on_linux_x86_64() {
         );
     }
 }
+
+// =============================================================================
+// Issue #291: off-by-one wheel python_tag selection — install must select
+// wheels matching the *target* venv's Python, not whatever python3/python
+// happens to resolve on PATH.
+// =============================================================================
+
+fn index_cp_tag_mismatch_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_cp_tag_mismatch.json")
+}
+
+/// Create a fake venv whose `bin/python` (or `Scripts/python.exe` on Windows)
+/// reports a controlled `--version` output, independent of any real Python
+/// installation on the host or on PATH.
+#[cfg(unix)]
+fn fake_venv_reporting_version(root: &std::path::Path, version_line: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let venv_dir = root.join(".fake-venv");
+    let bin_dir = venv_dir.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    let python = bin_dir.join("python");
+    let mut file = fs::File::create(&python).unwrap();
+    use std::io::Write;
+    writeln!(file, "#!/bin/sh\necho '{version_line}'").unwrap();
+    let mut perms = file.metadata().unwrap().permissions();
+    perms.set_mode(0o755);
+    file.set_permissions(perms).unwrap();
+
+    fs::write(venv_dir.join("pyvenv.cfg"), "version = 3.12.5\n").unwrap();
+
+    venv_dir
+}
+
+#[cfg(unix)]
+#[test]
+fn install_selects_wheel_for_target_venv_python_not_path_python() {
+    // Regression test for Issue #291: pybun install resolved `cp311` wheels into a
+    // Python 3.12 venv. The fake venv here reports "Python 3.12.5" regardless of
+    // whatever python3/python is on PATH (which may be 3.11, 3.13, or anything
+    // else on the machine running this test) — so a passing test proves install
+    // consults the *venv's* interpreter, not PATH, when selecting wheels.
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_cp_tag_mismatch_path();
+    let venv = fake_venv_reporting_version(temp.path(), "Python 3.12.5");
+
+    bin()
+        .env("PYBUN_ENV", &venv)
+        .env_remove("PYBUN_FORCE_CP_TAG")
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "verpkg==1.0.0",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let pkg = lock.packages.get("verpkg").expect("entry exists");
+    assert_eq!(
+        pkg.wheel, "verpkg-1.0.0-cp312-cp312-any.whl",
+        "should select the cp312 wheel matching the target venv's Python 3.12, \
+         not whatever python3/python resolves to on PATH"
+    );
+}

--- a/tests/fixtures/index_cp_tag_mismatch.json
+++ b/tests/fixtures/index_cp_tag_mismatch.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "verpkg",
+    "version": "1.0.0",
+    "dependencies": [],
+    "wheels": [
+      {
+        "file": "verpkg-1.0.0-cp311-cp311-any.whl",
+        "hash": "sha256:verpkgcp311"
+      },
+      {
+        "file": "verpkg-1.0.0-cp312-cp312-any.whl",
+        "hash": "sha256:verpkgcp312"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Closes #291

## Summary

- `pybun install` selected wheel `python_tag`s via `active_python_cp_tag()`, which shells out to whatever `python3`/`python` resolves on `PATH`. This ignored `PYBUN_ENV`, `PYBUN_PYTHON`, `.python-version`, and the project venv entirely when picking wheels — so wheel selection could pick a CPython ABI that doesn't match the interpreter packages are actually installed into (e.g. `cp311` wheels resolved into a Python 3.12 venv), producing `ImportError: No module named 'numpy.core._multiarray_umath'` at runtime.
- Moved install-target resolution (`find_python_env` + the system-Python safe-install-target guard) earlier in `install()`, before wheel selection, and derived the active CPython tag directly from that interpreter's actual `--version` output.
- Both wheel-selection passes (lockfile write and download list) now use `select_artifact_for_platform_with_cp(..., &active_cp_tag)` instead of the PATH-based `select_artifact_for_platform`.
- `PYBUN_FORCE_CP_TAG` still overrides detection, preserving existing test determinism.

## Test plan

- [x] New regression test `install_selects_wheel_for_target_venv_python_not_path_python` in `tests/cli_install.rs`: builds a fake venv reporting `Python 3.12.5` (independent of the host's real Python/PATH) and asserts the resolved lockfile picks the `cp312` wheel over a decoy `cp311` wheel.
- [x] `cargo test --test cli_install` — 24 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test` (full suite) — same pass/fail counts as `main` except for pre-existing, unrelated `cli_run` PEP 723 failures caused by a broken local Python 3.14 framework install on this dev machine (verified identical failures on `main` before this change)