### PR TITLE
fix(sandbox): preserve subprocess.Popen class identity when blocking (Issue #300)

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -639,7 +639,21 @@ def _block_subprocesses():
     def _blocked(*_a, **_kw):
         _deny("process creation", "blocked_subprocesses")
 
-    subprocess.Popen = _blocked
+    def _blocked_popen_init(_self, *_a, **_kw):
+        _deny("process creation", "blocked_subprocesses")
+
+    # Deny at the point of the actual spawn (Popen.__init__, which is what
+    # invokes _execute_child) instead of replacing subprocess.Popen itself.
+    # Reassigning subprocess.Popen to a plain function corrupts any code
+    # that subclasses it (`class MyPopen(subprocess.Popen): ...`, used by
+    # asyncio's subprocess transports and third-party process wrappers) or
+    # does isinstance()/issubclass() checks against it: once
+    # subprocess.Popen is a function instead of a class, the class
+    # statement fails with a confusing low-level TypeError instead of a
+    # clean sandbox denial. Patching __init__ on the real class keeps
+    # subclassing and isinstance checks working while still blocking every
+    # path that actually spawns a child process.
+    subprocess.Popen.__init__ = _blocked_popen_init
     subprocess.call = _blocked
     subprocess.run = _blocked
     subprocess.check_call = _blocked

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -156,6 +156,70 @@ urllib.request.urlopen("http://example.com", timeout=2)
     );
 }
 
+/// Regression test for Issue #300: blocking subprocess creation by
+/// reassigning subprocess.Popen to a plain function destroys the class
+/// identity, breaking `class Foo(subprocess.Popen): ...` subclassing and
+/// isinstance() checks. This mirrors the fix for Issue #263 (socket.socket).
+#[test]
+fn sandbox_subprocess_block_preserves_popen_class_identity() {
+    let temp = tempdir().unwrap();
+    let script = temp.path().join("popen_subclass.py");
+    fs::write(
+        &script,
+        r#"
+import subprocess
+
+class MyPopen(subprocess.Popen):
+    pass
+
+print("subclass ok")
+print(issubclass(MyPopen, subprocess.Popen))
+
+MyPopen(["echo", "hello from child"])
+print("should not reach here")
+"#,
+    )
+    .unwrap();
+
+    let assert = bin()
+        .args([
+            "--format=json",
+            "run",
+            "--sandbox",
+            script.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("\"exit_code\":1"));
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Subclassing subprocess.Popen must succeed: class identity must be
+    // preserved, so this must NOT surface a low-level TypeError from the
+    // class-body compilation.
+    assert!(
+        stdout.contains("subclass ok"),
+        "sandbox subprocess block corrupted Popen class identity \
+         (subclassing failed before printing): {stdout}"
+    );
+    assert!(
+        !stdout.contains("TypeError"),
+        "sandbox subprocess block leaked a raw TypeError instead of a clean denial: {stdout}"
+    );
+
+    // Must contain a clean, purpose-built sandbox denial when the subclass
+    // is actually instantiated (i.e. a real spawn is attempted).
+    assert!(
+        stdout.contains("pybun sandbox: process creation") && stdout.contains("blocked"),
+        "expected a clean sandbox process-creation denial message, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("should not reach here"),
+        "subprocess spawn via Popen subclass was not blocked: {stdout}"
+    );
+}
+
 #[test]
 fn sandbox_allow_read_blocks_unauthorized_path() {
     let temp = tempdir().unwrap();


### PR DESCRIPTION
Closes #300

## Summary
- `_block_subprocesses()` in `src/sandbox.rs` denied process creation by doing `subprocess.Popen = _blocked`, replacing the real `subprocess.Popen` *class* wholesale with a plain function.
- This broke anything that subclasses `subprocess.Popen` (e.g. asyncio's subprocess transports) or does `isinstance`/`issubclass` checks against it — the class statement fails with a confusing low-level `TypeError` instead of a clean sandbox denial.
- Fix patches `subprocess.Popen.__init__` to deny at the point of the actual spawn, instead of replacing the class itself — keeping subclassing/isinstance checks intact while still blocking every path that spawns a child process. Same pattern as the `socket.socket` fix for Issue #263.

## Test plan
- [x] New regression test in `tests/sandbox.rs` reproducing the subclass/isinstance scenario under the sandboxed subprocess block
- [x] `cargo test --test sandbox` — 35 passed
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)