### PR TITLE
fix(upgrade): select wheels via project venv python, not PATH (Issue #295)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::resolver::parse_version_relaxed;
 use crate::resolver::{
     PackageIndex, Requirement, compare_versions, cp_tag_to_dotted_version, current_platform_tags,
     is_wheel_python_compatible, parse_wheel_tags, python_version_to_cp_tag, resolve,
-    select_artifact_for_platform, select_artifact_for_platform_with_cp,
+    select_artifact_for_platform_with_cp,
 };
 use crate::sandbox;
 use crate::sbom;
@@ -4968,6 +4968,30 @@ async fn run_upgrade(args: &UpgradeArgs, collector: &mut EventCollector) -> Resu
     let mut verification_artifacts: Vec<Value> = Vec::new();
     let platform_tags = current_platform_tags();
 
+    // Detect the CPython tag of the actual project's Python (PYBUN_ENV / PYBUN_PYTHON /
+    // project venv / system Python) *before* re-selecting wheels, so the wheel filenames
+    // rewritten into the lockfile match the interpreter that will actually consume it.
+    // Selecting wheels against whatever `python3`/`python` happens to resolve on PATH (the
+    // previous behavior) could silently record wheels for the wrong CPython ABI, producing
+    // the kind of hash/ABI mismatch (or the #172 runtime compatibility warning) that only
+    // surfaces later when the rewritten lockfile is consumed (Issue #295; same root cause as
+    // #291, fixed for `pybun install` in #292, `pybun lock` in #293, and `pybun run` in #294).
+    // This is read-only detection only — `pybun upgrade` doesn't create venvs, so there's no
+    // side-effect-ordering concern here (unlike #292's install fix).
+    let target_env_probe = crate::env::find_python_env(&cwd)?;
+
+    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
+    // bypassing interpreter detection entirely.
+    let active_cp_tag = std::env::var("PYBUN_FORCE_CP_TAG")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            get_python_version(&target_env_probe.python_path)
+                .ok()
+                .and_then(|v| python_version_to_cp_tag(&v))
+        })
+        .unwrap_or_else(|| "cp311".to_string());
+
     // Use an empty lockfile if none exists for comparison base
     let base_lock =
         current_lock.unwrap_or_else(|| Lockfile::new(vec!["3.12".into()], vec!["any".into()]));
@@ -4979,7 +5003,7 @@ async fn run_upgrade(args: &UpgradeArgs, collector: &mut EventCollector) -> Resu
     );
 
     for (pkg_name, pkg) in &resolution.packages {
-        let selection = select_artifact_for_platform(pkg, &platform_tags);
+        let selection = select_artifact_for_platform_with_cp(pkg, &platform_tags, &active_cp_tag);
         let wheel_name = selection.filename.clone();
         let (hash, artifact) =
             ensure_selection_is_verifiable(pkg, &selection, collector, &source_index_url)?;

--- a/tests/cli_upgrade.rs
+++ b/tests/cli_upgrade.rs
@@ -1,9 +1,10 @@
 use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
-use pybun::lockfile::{Lockfile, PackageSource};
+use pybun::lockfile::{Lockfile, Package, PackageSource};
 use serde_json::Value;
 use std::fs;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 fn bin() -> Command {
@@ -474,5 +475,110 @@ dependencies = [
         vec!["pkg-a"],
         "upgrade --dry-run artifacts should only include packages that actually \
          changed (pkg-c is unchanged and must not appear), so it matches `outdated`"
+    );
+}
+
+// =============================================================================
+// Issue #295: `pybun upgrade` selected wheels via PATH python, ignoring the
+// target venv — same root cause as #291 (fixed for `pybun install` in #292,
+// `pybun lock` in #293, and `pybun run` in #294).
+// =============================================================================
+
+fn index_cp_tag_mismatch_path() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_cp_tag_mismatch.json")
+}
+
+/// Create a fake venv whose `bin/python` (or `Scripts/python.exe` on Windows)
+/// reports a controlled `--version` output, independent of any real Python
+/// installation on the host or on PATH.
+#[cfg(unix)]
+fn fake_venv_reporting_version(root: &Path, version_line: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let venv_dir = root.join(".fake-venv");
+    let bin_dir = venv_dir.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    let python = bin_dir.join("python");
+    let mut file = fs::File::create(&python).unwrap();
+    use std::io::Write;
+    writeln!(file, "#!/bin/sh\necho '{version_line}'").unwrap();
+    let mut perms = file.metadata().unwrap().permissions();
+    perms.set_mode(0o755);
+    file.set_permissions(perms).unwrap();
+
+    fs::write(venv_dir.join("pyvenv.cfg"), "version = 3.12.5\n").unwrap();
+
+    venv_dir
+}
+
+#[cfg(unix)]
+#[test]
+fn upgrade_selects_wheel_for_target_venv_python_not_path_python() {
+    // Regression test for Issue #295: `pybun upgrade` re-resolves dependencies and
+    // rewrites pybun.lockb using select_artifact_for_platform(), which shells out to
+    // whatever python3/python resolves on PATH, ignoring the project's actual venv.
+    // Seed a lockfile that already recorded a (mismatched) cp311 wheel, then run
+    // `upgrade` against a fake venv that reports Python 3.12.5 — a passing test
+    // proves upgrade now consults the *venv's* interpreter, not PATH, when
+    // re-selecting wheels to record.
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+    let index = index_cp_tag_mismatch_path();
+    let lock_path = project_root.join("pybun.lockb");
+    let venv = fake_venv_reporting_version(project_root, "Python 3.12.5");
+
+    fs::write(
+        project_root.join("pyproject.toml"),
+        r#"
+[project]
+name = "cp-tag-test"
+version = "0.1.0"
+dependencies = [
+    "verpkg==1.0.0"
+]
+"#,
+    )
+    .unwrap();
+
+    // Seed an existing lockfile recording the (mismatched) cp311 wheel, as if a
+    // prior `install`/`lock` had run against a PATH python reporting 3.11.
+    let mut seed_lock = Lockfile::new(vec!["3.11".into()], vec!["any".into()]);
+    seed_lock.add_package(Package {
+        name: "verpkg".to_string(),
+        version: "1.0.0".to_string(),
+        source: PackageSource::Registry {
+            index: "pypi".to_string(),
+            url: index.display().to_string(),
+        },
+        wheel: "verpkg-1.0.0-cp311-cp311-any.whl".to_string(),
+        hash: "sha256:verpkgcp311".to_string(),
+        dependencies: vec![],
+    });
+    seed_lock.save_to_path(&lock_path).unwrap();
+
+    bin()
+        .current_dir(project_root)
+        .env("PYBUN_ENV", &venv)
+        .env_remove("PYBUN_FORCE_CP_TAG")
+        .args([
+            "--format=json",
+            "upgrade",
+            "--index",
+            index.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let pkg = lock.packages.get("verpkg").expect("entry exists");
+    assert_eq!(
+        pkg.wheel, "verpkg-1.0.0-cp312-cp312-any.whl",
+        "should record the cp312 wheel matching the target venv's Python 3.12, \
+         not whatever python3/python resolves to on PATH"
     );
 }


### PR DESCRIPTION
Closes #295

## Summary
- `pybun upgrade` re-resolved project dependencies and rewrote `pybun.lockb` using `select_artifact_for_platform()`, which detects the CPython ABI tag via whatever `python3`/`python` resolves on PATH, ignoring `PYBUN_ENV`, `PYBUN_PYTHON`, and the project's actual venv. Same root cause as #291 (fixed for `pybun install` in #292, `pybun lock` in #293, and `pybun run` in #294).
- Resolves the project's target interpreter via a read-only `find_python_env()` probe before wheel selection (no venv creation — `upgrade` doesn't create venvs, so there's no side-effect-ordering concern like #292's install fix had to address), derives `active_cp_tag` from its real `--version` output (honoring `PYBUN_FORCE_CP_TAG` for deterministic tests), and switches wheel selection to `select_artifact_for_platform_with_cp()`.

## Test plan
- [x] Added `upgrade_selects_wheel_for_target_venv_python_not_path_python` in `tests/cli_upgrade.rs`: seeds a lockfile recording a mismatched `cp311` wheel, runs `pybun upgrade` against a fake venv reporting Python 3.12.5, and asserts the rewritten lockfile now records the `cp312` wheel.
- [x] `cargo test` — all suites pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — clean