### PR TITLE
fix: pybun outdated matches upgrade --dry-run results (Issue #261)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4949,7 +4949,6 @@ async fn run_upgrade(args: &UpgradeArgs, collector: &mut EventCollector) -> Resu
         let wheel_name = selection.filename.clone();
         let (hash, artifact) =
             ensure_selection_is_verifiable(pkg, &selection, collector, &source_index_url)?;
-        verification_artifacts.push(artifact);
 
         let new_pkg = Package {
             name: pkg.name.clone(),
@@ -4970,7 +4969,12 @@ async fn run_upgrade(args: &UpgradeArgs, collector: &mut EventCollector) -> Resu
             None => true, // New package
         };
 
+        // Only surface artifacts for packages that actually changed. Otherwise
+        // `detail.artifacts` includes every resolved package (changed or not),
+        // which contradicts `pybun outdated`'s "has an update" definition and
+        // misleads agents gating upgrade decisions on `outdated` (Issue #261).
         if is_change {
+            verification_artifacts.push(artifact);
             upgraded_packages.push(json!({
                 "package": pkg_name,
                 "from": from_version,

--- a/tests/cli_upgrade.rs
+++ b/tests/cli_upgrade.rs
@@ -2,6 +2,7 @@ use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use pybun::lockfile::{Lockfile, PackageSource};
+use serde_json::Value;
 use std::fs;
 use tempfile::TempDir;
 
@@ -351,5 +352,127 @@ dependencies = [
     assert_eq!(
         before, after,
         "upgrade should keep the existing lockfile when verification fails"
+    );
+}
+
+/// Regression test for Issue #261: `pybun outdated` and `pybun upgrade --dry-run`
+/// gave contradictory answers about which packages have available updates.
+///
+/// Root cause: `upgrade --dry-run`'s JSON `detail.artifacts` array listed every
+/// resolved package (changed or not), while `outdated`'s `detail.outdated` array
+/// (correctly) only lists packages whose version actually changed. An agent
+/// gating on `outdated` before deciding whether to run `upgrade` could get a
+/// false negative because `outdated` looked "up to date" while `upgrade
+/// --dry-run`'s artifacts list contained unrelated, unchanged packages.
+///
+/// `artifacts` must only include packages that are actually part of the
+/// `upgraded` set, matching `outdated`'s definition of "has an update".
+#[test]
+fn upgrade_dry_run_artifacts_only_list_changed_packages() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Two direct dependencies: pkg-a will get a new version, pkg-c will not.
+    fs::write(
+        project_root.join("pyproject.toml"),
+        r#"
+[project]
+name = "test-project"
+version = "0.1.0"
+dependencies = [
+    "pkg-a",
+    "pkg-c"
+]
+"#,
+    )
+    .unwrap();
+
+    let index_path = project_root.join("index.json");
+    fs::write(
+        &index_path,
+        r#"[
+  {"name": "pkg-a", "version": "1.0.0", "dependencies": [], "wheels": [{"file": "pkg_a-1.0.0-py3-none-any.whl", "hash": "sha256:a1"}]},
+  {"name": "pkg-c", "version": "1.0.0", "dependencies": [], "wheels": [{"file": "pkg_c-1.0.0-py3-none-any.whl", "hash": "sha256:c1"}]}
+]"#,
+    )
+    .unwrap();
+
+    bin()
+        .current_dir(project_root)
+        .args(["install", "--index", index_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Only pkg-a gets a new version; pkg-c is unchanged.
+    fs::write(
+        &index_path,
+        r#"[
+  {"name": "pkg-a", "version": "1.0.0", "dependencies": [], "wheels": [{"file": "pkg_a-1.0.0-py3-none-any.whl", "hash": "sha256:a1"}]},
+  {"name": "pkg-a", "version": "2.0.0", "dependencies": [], "wheels": [{"file": "pkg_a-2.0.0-py3-none-any.whl", "hash": "sha256:a2"}]},
+  {"name": "pkg-c", "version": "1.0.0", "dependencies": [], "wheels": [{"file": "pkg_c-1.0.0-py3-none-any.whl", "hash": "sha256:c1"}]}
+]"#,
+    )
+    .unwrap();
+
+    // (A) upgrade --dry-run
+    let upgrade_output = bin()
+        .current_dir(project_root)
+        .args([
+            "--format=json",
+            "upgrade",
+            "--dry-run",
+            "--index",
+            index_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let upgrade_json: Value = serde_json::from_str(std::str::from_utf8(&upgrade_output).unwrap())
+        .expect("valid JSON from upgrade --dry-run");
+
+    let artifact_packages: Vec<&str> = upgrade_json["detail"]["artifacts"]
+        .as_array()
+        .expect("artifacts array")
+        .iter()
+        .map(|a| a["package"].as_str().unwrap())
+        .collect();
+
+    // (B) outdated
+    let outdated_output = bin()
+        .current_dir(project_root)
+        .args([
+            "--format=json",
+            "outdated",
+            "--index",
+            index_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let outdated_json: Value = serde_json::from_str(std::str::from_utf8(&outdated_output).unwrap())
+        .expect("valid JSON from outdated");
+
+    let outdated_packages: Vec<&str> = outdated_json["detail"]["outdated"]
+        .as_array()
+        .expect("outdated array")
+        .iter()
+        .map(|o| o["package"].as_str().unwrap())
+        .collect();
+
+    // The two commands must agree on which packages have updates available.
+    assert_eq!(
+        outdated_packages,
+        vec!["pkg-a"],
+        "outdated should report pkg-a as having an update"
+    );
+    assert_eq!(
+        artifact_packages,
+        vec!["pkg-a"],
+        "upgrade --dry-run artifacts should only include packages that actually \
+         changed (pkg-c is unchanged and must not appear), so it matches `outdated`"
     );
 }


### PR DESCRIPTION
Closes #261

## Summary
- `pybun upgrade --dry-run`'s JSON `detail.artifacts` array unconditionally listed *every* resolved package, including ones whose version hadn't changed, while `pybun outdated`'s `detail.outdated` array correctly listed only packages with an actual available update.
- An agent or CI job that checks `pybun outdated` before deciding whether to run `upgrade` could see an empty/"up to date" result from `outdated` while `upgrade --dry-run`'s artifacts list contained unrelated, unchanged packages — creating the appearance of contradictory answers described in #261.
- Root cause isolated in `run_upgrade` (`src/commands/mod.rs`): `verification_artifacts.push(artifact)` ran for every resolved package before the `is_change` check, so unchanged packages leaked into the dry-run "artifacts" output. Reproduced deterministically with a local `--index` fixture (no network needed) using two direct dependencies, one bumped and one unchanged.
- Fix: only push the verification artifact into `detail.artifacts` when the package is actually part of the `upgraded` set (`is_change == true`), matching `outdated`'s definition of "has an update". Lockfile hash/verification computation for every resolved package is unaffected — only the user-visible `artifacts` list is now filtered.

## Test plan
- [x] Added `upgrade_dry_run_artifacts_only_list_changed_packages` in `tests/cli_upgrade.rs`: installs two packages via a local index, bumps only one, then asserts `pybun outdated` and `pybun upgrade --dry-run --format=json` agree on which package has an update (confirmed RED before the fix, GREEN after).
- [x] `cargo test` (full suite, 956 passed / 6 ignored)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo fmt -- --check` (clean)