### PR TITLE
fix(outdated): self-heal corrupt pybun.lockb (Issue #325)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4782,8 +4782,25 @@ async fn run_outdated(args: &OutdatedArgs, collector: &mut EventCollector) -> Re
         return Err(eyre!(message));
     }
 
-    let lockfile = Lockfile::load_from_path(&lock_path)
-        .map_err(|e| eyre!("failed to load lockfile: {}", e))?;
+    // A pybun.lockb that exists but fails to decode (e.g. truncated by a
+    // crash mid-write, or corrupted on disk) is treated the same as a
+    // missing lockfile rather than propagated as a fatal error. This
+    // mirrors the self-heal behavior already applied to `load_script_lock`
+    // (issue #301, itself tracking the same failure mode as #299/#262) and
+    // to `run_upgrade`'s `Lockfile::load_from_path(&lock_path).ok()`. We
+    // fall back to "no packages currently locked", which naturally reduces
+    // `pybun outdated` to reporting nothing outdated rather than crashing.
+    let lockfile = match Lockfile::load_from_path(&lock_path) {
+        Ok(lockfile) => lockfile,
+        Err(e) => {
+            collector.warning(format!(
+                "discarded unreadable pybun.lockb at {} ({}); treating as no current lock",
+                lock_path.display(),
+                e
+            ));
+            Lockfile::new(Vec::new(), Vec::new())
+        }
+    };
 
     // Load constraints for "wanted" logic, optionally scoped by --member/--group
     let (constraints, scope_detail) = if let Ok(project) = Project::discover(&cwd) {

--- a/tests/cli_outdated.rs
+++ b/tests/cli_outdated.rs
@@ -76,3 +76,66 @@ dependencies = [
     // Testing logic works with mock index is better.
     // I'll skip complex setup for now and focus on `fails_without_lockfile` and maybe JSON flag check.
 }
+
+/// Regression test for Issue #325 (same pattern as #301/#299/#262): a
+/// `pybun.lockb` that exists but fails to decode (e.g. truncated by a crash
+/// mid-write) must be self-healed - treated as "no current lock" - rather
+/// than causing `pybun outdated` to hard-fail with a misleading "Run `pybun
+/// install`" suggestion (which won't fix an existing corrupt lockfile).
+#[test]
+fn outdated_self_heals_from_corrupt_lockfile() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    let pyproject = r#"
+[project]
+name = "test-outdated"
+version = "0.1.0"
+dependencies = ["requests"]
+"#;
+    fs::write(project_root.join("pyproject.toml"), pyproject).unwrap();
+
+    // Simulate a lockfile corrupted/truncated by a crash mid-write.
+    fs::write(
+        project_root.join("pybun.lockb"),
+        "this is not a valid bincode lockfile, truncated garbage",
+    )
+    .unwrap();
+
+    let output = bin()
+        .current_dir(project_root)
+        .args(["--format=json", "outdated"])
+        .output()
+        .expect("pybun outdated runs");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "pybun outdated should self-heal past a corrupt pybun.lockb, not fail: \
+         stdout={stdout}\nstderr={stderr}"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("valid JSON output from outdated");
+    assert_eq!(json["status"], "ok");
+
+    let diagnostics = json["diagnostics"]
+        .as_array()
+        .expect("diagnostics array present");
+    assert!(
+        diagnostics.iter().any(|d| {
+            d["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("pybun.lockb") && m.contains("no current lock"))
+        }),
+        "expected a self-heal diagnostic about the discarded corrupt lockfile: {diagnostics:?}"
+    );
+
+    // Must not claim the lockfile is simply missing.
+    assert!(
+        !stdout.contains("pybun.lockb not found"),
+        "corrupt lockfile should not be reported as missing: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #325

`run_outdated` in `src/commands/mod.rs` was the one remaining `Lockfile::load_from_path` call site that still hard-failed (`?`) on a corrupt/undecodable `pybun.lockb`, unlike sibling call sites in the same file that already self-heal on decode failure:

- `load_script_lock` (fixed in #301): treats decode failure as `Ok(None)`, logs an informational notice, falls back to PEP 723 declared deps.
- `run_upgrade`: calls `Lockfile::load_from_path(&lock_path).ok()` — corrupt lockfile silently treated as "no current lock".
- `check_lockfile_python_compatibility`: explicitly best-effort, skips validation on any failure.
- `src/mcp.rs` `pybun_doctor` lockfile check: treats decode failure as non-fatal "corrupt" status.

This PR mirrors that established convention: `run_outdated` now catches the decode error, logs a warning diagnostic ("discarded unreadable pybun.lockb ...; treating as no current lock"), and falls back to an empty lockfile (`Lockfile::new(vec![], vec![])`), instead of hard-failing with a misleading "Run `pybun install`" suggestion that wouldn't fix an already-existing corrupt lockfile.

- No behavior change for the missing-lockfile case (still the existing `E_LOCKFILE_NOT_FOUND` diagnostic + hard error).
- Corrupt-but-present lockfile now yields `status: "ok"` with an empty `outdated` list plus a warning diagnostic explaining the self-heal.

## Test plan

- [x] Added `outdated_self_heals_from_corrupt_lockfile` integration test in `tests/cli_outdated.rs` reproducing the exact repro from the issue (corrupt `pybun.lockb` + `pyproject.toml` with a dependency), asserting `status: "ok"`, a self-heal warning diagnostic, and no "not found" message.
- [x] Confirmed the new test fails (RED) against the pre-fix code, and passes (GREEN) after the fix.
- [x] `cargo test` — full suite passes (433 unit tests + all integration suites), except one pre-existing, unrelated flaky test (`duration_ms_in_response` in `tests/observability.rs`, a `pybun gc` wall-clock timing assertion that occasionally exceeds 30s under full-suite parallel contention; passes reliably in isolation and is untouched by this change).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues.
- [x] `cargo fmt -- --check` — clean.