### PR TITLE
fix: sandbox network-block raises clean denial instead of corrupting ssl.py import (Issue #263)

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -677,7 +677,20 @@ def _block_network():
     def _blocked(*_a, **_kw):
         _deny("network access", "blocked_network")
 
-    socket.socket = _blocked
+    def _blocked_connect(_self, *_a, **_kw):
+        _deny("network access", "blocked_network")
+
+    # Deny at the point of the actual network operation (connect) instead of
+    # replacing socket.socket itself. Reassigning socket.socket to a plain
+    # function corrupts unrelated stdlib import machinery: modules such as
+    # ssl.py do `from socket import socket` at import time and then subclass
+    # it (`class SSLSocket(socket):`), so once socket.socket is a function
+    # instead of a class, that class statement fails with a confusing
+    # low-level TypeError instead of a clean sandbox denial. Patching
+    # connect/connect_ex on the real class keeps subclassing working while
+    # still blocking every path that establishes an outbound connection.
+    socket.socket.connect = _blocked_connect
+    socket.socket.connect_ex = _blocked_connect
     socket.create_connection = _blocked
     if hasattr(socket, "socketpair"):
         socket.socketpair = _blocked

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -44,17 +44,20 @@ subprocess.run(["echo", "hello from child"])
 fn sandbox_can_opt_in_network_access() {
     let temp = tempdir().unwrap();
     let script = temp.path().join("network.py");
+
+    // Without opt-in, the actual connect attempt should be blocked and
+    // exit_code should be non-zero. The denial happens before any real
+    // syscall, so the destination does not need to exist.
     fs::write(
         &script,
         r#"
 import socket
-socket.socket()
+socket.socket().connect(("127.0.0.1", 1))
 print("network allowed")
 "#,
     )
     .unwrap();
 
-    // Without opt-in, socket creation should be blocked and exit_code should be non-zero.
     bin()
         .args([
             "--format=json",
@@ -66,7 +69,27 @@ print("network allowed")
         .code(1)
         .stdout(predicate::str::contains("\"exit_code\":1"));
 
-    // With opt-in, the script should run successfully and report the sandbox policy in JSON.
+    // With opt-in, connect should actually be attempted, so use a real
+    // listener bound to localhost so the script can succeed without
+    // depending on external network access.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let accept_thread = std::thread::spawn(move || {
+        let _ = listener.accept();
+    });
+
+    fs::write(
+        &script,
+        format!(
+            r#"
+import socket
+socket.socket().connect(("127.0.0.1", {port}))
+print("network allowed")
+"#
+        ),
+    )
+    .unwrap();
+
     bin()
         .args([
             "--format=json",
@@ -80,6 +103,57 @@ print("network allowed")
         .stdout(predicate::str::contains("\"exit_code\":0"))
         .stdout(predicate::str::contains("\"sandbox\""))
         .stdout(predicate::str::contains("\"allow_network\":true"));
+
+    accept_thread.join().unwrap();
+}
+
+/// Regression test for Issue #263: blocking network access via a stdlib
+/// import chain (urllib -> http.client -> ssl) must surface a clean
+/// sandbox denial, not a low-level TypeError from ssl.py's class-body
+/// compilation (`class SSLSocket(socket):`).
+#[test]
+fn sandbox_network_block_via_ssl_import_is_clean() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("urlopen.py");
+    fs::write(
+        &script,
+        r#"
+import urllib.request
+urllib.request.urlopen("http://example.com", timeout=2)
+"#,
+    )
+    .unwrap();
+
+    let assert = bin()
+        .args([
+            "--format=json",
+            "run",
+            "--sandbox",
+            script.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"exit_code\":1"));
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Must NOT contain the misleading low-level TypeError from ssl.py's
+    // class-body compilation.
+    assert!(
+        !stdout.contains("TypeError: function() argument"),
+        "sandbox network block leaked a raw TypeError instead of a clean denial: {stdout}"
+    );
+    assert!(
+        !stdout.contains("class SSLSocket(socket):"),
+        "sandbox network block corrupted ssl.py class-body compilation: {stdout}"
+    );
+
+    // Must contain a clean, purpose-built sandbox denial.
+    assert!(
+        stdout.contains("pybun sandbox: network access") && stdout.contains("blocked"),
+        "expected a clean sandbox network denial message, got: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #263

## Summary

- `--sandbox` network-blocking previously reassigned `socket.socket` to a plain function. Any stdlib module that does `from socket import socket` at import time and then subclasses it (notably `ssl.py`'s `class SSLSocket(socket):`, reached via `urllib.request -> http.client -> ssl`) would fail with a confusing low-level `TypeError: function() argument 'code' must be code, not str` raised from class-body compilation, instead of a clean sandbox denial.
- Fixed by patching `connect`/`connect_ex` on the real `socket.socket` class instead of replacing the class itself. This leaves `socket.socket` usable as a base class (so `ssl.py` imports/subclasses correctly) while still denying every code path that attempts an outbound connection (`socket.connect`, `ssl.SSLSocket.connect` via `super().connect()`, `socket.create_connection`, `socket.socketpair`).
- The denial is now a clean `PermissionError`/`OSError`-derived error raised at the actual `connect()` call site: `pybun sandbox: network access blocked`, matching the style of the existing subprocess-block and file-write-block denials.

## Test plan

- [x] Added `sandbox_network_block_via_ssl_import_is_clean` (`tests/sandbox.rs`) reproducing the exact issue repro (`urllib.request.urlopen` under `--sandbox`), asserting the output does NOT contain the misleading `TypeError` / `class SSLSocket(socket):` traceback and DOES contain a clean `pybun sandbox: network access ... blocked` message. Confirmed RED against the old implementation, GREEN after the fix.
- [x] Updated `sandbox_can_opt_in_network_access` to exercise an actual `connect()` (denied without `--allow-network`; succeeds against a local `TcpListener` with `--allow-network`), since blocking now happens at connect-time rather than at bare `socket.socket()` construction.
- [x] Verified `sandbox_blocks_subprocess_spawns` and the file-read/file-write sandbox denial tests still pass unmodified (no regression to other sandbox denial paths).
- [x] `cargo test` — 956 passed, 6 ignored, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues.
- [x] `cargo fmt -- --check` — clean.
- [x] Manually reproduced the original bug and confirmed the fix with `PYBUN_PYTHON=... pybun run --sandbox -c "import urllib.request; urllib.request.urlopen('http://example.com', timeout=2)"`, which now raises `urllib.error.URLError: <urlopen error pybun sandbox: network access blocked>` instead of the `TypeError` traceback.