### PR TITLE
fix(doctor): detect PyPI cache corruption (Issue #268)

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2047,6 +2047,38 @@ impl McpServer {
             }
         }
 
+        // Check the PyPI metadata cache directory (separate from the main
+        // cache root above - see issue #202). Flag stale/corrupt entries
+        // (e.g. unreadable `.bin`/`.json` files left over from an older or
+        // interrupted `pybun` run, see issue #268) as a non-fatal `info`
+        // status pointing at `pybun gc` as the fix, mirroring the CLI
+        // `pybun doctor` check and the `corrupt` lockfile status below.
+        if let Some(pypi_cache_dir) = crate::pypi::pypi_cache_dir() {
+            let stats = crate::pypi::pypi_cache_stats(&pypi_cache_dir);
+            let status = if stats.stale_count > 0 { "info" } else { "ok" };
+            checks.push(json!({
+                "name": "pypi_cache",
+                "status": status,
+                "message": format!(
+                    "PyPI metadata cache: {} ({} entries, {} stale)",
+                    pypi_cache_dir.display(),
+                    stats.entry_count,
+                    stats.stale_count,
+                ),
+                "path": pypi_cache_dir.display().to_string(),
+                "entry_count": stats.entry_count,
+                "total_bytes": stats.total_bytes,
+                "stale_count": stats.stale_count,
+                "hint": if stats.stale_count > 0 {
+                    json!("Run `pybun gc` to remove corrupt/stale PyPI cache entries")
+                } else {
+                    Value::Null
+                },
+            }));
+            // Stale/corrupt cache entries are non-fatal (self-healed on
+            // next fetch) - they do not flip `all_ok` to false.
+        }
+
         // Check for pyproject.toml
         match Project::discover(&working_dir) {
             Ok(project) => {

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -822,13 +822,20 @@ pub fn pypi_cache_dir() -> Option<PathBuf> {
 
 /// Returns `true` if `path` is a `.bin` PyPI cache entry that fails to
 /// deserialize as the current [`CacheEntry`] layout (e.g. left over from a
-/// pre-v0.1.19 pybun install, see issue #202). Such entries are never used
+/// pre-v0.1.19 pybun install, see issue #202), or a legacy `.json` cache
+/// entry that fails to parse as [`LegacyCacheEntry`] (e.g. corrupted by a
+/// crash or manual edit, see issue #268). Such entries are never used
 /// (see [`load_cache_from_paths`]) and are safe to remove.
 fn is_stale_pypi_cache_entry(path: &Path) -> bool {
-    path.extension().and_then(|e| e.to_str()) == Some("bin")
-        && fs::read(path)
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("bin") => fs::read(path)
             .map(|data| bincode::deserialize::<CacheEntry>(&data).is_err())
-            .unwrap_or(false)
+            .unwrap_or(false),
+        Some("json") => fs::read_to_string(path)
+            .map(|data| serde_json::from_str::<LegacyCacheEntry>(&data).is_err())
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 /// Summary statistics for the PyPI metadata cache directory.
@@ -1095,6 +1102,41 @@ mod tests {
 
         // Notices are drained after being taken.
         assert!(client.take_stale_cache_notices().is_empty());
+    }
+
+    #[test]
+    fn is_stale_pypi_cache_entry_flags_corrupt_legacy_json() {
+        // Regression test for issue #268: `pybun doctor` must be able to
+        // detect a corrupt legacy `.json` cache entry, not just corrupt
+        // `.bin` entries. `is_stale_pypi_cache_entry` backs both the
+        // `pypi_cache_stats` doctor check and `gc_stale_pypi_cache`.
+        let temp = tempdir().unwrap();
+        let dir = temp.path().join("cache");
+        fs::create_dir_all(&dir).unwrap();
+
+        let corrupt_json = dir.join("requests.json");
+        fs::write(&corrupt_json, b"not valid json{{{").unwrap();
+        assert!(is_stale_pypi_cache_entry(&corrupt_json));
+
+        let valid_json = dir.join("valid.json");
+        fs::write(
+            &valid_json,
+            br#"{"etag":null,"last_modified":null,"packages":[]}"#,
+        )
+        .unwrap();
+        assert!(!is_stale_pypi_cache_entry(&valid_json));
+    }
+
+    #[test]
+    fn pypi_cache_stats_counts_corrupt_legacy_json_as_stale() {
+        let temp = tempdir().unwrap();
+        let dir = temp.path().join("cache");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("requests.json"), b"not valid json{{{").unwrap();
+
+        let stats = pypi_cache_stats(&dir);
+        assert_eq!(stats.entry_count, 1);
+        assert_eq!(stats.stale_count, 1);
     }
 
     #[test]

--- a/tests/doctor_fix.rs
+++ b/tests/doctor_fix.rs
@@ -114,6 +114,55 @@ fn doctor_fix_surfaces_stale_pypi_cache_remediation() {
     );
 }
 
+/// Write a corrupt legacy `.json` PyPI cache entry (see issue #268 / #263):
+/// a malformed JSON payload that fails to parse as `LegacyCacheEntry`.
+fn write_corrupt_legacy_pypi_cache_entry(dir: &std::path::Path) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(dir.join("requests.json"), b"not valid json{{{").unwrap();
+}
+
+#[test]
+fn doctor_detects_corrupt_legacy_pypi_cache_json_entry() {
+    let temp = tempdir().unwrap();
+    let pypi_cache = temp.path().join("pypi-cache");
+    write_corrupt_legacy_pypi_cache_entry(&pypi_cache);
+
+    let output = pybun_bin()
+        .env("PYBUN_PYPI_CACHE_DIR", &pypi_cache)
+        .args(["--format=json", "doctor"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    // Doctor must not silently report all-clear when a cache entry is corrupt.
+    let checks = json["detail"]["checks"].as_array().expect("checks array");
+    let pypi_check = checks
+        .iter()
+        .find(|c| c["name"] == "pypi_cache")
+        .expect("pypi_cache check should be present");
+    assert_eq!(
+        pypi_check["stale_count"], 1,
+        "corrupt legacy .json cache entry should be counted as stale/corrupt"
+    );
+
+    let diagnostics = json["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array");
+    assert!(
+        diagnostics.iter().any(
+            |d| d["code"] == "I_DOCTOR_STALE_PYPI_CACHE" || d["code"] == "W_PYPI_CACHE_CORRUPT"
+        ),
+        "doctor should emit a non-fatal diagnostic pointing at the corrupt cache entry, got: {:?}",
+        diagnostics
+    );
+
+    // The overall doctor run must stay healthy - this is a warning, not fatal.
+    assert_eq!(json["status"], "ok");
+}
+
 #[test]
 fn doctor_fix_apply_removes_stale_pypi_cache_entry() {
     let temp = tempdir().unwrap();

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -203,6 +203,82 @@ fn mcp_tools_call_doctor() {
 }
 
 #[test]
+fn mcp_tools_call_doctor_detects_corrupt_pypi_cache() {
+    // Regression test for issue #268: the `pybun_doctor` MCP tool must flag
+    // a corrupt legacy `.json` PyPI cache entry as a non-fatal `info`
+    // status, the same way the CLI `pybun doctor` command does.
+    let temp = tempdir().unwrap();
+    let pypi_cache = temp.path().join("pypi-cache");
+    fs::create_dir_all(&pypi_cache).unwrap();
+    fs::write(pypi_cache.join("requests.json"), b"not valid json{{{").unwrap();
+
+    let mut child = pybun_bin()
+        .env("PYBUN_HOME", temp.path())
+        .env("PYBUN_PYPI_CACHE_DIR", &pypi_cache)
+        .args(["mcp", "serve", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to start MCP server");
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let init_req = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}"#;
+        writeln!(stdin, "{}", init_req).ok();
+
+        let call_req = r#"{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"pybun_doctor","arguments":{"verbose":true}}}"#;
+        writeln!(stdin, "{}", call_req).ok();
+        stdin.flush().ok();
+    }
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let mut found_pypi_cache_check = false;
+    for line in stdout.lines() {
+        if !line.starts_with('{') {
+            continue;
+        }
+        let Ok(response) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(text) = response
+            .get("result")
+            .and_then(|r| r.get("content"))
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+        else {
+            continue;
+        };
+        let Ok(doctor_result) = serde_json::from_str::<serde_json::Value>(text) else {
+            continue;
+        };
+        let Some(checks) = doctor_result.get("checks").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        if let Some(pypi_check) = checks.iter().find(|c| c["name"] == "pypi_cache") {
+            found_pypi_cache_check = true;
+            assert_eq!(
+                pypi_check["stale_count"], 1,
+                "corrupt legacy .json cache entry should be counted as stale/corrupt: {}",
+                pypi_check
+            );
+            assert_eq!(
+                pypi_check["status"], "info",
+                "corrupt cache entries should be a non-fatal info status, not error"
+            );
+        }
+    }
+
+    assert!(
+        found_pypi_cache_check,
+        "pybun_doctor response should include a pypi_cache check. Got: {}",
+        stdout
+    );
+}
+
+#[test]
 fn mcp_tools_call_run_inline_code() {
     let temp = tempdir().unwrap();
 


### PR DESCRIPTION
## Summary

- `pybun doctor` previously only flagged corrupt/stale PyPI metadata cache entries when they used the `.bin` extension (see issue #202's `is_stale_pypi_cache_entry`). A corrupt legacy `.json` cache file — the exact shape produced by issue #263 — was invisible to `doctor`, so it reported "All checks passed" even in an environment where `pybun add`/`install` could hit a fatal `E_RESOLVE_IO` error caused by that same corrupt file.
- Extends `is_stale_pypi_cache_entry` in `src/pypi.rs` to also attempt to parse `.json` cache entries as `LegacyCacheEntry`, reusing the exact parsing logic already used by the runtime cache loader (`load_cache_from_paths`) rather than duplicating it.
- This flows straight through the existing `pypi_cache_stats` / `I_DOCTOR_STALE_PYPI_CACHE` non-fatal diagnostic path that both `pybun doctor` and `pybun doctor --fix` already use for `.bin` corruption (pointing at `pybun gc` as the fix), so `.json` corruption now gets the same warning-level (non-fatal) treatment, fix-candidate suggestion, and `--fix --apply` remediation for free.
- Adds the equivalent `pypi_cache` check to the `pybun_doctor` MCP tool in `src/mcp.rs`, which previously had no PyPI cache validation at all.

## Test plan

- [x] Added a failing-first integration test (`doctor_detects_corrupt_legacy_pypi_cache_json_entry` in `tests/doctor_fix.rs`) reproducing the exact repro from the issue (`PYBUN_PYPI_CACHE_DIR` pointed at a dir containing a corrupt `requests.json`), confirmed it failed before the fix and passes after.
- [x] Added unit tests for the extracted cache-validation helper (`is_stale_pypi_cache_entry_flags_corrupt_legacy_json`, `pypi_cache_stats_counts_corrupt_legacy_json_as_stale` in `src/pypi.rs`).
- [x] Added an MCP-level test (`mcp_tools_call_doctor_detects_corrupt_pypi_cache` in `tests/mcp.rs`) asserting the `pybun_doctor` tool surfaces the same non-fatal `pypi_cache` check.
- [x] `cargo test` — full suite passes (`rtk proxy cargo test` raw run: all suites `ok`, no `FAILED` entries).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.

Closes #268