### PR TITLE
fix(pep723): self-heal corrupted script cache entries (Issue #299)

### DIFF
--- a/src/pep723_cache.rs
+++ b/src/pep723_cache.rs
@@ -363,6 +363,15 @@ impl Pep723Cache {
     }
 
     /// Read metadata about a cached venv from a specific root directory.
+    ///
+    /// Returns `Ok(None)` when the entry is missing **or** unreadable/corrupt.
+    /// A `deps.json` that fails to decode (e.g. truncated by a crash mid-write)
+    /// is treated the same as a missing entry rather than propagated as a
+    /// fatal error - this mirrors the self-heal behavior already applied to
+    /// the PyPI cache for issue #262 (a recurrence of #202's failure mode).
+    /// Callers observe a plain cache miss and fall through to the existing
+    /// rebuild-from-scratch path, which already removes any stale venv and
+    /// metadata before recreating the environment.
     pub fn read_cache_entry(&self, root: &Path) -> Result<Option<CachedEnvInfo>> {
         let info_path = root.join("deps.json");
         if !info_path.exists() {
@@ -370,8 +379,17 @@ impl Pep723Cache {
         }
 
         let content = fs::read_to_string(&info_path)?;
-        let info: CachedEnvInfo = serde_json::from_str(&content)?;
-        Ok(Some(info))
+        match serde_json::from_str::<CachedEnvInfo>(&content) {
+            Ok(info) => Ok(Some(info)),
+            Err(e) => {
+                eprintln!(
+                    "info: discarded unreadable PEP 723 cache entry at {} ({}); rebuilding",
+                    info_path.display(),
+                    e
+                );
+                Ok(None)
+            }
+        }
     }
 
     /// Determine if the cached entry matches the expected cache key.
@@ -836,6 +854,31 @@ mod tests {
         };
 
         assert!(Pep723Cache::cache_entry_matches_key(&info, &key));
+    }
+
+    #[test]
+    fn read_cache_entry_self_heals_on_corrupt_json() {
+        // Regression test for issue #299 (same bug class as #262): a
+        // truncated/corrupt `deps.json` (e.g. from a crash mid-write) must
+        // be treated as a cache miss - `Ok(None)` - not propagated as a
+        // fatal `Pep723CacheError`, so `pybun run script.py` can self-heal
+        // by rebuilding the cached environment from scratch instead of
+        // crashing.
+        let temp = tempdir().unwrap();
+        let cache = Pep723Cache::with_root(temp.path());
+        let root = temp.path().join("env-root");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("deps.json"), b"not valid json{{{").unwrap();
+
+        let result = cache.read_cache_entry(&root);
+        assert!(
+            result.is_ok(),
+            "corrupt cache entry must not be a fatal error: {result:?}"
+        );
+        assert!(
+            result.unwrap().is_none(),
+            "corrupt cache entry must be treated as a cache miss"
+        );
     }
 
     #[test]

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -9,6 +9,10 @@ fn bin() -> Command {
     cargo_bin_cmd!("pybun")
 }
 
+fn network_enabled() -> bool {
+    std::env::var_os("PYBUN_E2E_NETWORK").is_some()
+}
+
 #[test]
 fn run_simple_script() {
     let temp = tempdir().unwrap();
@@ -436,6 +440,90 @@ print("test cleanup field")
         .success()
         // cleanup should be false with caching (venv not cleaned up)
         .stdout(predicate::str::contains("\"cleanup\":false"));
+}
+
+#[test]
+fn run_pep723_self_heals_from_corrupt_deps_json_cache_entry() {
+    // Regression test for issue #299 (same bug class as #262): a corrupt
+    // `deps.json` cache entry (e.g. truncated by a crash mid-write) must be
+    // treated as a cache miss and trigger a rebuild-from-scratch, not crash
+    // `pybun run script.py` with a fatal error.
+    //
+    // This reproduces the live repro from the issue:
+    // ```text
+    // echo "not valid json{{{" > <pep723-envs>/<hash>/deps.json
+    // pybun run script.py
+    // ```
+    if !network_enabled() {
+        eprintln!(
+            "Skipping run_pep723_self_heals_from_corrupt_deps_json_cache_entry \
+             (PYBUN_E2E_NETWORK not set)"
+        );
+        return;
+    }
+
+    let temp = tempdir().unwrap();
+    let home = temp.path().join("pybun-home");
+    fs::create_dir_all(&home).unwrap();
+    let script = temp.path().join("pep723_corrupt_cache.py");
+
+    let content = r#"# /// script
+# dependencies = ["cowsay"]
+# ///
+print("test corrupt cache self-heal")
+"#;
+    fs::write(&script, content).unwrap();
+
+    // First run: builds a fresh cached environment and records deps.json.
+    bin()
+        .env("PYBUN_HOME", &home)
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let envs_dir = home.join("pep723-envs");
+    let mut entries: Vec<_> = fs::read_dir(&envs_dir)
+        .expect("pep723-envs dir should exist after first run")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly one cached env after first run"
+    );
+    let env_root = entries.remove(0).path();
+    let deps_json = env_root.join("deps.json");
+    assert!(deps_json.exists(), "deps.json should exist after caching");
+
+    // Corrupt the cache entry to simulate a crash mid-write.
+    fs::write(&deps_json, "not valid json{{{").unwrap();
+
+    // Second run: must self-heal (rebuild) rather than crash.
+    let output = bin()
+        .env("PYBUN_HOME", &home)
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("command runs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "pybun run should self-heal past a corrupt PEP 723 cache entry, not fail: \
+         stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains("discarded unreadable PEP 723 cache entry"),
+        "expected a self-heal notice on stderr: {stderr}"
+    );
+
+    // The cache entry should have been rebuilt with valid JSON.
+    let rebuilt = fs::read_to_string(&deps_json).expect("deps.json should exist again");
+    assert!(
+        serde_json::from_str::<Value>(&rebuilt).is_ok(),
+        "rebuilt deps.json should be valid JSON: {rebuilt}"
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #299

## Summary
- `Pep723Cache::read_cache_entry` treated an undecodable `deps.json` (e.g. truncated by a crash mid-write) as a fatal error via `serde_json::from_str(&content)?`, propagating a crash from `pybun run script.py` instead of routing to the existing rebuild-from-scratch path already used for the "cache key mismatch" case.
- Now a decode failure is treated the same as a missing entry: logs `discarded unreadable PEP 723 cache entry at {path} ({err}); rebuilding` to stderr and returns `Ok(None)`, letting callers self-heal by rebuilding the cached environment.
- Same self-heal pattern already applied to the PyPI legacy cache for Issue #262.

## Test plan
- [x] Unit test `read_cache_entry_self_heals_on_corrupt_json` — corrupt `deps.json`, asserts `Ok(None)`
- [x] Integration test `run_pep723_self_heals_from_corrupt_deps_json_cache_entry` in `tests/cli_run.rs` — runs a real PEP 723 script twice via the CLI, corrupts the cache entry between runs, asserts the second run succeeds and the cache rebuilds (gated behind `PYBUN_E2E_NETWORK`, consistent with other network-dependent tests in this suite)
- [x] `cargo test --lib pep723_cache` — 21 passed
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)