### PR TITLE
fix: legacy JSON PyPI cache self-heals on decode error (Issue #262)

### DIFF
--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -750,6 +750,13 @@ fn now_epoch_seconds() -> u64 {
 /// from the index is the correct recovery. `stale_notice` is set in that
 /// case so callers can surface an informational diagnostic without failing
 /// the command.
+///
+/// The same self-heal behavior applies to the legacy `.json` cache fallback
+/// (see issue #262, a recurrence of #202's failure mode): a `serde_json`
+/// decode failure there - e.g. a stale entry from a pre-bincode-era `pybun`,
+/// or a truncated write from a crash - is also treated as a cache miss
+/// rather than propagating a fatal `PyPiError` that would block
+/// `add`/`install`/`lock`.
 fn load_cache_from_paths(
     path: &Path,
     legacy_path: &Path,
@@ -771,23 +778,31 @@ fn load_cache_from_paths(
     }
     if legacy_path.exists() {
         let data = fs::read_to_string(legacy_path)?;
-        let entry: LegacyCacheEntry = serde_json::from_str(&data)
-            .map_err(|e| PyPiError::Parse(format!("cache decode error: {}", e)))?;
-        return Ok((
-            Some(CacheEntry {
-                policy: HttpCachePolicy {
-                    etag: entry.etag,
-                    last_modified: entry.last_modified,
-                    max_age: None,
-                    no_cache: false,
-                    no_store: false,
-                    fetched_at: now,
-                },
-                body: Vec::new(),
-                packages: entry.packages,
-            }),
-            None,
-        ));
+        return match serde_json::from_str::<LegacyCacheEntry>(&data) {
+            Ok(entry) => Ok((
+                Some(CacheEntry {
+                    policy: HttpCachePolicy {
+                        etag: entry.etag,
+                        last_modified: entry.last_modified,
+                        max_age: None,
+                        no_cache: false,
+                        no_store: false,
+                        fetched_at: now,
+                    },
+                    body: Vec::new(),
+                    packages: entry.packages,
+                }),
+                None,
+            )),
+            Err(e) => {
+                let notice = format!(
+                    "discarded unreadable legacy PyPI cache entry at {} ({}); re-fetching from index",
+                    legacy_path.display(),
+                    e
+                );
+                Ok((None, Some(notice)))
+            }
+        };
     }
     Ok((None, None))
 }
@@ -1040,6 +1055,43 @@ mod tests {
         let notices = client.take_stale_cache_notices();
         assert_eq!(notices.len(), 1);
         assert!(notices[0].contains("demo.bin"));
+
+        // Notices are drained after being taken.
+        assert!(client.take_stale_cache_notices().is_empty());
+    }
+
+    #[tokio::test]
+    async fn corrupt_legacy_json_cache_is_treated_as_cache_miss() {
+        // Regression test for issue #262 (recurrence of #202's failure
+        // mode): a corrupt/truncated legacy `.json` cache entry must
+        // self-heal the same way a corrupt `.bin` entry does - treated as
+        // a cache miss with an informational notice, not a fatal
+        // `PyPiError` that blocks `add`/`install`/`lock`.
+        let temp = tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        fs::create_dir_all(&cache_dir).unwrap();
+        fs::write(cache_dir.join("demo.json"), b"not valid json{{{").unwrap();
+
+        let client = PyPiClient {
+            base: Url::parse("https://pypi.org").unwrap(),
+            cache_dir,
+            http: reqwest::Client::new(),
+            offline: false,
+            package_once: Arc::new(OnceMap::new()),
+            deps_once: Arc::new(OnceMap::new()),
+            stale_cache_notices: Arc::new(Mutex::new(Vec::new())),
+        };
+
+        // Must not error - the unreadable legacy entry is discarded and
+        // treated as a cache miss so callers can re-fetch from the index.
+        let loaded = client.load_cache("demo").await.unwrap();
+        assert!(loaded.is_none());
+
+        // A notice about the discarded entry should be available for
+        // callers to surface as an info/warn diagnostic.
+        let notices = client.take_stale_cache_notices();
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("demo.json"));
 
         // Notices are drained after being taken.
         assert!(client.take_stale_cache_notices().is_empty());

--- a/tests/pypi_integration.rs
+++ b/tests/pypi_integration.rs
@@ -741,3 +741,61 @@ dependencies = ["app==1.0.0"]
         "should warn explicitly when installing to system Python via --system: {stdout}"
     );
 }
+
+/// Regression test for issue #262 (recurrence of #202's failure mode): a
+/// corrupt/unreadable legacy `.json` PyPI cache entry must self-heal (be
+/// treated as a cache miss and re-fetched from the index) rather than
+/// propagating a fatal `E_RESOLVE_IO` error that blocks `install`.
+///
+/// This mirrors the live repro from the issue:
+/// ```text
+/// echo "not valid json{{{" > $PYBUN_PYPI_CACHE_DIR/app.json
+/// pybun --format=json add app
+/// ```
+#[test]
+fn install_self_heals_from_corrupt_legacy_json_cache() {
+    let temp = tempdir().unwrap();
+    let cache_dir = temp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let server = MockServer::start();
+    let base = single_app_mock(&server);
+    let venv = ensure_venv(temp.path());
+
+    // Simulate a legacy `.json` cache entry left over from a pre-bincode-era
+    // `pybun`, or truncated by a crash during write - either way it fails to
+    // parse as valid JSON.
+    fs::write(cache_dir.join("app.json"), "not valid json{{{").unwrap();
+
+    fs::write(
+        temp.path().join("pyproject.toml"),
+        r#"[project]
+name = "demo"
+version = "0.1.0"
+dependencies = ["app==1.0.0"]
+"#,
+    )
+    .unwrap();
+
+    let output = bin()
+        .current_dir(temp.path())
+        .env("PYBUN_PYPI_BASE_URL", &base)
+        .env("PYBUN_PYPI_CACHE_DIR", cache_dir.to_str().unwrap())
+        .env("PYBUN_ENV", venv.to_str().unwrap())
+        .args(["--format=json", "install"])
+        .output()
+        .expect("command runs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "install should self-heal past a corrupt legacy cache entry, not fail: {stdout}\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !stdout.contains("E_RESOLVE_IO"),
+        "a corrupt legacy cache entry must not surface a fatal E_RESOLVE_IO diagnostic: {stdout}"
+    );
+
+    let lock = Lockfile::load_from_path(temp.path().join("pybun.lockb")).unwrap();
+    assert!(lock.packages.contains_key("app"));
+}


### PR DESCRIPTION
Closes #262

## Summary
- The bincode (`.bin`) PyPI cache path already treats a deserialize failure as a cache miss and transparently re-fetches from the index (fixed for #202). The legacy JSON (`.json`) fallback path did not have this self-heal behavior: a parse failure there was propagated as a fatal `E_RESOLVE_IO` error, blocking `add`/`install`/`lock` entirely.
- `load_cache_from_paths()` in `src/pypi.rs` now applies the same self-heal pattern to the legacy path: a `serde_json` decode failure is treated as a cache miss, an informational "discarded unreadable legacy PyPI cache entry ...; re-fetching from index" notice is recorded (surfaced the same way as the existing `.bin` stale-cache notices), and the caller falls through to re-fetch from the index instead of propagating a fatal error.
- This affects users upgrading from a pre-bincode-era `pybun` whose legacy `.json` cache entries are stale/incompatible, or anyone whose legacy cache file is truncated/corrupted (e.g. crash during write).
- Scope: only the self-heal/cache-miss-on-decode-error behavior for the legacy `.json` path. Locale text leakage in diagnostic messages (#263) is a separate issue and is intentionally not addressed here.

## Test plan
- [x] Unit test `corrupt_legacy_json_cache_is_treated_as_cache_miss` in `src/pypi.rs` — writes a corrupt legacy `.json` cache entry and asserts `load_cache_from_paths`/`PyPiClient::load_cache` treats it as a cache miss (`None`) with a notice, not a fatal error. Confirmed RED (panicked with `Parse("cache decode error: ...")`) before the fix, GREEN after.
- [x] Integration test `install_self_heals_from_corrupt_legacy_json_cache` in `tests/pypi_integration.rs` — reproduces the issue's exact repro at the CLI level (corrupt `app.json` cache file + `pybun --format=json install`), asserting the command succeeds and the JSON output does not contain `E_RESOLVE_IO`. Confirmed RED (surfaced `E_RESOLVE_IO`) before the fix, GREEN after.
- [x] `cargo test` — full suite passes (one pre-existing, unrelated flaky timing test in `tests/observability.rs::duration_ms_in_response` under parallel load; passes in isolation).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues.
- [x] `cargo fmt -- --check` — clean.