### PR TITLE
fix(lock): select wheels via target venv's Python, not PATH (Issue #293)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1947,6 +1947,31 @@ async fn lock_dependencies(args: &LockArgs, collector: &mut EventCollector) -> R
         event.progress = Some(40);
     });
 
+    // Detect the CPython tag of the actual lock target's Python (PYBUN_ENV / PYBUN_PYTHON /
+    // project venv / system Python) *before* selecting wheels, so the wheel filenames recorded
+    // in the lockfile match the interpreter that will actually install them. Selecting wheels
+    // against whatever `python3`/`python` happens to resolve on PATH (the previous behavior)
+    // could silently record wheels for the wrong CPython ABI, producing the kind of
+    // `ImportError` #172's runtime compatibility check was built to detect after the fact
+    // (Issue #293; same root cause as #291, fixed for `pybun install` in #292). This is
+    // read-only detection only and covers both project-mode and `--script` PEP 723 locking,
+    // since both resolve the target interpreter relative to the current working directory
+    // (honoring PYBUN_ENV/PYBUN_PYTHON regardless of cwd).
+    let working_dir = std::env::current_dir()?;
+    let target_env_probe = crate::env::find_python_env(&working_dir)?;
+
+    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
+    // bypassing interpreter detection entirely.
+    let active_cp_tag = std::env::var("PYBUN_FORCE_CP_TAG")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            get_python_version(&target_env_probe.python_path)
+                .ok()
+                .and_then(|v| python_version_to_cp_tag(&v))
+        })
+        .unwrap_or_else(|| "cp311".to_string());
+
     let platform_tags = current_platform_tags();
     let mut lock = Lockfile::new(
         vec!["3.11".into()],
@@ -1960,7 +1985,7 @@ async fn lock_dependencies(args: &LockArgs, collector: &mut EventCollector) -> R
     let mut verified_artifacts = Vec::new();
 
     for pkg in resolution.packages.values() {
-        let selection = select_artifact_for_platform(pkg, &platform_tags);
+        let selection = select_artifact_for_platform_with_cp(pkg, &platform_tags, &active_cp_tag);
         if selection.from_source {
             let message = format!(
                 "no compatible pre-built wheel for {} {} on {}; falling back to source build",

--- a/tests/cli_lock.rs
+++ b/tests/cli_lock.rs
@@ -190,6 +190,120 @@ version = "0.1.0"
     assert!(lock.packages.is_empty());
 }
 
+// =============================================================================
+// Issue #293: `pybun lock` selected wheels via PATH python, ignoring the
+// target venv — same root cause as #291 (fixed for `pybun install` in #292).
+// =============================================================================
+
+fn index_cp_tag_mismatch_path() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_cp_tag_mismatch.json")
+}
+
+/// Create a fake venv whose `bin/python` (or `Scripts/python.exe` on Windows)
+/// reports a controlled `--version` output, independent of any real Python
+/// installation on the host or on PATH.
+#[cfg(unix)]
+fn fake_venv_reporting_version(root: &Path, version_line: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let venv_dir = root.join(".fake-venv");
+    let bin_dir = venv_dir.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    let python = bin_dir.join("python");
+    let mut file = fs::File::create(&python).unwrap();
+    use std::io::Write;
+    writeln!(file, "#!/bin/sh\necho '{version_line}'").unwrap();
+    let mut perms = file.metadata().unwrap().permissions();
+    perms.set_mode(0o755);
+    file.set_permissions(perms).unwrap();
+
+    fs::write(venv_dir.join("pyvenv.cfg"), "version = 3.12.5\n").unwrap();
+
+    venv_dir
+}
+
+#[cfg(unix)]
+#[test]
+fn lock_project_selects_wheel_for_target_venv_python_not_path_python() {
+    // Regression test for Issue #293: `pybun lock` (project mode) resolved `cp311`
+    // wheels for a project whose venv reports Python 3.12.5, regardless of
+    // whatever python3/python is on PATH. A passing test proves `lock` consults
+    // the *venv's* interpreter, not PATH, when selecting wheels to record.
+    let temp = tempdir().unwrap();
+    let pyproject_path = temp.path().join("pyproject.toml");
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_cp_tag_mismatch_path();
+    let venv = fake_venv_reporting_version(temp.path(), "Python 3.12.5");
+
+    let pyproject_content = r#"[project]
+name = "cp-tag-test"
+version = "0.1.0"
+dependencies = ["verpkg==1.0.0"]
+"#;
+    fs::write(&pyproject_path, pyproject_content).unwrap();
+
+    bin()
+        .current_dir(temp.path())
+        .env("PYBUN_ENV", &venv)
+        .env_remove("PYBUN_FORCE_CP_TAG")
+        .args(["--format=json", "lock", "--index", index.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let pkg = lock.packages.get("verpkg").expect("entry exists");
+    assert_eq!(
+        pkg.wheel, "verpkg-1.0.0-cp312-cp312-any.whl",
+        "should record the cp312 wheel matching the target venv's Python 3.12, \
+         not whatever python3/python resolves to on PATH"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn lock_script_selects_wheel_for_target_venv_python_not_path_python() {
+    // Same regression as above, but for `pybun lock --script` (PEP 723 mode).
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("example.py");
+    let content = r#"# /// script
+# dependencies = ["verpkg==1.0.0"]
+# ///
+print("hello")
+"#;
+    fs::write(&script, content).unwrap();
+
+    let index = index_cp_tag_mismatch_path();
+    let lock_path = script_lock_path(&script);
+    let venv = fake_venv_reporting_version(temp.path(), "Python 3.12.5");
+
+    bin()
+        .env("PYBUN_ENV", &venv)
+        .env_remove("PYBUN_FORCE_CP_TAG")
+        .args([
+            "--format=json",
+            "lock",
+            "--script",
+            script.to_str().unwrap(),
+            "--index",
+            index.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let pkg = lock.packages.get("verpkg").expect("entry exists");
+    assert_eq!(
+        pkg.wheel, "verpkg-1.0.0-cp312-cp312-any.whl",
+        "should record the cp312 wheel matching the target venv's Python 3.12, \
+         not whatever python3/python resolves to on PATH"
+    );
+}
+
 #[test]
 fn lock_without_script_or_pyproject_fails_with_actionable_error() {
     let temp = tempdir().unwrap();


### PR DESCRIPTION
Closes #293

## Summary
- `pybun lock` (both project mode and `--script` PEP 723 mode) resolved wheel filenames using `select_artifact_for_platform()`, which derives its CPython tag from whatever `python3`/`python` resolves on `PATH` — ignoring `PYBUN_ENV`, `PYBUN_PYTHON`, `.python-version`, and the actual project/script venv.
- Same root cause as #291 (fixed for `pybun install` in #292), just in `lock_dependencies()`.
- Fix: resolve the lock target's interpreter via `crate::env::find_python_env()` (covers both project mode and `--script` mode), derive `active_cp_tag` from its real `--version` (honoring `PYBUN_FORCE_CP_TAG` for test determinism), and use `select_artifact_for_platform_with_cp()` instead of the PATH-based call — mirroring the `install()` fix exactly.

## Test plan
- [x] Added `lock_project_selects_wheel_for_target_venv_python_not_path_python` and `lock_script_selects_wheel_for_target_venv_python_not_path_python` in `tests/cli_lock.rs`, using a fake venv reporting a spoofed Python version distinct from PATH's python.
- [x] Confirmed both tests fail before the fix (wrong cp tag recorded) and pass after.
- [x] `cargo test` — 961 passed, 6 ignored.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.