### PR TITLE
fix(run): report cache_hit=true on PEP723 warm runs (Issue #267)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2675,7 +2675,50 @@ async fn run_script(
         {
             if let Some(uv_path) = crate::env::find_uv_executable() {
                 pep723_backend = "uv_run".to_string();
-                (RunProgram::Uv { uv_path }, None, false)
+
+                // `uv run --script` manages its own venv/wheel cache internally, so PyBun
+                // has no direct signal for whether this invocation was served from cache.
+                // Mirror the same cache-key semantics used by the native "pybun" backend
+                // (script path + dependency set + Python version + index settings + lock
+                // hash) to detect a repeat ("warm") invocation of this exact script, so
+                // `--format=json` can report `cache_hit` accurately instead of always
+                // reporting `false` (Issue #267).
+                let pep_cache =
+                    Pep723Cache::new().map_err(|e| eyre!("failed to initialize cache: {}", e))?;
+                let (base_python, _env_source) = find_python_interpreter()?;
+                let python_version = get_python_version(Path::new(&base_python))?;
+                let index_settings = pep723_index_settings(pep723_metadata.as_ref());
+                let cache_key = Pep723CacheKey::new(
+                    &install_deps,
+                    &python_version,
+                    &index_settings,
+                    lock_hash.as_deref(),
+                );
+                let env_root = pep_cache
+                    .script_env_root(&script_path)
+                    .map_err(|e| eyre!("failed to resolve script env root: {}", e))?;
+                let _env_lock = pep_cache
+                    .lock_script_env(&env_root)
+                    .map_err(|e| eyre!("failed to lock script env: {}", e))?;
+
+                let uv_cache_hit = pep_cache
+                    .read_cache_entry(&env_root)
+                    .map_err(|e| eyre!("failed to read cache entry: {}", e))?
+                    .map(|info| Pep723Cache::cache_entry_matches_key(&info, &cache_key))
+                    .unwrap_or(false);
+
+                pep_cache
+                    .record_cache_entry_at(&env_root, &cache_key)
+                    .map_err(|e| eyre!("failed to record cache entry: {}", e))?;
+
+                if uv_cache_hit {
+                    collector.info(format!(
+                        "Cache hit: reusing uv-managed environment (hash: {})",
+                        &cache_key.hash[..8]
+                    ));
+                }
+
+                (RunProgram::Uv { uv_path }, None, uv_cache_hit)
             } else if pep723_backend_setting == "uv" {
                 return Err(eyre!(
                     "PYBUN_PEP723_BACKEND=uv requires `uv` to be available in PATH"

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -439,6 +439,107 @@ print("test cleanup field")
 }
 
 // =============================================================================
+// Issue #267: cache_hit must report true on warm PEP 723 runs via the uv backend
+// =============================================================================
+
+/// Build a fake `uv` executable that mimics `uv run --script <path> [-- args...]`
+/// by simply forwarding execution to the system Python interpreter. This lets us
+/// exercise the `uv_run` PEP 723 backend path deterministically in CI without a
+/// network-dependent install, and without requiring a real `uv` binary.
+#[cfg(unix)]
+fn write_fake_uv(dir: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let uv_path = dir.join("uv");
+    let script = r#"#!/bin/sh
+set -e
+# Expected invocation: uv run --script <script> [-- args...]
+shift 2
+script="$1"
+shift
+if [ "$1" = "--" ]; then
+  shift
+fi
+exec python3 "$script" "$@"
+"#;
+    fs::write(&uv_path, script).unwrap();
+    let mut perms = fs::metadata(&uv_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&uv_path, perms).unwrap();
+    uv_path
+}
+
+#[cfg(unix)]
+#[test]
+fn run_pep723_uv_backend_reports_cache_hit_on_warm_run() {
+    let temp = tempdir().unwrap();
+    let fake_bin_dir = temp.path().join("fakebin");
+    fs::create_dir_all(&fake_bin_dir).unwrap();
+    write_fake_uv(&fake_bin_dir);
+
+    // Prepend our fake `uv` directory to PATH so `find_uv_executable()` picks it
+    // up ahead of any real `uv` that might also be installed.
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", fake_bin_dir.display(), existing_path);
+
+    let script = temp.path().join("warm_cache.py");
+    let content = r#"# /// script
+# dependencies = ["requests"]
+# ///
+print("hello from uv backend")
+"#;
+    fs::write(&script, content).unwrap();
+
+    let pybun_home = temp.path().join("home");
+
+    // First ("cold") run: no prior marker exists, so cache_hit must be false.
+    let cold_output = bin()
+        .env("PATH", &new_path)
+        .env("PYBUN_HOME", &pybun_home)
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun (cold)");
+    assert!(
+        cold_output.status.success(),
+        "cold run failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&cold_output.stdout),
+        String::from_utf8_lossy(&cold_output.stderr)
+    );
+    let cold_stdout = String::from_utf8_lossy(&cold_output.stdout);
+    let cold_json: Value = serde_json::from_str(&cold_stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {cold_stdout}"));
+    assert_eq!(
+        cold_json["detail"]["cache_hit"],
+        Value::Bool(false),
+        "cold run should report cache_hit=false, got: {cold_json}"
+    );
+
+    // Second ("warm") run of the identical script + dependency signature must
+    // report cache_hit=true (Issue #267): previously this always reported false
+    // for the uv backend regardless of whether the environment was reused.
+    let warm_output = bin()
+        .env("PATH", &new_path)
+        .env("PYBUN_HOME", &pybun_home)
+        .args(["--format=json", "run", script.to_str().unwrap()])
+        .output()
+        .expect("run pybun (warm)");
+    assert!(
+        warm_output.status.success(),
+        "warm run failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&warm_output.stdout),
+        String::from_utf8_lossy(&warm_output.stderr)
+    );
+    let warm_stdout = String::from_utf8_lossy(&warm_output.stdout);
+    let warm_json: Value = serde_json::from_str(&warm_stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {warm_stdout}"));
+    assert_eq!(
+        warm_json["detail"]["cache_hit"],
+        Value::Bool(true),
+        "warm run should report cache_hit=true, got: {warm_json}"
+    );
+}
+
+// =============================================================================
 // Issue #155: --format=json must report status "error" when child exits non-zero
 // =============================================================================
 


### PR DESCRIPTION
Closes #267

## Summary

- `pybun run` on a PEP 723 script with inline dependencies always reported `detail.cache_hit=false` in `--format=json` output on the default backend path — even on a "warm" second run that was demonstrably faster (e.g. 167ms vs 953ms) because of a resolver/dependency cache hit.
- Root cause: when `uv` is available in `PATH` (the default/most common environment), `pybun run` takes the `uv_run` backend path in `src/commands/mod.rs`, which hands the venv/dependency cache entirely to `uv run --script`. That branch hardcoded `cache_hit` to `false` unconditionally — it never even attempted to detect whether the invocation was a repeat of a previously-seen script signature.
- Fix: for the `uv_run` backend, reuse the same cache-key semantics already used by the native `pybun` backend (`Pep723Cache` / `Pep723CacheKey`, keyed on script path + normalized dependency list + Python version + index settings + lock hash). Before invoking `uv`, PyBun now checks whether a marker for this exact signature was recorded on a prior run; if so it reports `cache_hit=true`, otherwise `false`, and it records/refreshes the marker for the next run.
- This does not change how `uv` itself manages its cache — it only fixes PyBun's own JSON diagnostic reporting to accurately reflect a warm vs. cold invocation of the same script.

## Files changed

- `src/commands/mod.rs`: compute and report an accurate `cache_hit` for the `uv_run` PEP 723 backend path.
- `tests/cli_run.rs`: new integration test `run_pep723_uv_backend_reports_cache_hit_on_warm_run` that installs a fake `uv` executable (forwarding to `python3`, so no network/package install is needed) ahead of `PATH`, runs the same PEP 723 script twice with an isolated `PYBUN_HOME`, and asserts `detail.cache_hit == false` on the first run and `== true` on the second.

## Test plan

- [x] New integration test written first and confirmed to fail (Red) against the pre-fix code via `git stash`.
- [x] New integration test passes (Green) with the fix: `cargo test --test cli_run run_pep723_uv_backend_reports_cache_hit_on_warm_run -- --exact`.
- [x] Full suite: `cargo test` → 954 passed, 6 ignored (49 suites, ~288s).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → no issues found.
- [x] `cargo fmt -- --check` → clean.

Not merging — leaving open for human review as requested.