### PR TITLE
fix(diagnostics): JSON contract gaps — exit diagnostics + code naming (Issue #266)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -324,39 +324,54 @@ pub async fn execute(cli: Cli) -> Result<()> {
                 }) => {
                     collector.event(EventType::ScriptEnd);
 
-                    // Enrich diagnostics with structured traceback when the script failed
-                    if exit_code != 0
-                        && let Some(tb) = stderr.as_deref().and_then(crate::traceback::parse)
-                    {
-                        let mut diag = Diagnostic::error(tb.message.clone());
-                        diag.code = Some(tb.code);
-                        diag.file = tb.location.as_ref().map(|l| l.file.clone());
-                        diag.line = tb.location.as_ref().map(|l| l.line);
-                        diag.exception_type = Some(tb.exception_type);
-                        diag.location = tb.location.as_ref().map(|loc| {
-                            json!({
-                                "file": loc.file,
-                                "line": loc.line,
-                                "function": loc.function,
-                            })
-                        });
-                        if let Some(action) = &tb.next_action {
-                            diag.suggestion = Some(format!(
-                                "Run: pybun add {}",
-                                action
-                                    .args
-                                    .get("package")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                            ));
+                    // Enrich diagnostics with structured traceback when the script failed.
+                    // If the script exited nonzero without a parseable Python traceback on
+                    // stderr (e.g. a plain `sys.exit(N)`), still emit a diagnostic so
+                    // `diagnostics[]` is never empty on a failed run (Issue #266) — callers
+                    // should not have to fall back to inspecting `detail.exit_code` alone.
+                    if exit_code != 0 {
+                        match stderr.as_deref().and_then(crate::traceback::parse) {
+                            Some(tb) => {
+                                let mut diag = Diagnostic::error(tb.message.clone());
+                                diag.code = Some(tb.code);
+                                diag.file = tb.location.as_ref().map(|l| l.file.clone());
+                                diag.line = tb.location.as_ref().map(|l| l.line);
+                                diag.exception_type = Some(tb.exception_type);
+                                diag.location = tb.location.as_ref().map(|loc| {
+                                    json!({
+                                        "file": loc.file,
+                                        "line": loc.line,
+                                        "function": loc.function,
+                                    })
+                                });
+                                if let Some(action) = &tb.next_action {
+                                    diag.suggestion = Some(format!(
+                                        "Run: pybun add {}",
+                                        action
+                                            .args
+                                            .get("package")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("")
+                                    ));
+                                }
+                                diag.next_action = tb.next_action.map(|a| {
+                                    json!({
+                                        "tool": a.tool,
+                                        "args": a.args,
+                                    })
+                                });
+                                collector.diagnostic(diag);
+                            }
+                            None => {
+                                collector.error_with_code(
+                                    "E_SCRIPT_EXIT_NONZERO",
+                                    format!(
+                                        "Script exited with a nonzero status (exit_code={exit_code})"
+                                    ),
+                                    "Check detail.exit_code and the script's stdout/stderr for the cause.",
+                                );
+                            }
                         }
-                        diag.next_action = tb.next_action.map(|a| {
-                            json!({
-                                "tool": a.tool,
-                                "args": a.args,
-                            })
-                        });
-                        collector.diagnostic(diag);
                     }
 
                     let sandbox_detail = sandbox.as_ref().map(|s| {

--- a/src/traceback.rs
+++ b/src/traceback.rs
@@ -1,7 +1,7 @@
 //! Python traceback parser for structured diagnostic output.
 //!
 //! Converts raw Python stderr into machine-readable `ParsedTraceback` values
-//! with stable dot-notation error codes and structured `next_action` hints.
+//! with stable `E_*` error codes and structured `next_action` hints.
 
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +28,7 @@ pub struct TracebackLocation {
 /// Parsed representation of a Python exception.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParsedTraceback {
-    /// Stable dot-notation error code (e.g. `runtime.module_not_found`).
+    /// Stable `E_*` error code (e.g. `E_RUNTIME_MODULE_NOT_FOUND`).
     pub code: String,
     /// Python exception class name (e.g. `ModuleNotFoundError`).
     pub exception_type: String,
@@ -187,41 +187,41 @@ fn extract_exception(stderr: &str) -> Option<(String, String)> {
     None
 }
 
-/// Map a Python exception type (and optionally message) to a stable dot-notation code.
+/// Map a Python exception type (and optionally message) to a stable `E_*` code.
 fn map_exception_to_code(exception_type: &str, message: &str) -> String {
     // Normalise dotted names: take only the last component
     let base = exception_type.rsplit('.').next().unwrap_or(exception_type);
 
     match base {
-        "ModuleNotFoundError" => "runtime.module_not_found".to_string(),
+        "ModuleNotFoundError" => "E_RUNTIME_MODULE_NOT_FOUND".to_string(),
         "ImportError" => {
             if message.contains("No module named") {
-                "runtime.module_not_found".to_string()
+                "E_RUNTIME_MODULE_NOT_FOUND".to_string()
             } else {
-                "runtime.import_error".to_string()
+                "E_RUNTIME_IMPORT_ERROR".to_string()
             }
         }
-        "SyntaxError" | "IndentationError" | "TabError" => "runtime.syntax_error".to_string(),
-        "TypeError" => "runtime.type_error".to_string(),
-        "AttributeError" => "runtime.attribute_error".to_string(),
-        "PermissionError" => "runtime.permission_denied".to_string(),
-        "FileNotFoundError" => "runtime.file_not_found".to_string(),
-        "ValueError" => "runtime.value_error".to_string(),
-        "KeyError" => "runtime.key_error".to_string(),
-        "IndexError" => "runtime.index_error".to_string(),
-        "NameError" | "UnboundLocalError" => "runtime.name_error".to_string(),
-        "RecursionError" => "runtime.recursion_error".to_string(),
-        "MemoryError" => "runtime.memory_error".to_string(),
-        "TimeoutError" | "asyncio.TimeoutError" => "runtime.timeout".to_string(),
-        "SystemExit" => "runtime.exit_nonzero".to_string(),
-        "KeyboardInterrupt" => "runtime.interrupted".to_string(),
-        "AssertionError" => "runtime.assertion_error".to_string(),
-        "OSError" | "IOError" => "runtime.io_error".to_string(),
+        "SyntaxError" | "IndentationError" | "TabError" => "E_RUNTIME_SYNTAX_ERROR".to_string(),
+        "TypeError" => "E_RUNTIME_TYPE_ERROR".to_string(),
+        "AttributeError" => "E_RUNTIME_ATTRIBUTE_ERROR".to_string(),
+        "PermissionError" => "E_RUNTIME_PERMISSION_DENIED".to_string(),
+        "FileNotFoundError" => "E_RUNTIME_FILE_NOT_FOUND".to_string(),
+        "ValueError" => "E_RUNTIME_VALUE_ERROR".to_string(),
+        "KeyError" => "E_RUNTIME_KEY_ERROR".to_string(),
+        "IndexError" => "E_RUNTIME_INDEX_ERROR".to_string(),
+        "NameError" | "UnboundLocalError" => "E_RUNTIME_NAME_ERROR".to_string(),
+        "RecursionError" => "E_RUNTIME_RECURSION_ERROR".to_string(),
+        "MemoryError" => "E_RUNTIME_MEMORY_ERROR".to_string(),
+        "TimeoutError" | "asyncio.TimeoutError" => "E_RUNTIME_TIMEOUT".to_string(),
+        "SystemExit" => "E_RUNTIME_EXIT_NONZERO".to_string(),
+        "KeyboardInterrupt" => "E_RUNTIME_INTERRUPTED".to_string(),
+        "AssertionError" => "E_RUNTIME_ASSERTION_ERROR".to_string(),
+        "OSError" | "IOError" => "E_RUNTIME_IO_ERROR".to_string(),
         "ConnectionError"
         | "ConnectionRefusedError"
         | "ConnectionResetError"
-        | "BrokenPipeError" => "runtime.connection_error".to_string(),
-        _ => "runtime.unknown".to_string(),
+        | "BrokenPipeError" => "E_RUNTIME_CONNECTION_ERROR".to_string(),
+        _ => "E_RUNTIME_UNKNOWN".to_string(),
     }
 }
 
@@ -324,7 +324,7 @@ ModuleNotFoundError: No module named 'sklearn'"#;
     #[test]
     fn parse_module_not_found_code() {
         let tb = parse(MODULE_NOT_FOUND).unwrap();
-        assert_eq!(tb.code, "runtime.module_not_found");
+        assert_eq!(tb.code, "E_RUNTIME_MODULE_NOT_FOUND");
     }
 
     #[test]
@@ -367,7 +367,7 @@ ModuleNotFoundError: No module named 'sklearn'"#;
     #[test]
     fn parse_syntax_error_code() {
         let tb = parse(SYNTAX_ERROR).unwrap();
-        assert_eq!(tb.code, "runtime.syntax_error");
+        assert_eq!(tb.code, "E_RUNTIME_SYNTAX_ERROR");
         assert_eq!(tb.exception_type, "SyntaxError");
     }
 
@@ -388,7 +388,7 @@ ModuleNotFoundError: No module named 'sklearn'"#;
     #[test]
     fn parse_type_error_code() {
         let tb = parse(TYPE_ERROR).unwrap();
-        assert_eq!(tb.code, "runtime.type_error");
+        assert_eq!(tb.code, "E_RUNTIME_TYPE_ERROR");
         assert_eq!(tb.exception_type, "TypeError");
     }
 
@@ -404,19 +404,19 @@ ModuleNotFoundError: No module named 'sklearn'"#;
     #[test]
     fn parse_attribute_error_code() {
         let tb = parse(ATTRIBUTE_ERROR).unwrap();
-        assert_eq!(tb.code, "runtime.attribute_error");
+        assert_eq!(tb.code, "E_RUNTIME_ATTRIBUTE_ERROR");
     }
 
     #[test]
     fn parse_name_error_code() {
         let tb = parse(NAME_ERROR).unwrap();
-        assert_eq!(tb.code, "runtime.name_error");
+        assert_eq!(tb.code, "E_RUNTIME_NAME_ERROR");
     }
 
     #[test]
     fn parse_file_not_found_code() {
         let tb = parse(FILE_NOT_FOUND).unwrap();
-        assert_eq!(tb.code, "runtime.file_not_found");
+        assert_eq!(tb.code, "E_RUNTIME_FILE_NOT_FOUND");
         assert_eq!(tb.exception_type, "FileNotFoundError");
     }
 
@@ -458,7 +458,7 @@ RuntimeError: boom"#,
 KeyboardInterrupt"#;
 
         let tb = parse(stderr).unwrap();
-        assert_eq!(tb.code, "runtime.interrupted");
+        assert_eq!(tb.code, "E_RUNTIME_INTERRUPTED");
         assert_eq!(tb.exception_type, "KeyboardInterrupt");
         assert_eq!(tb.message, "");
     }
@@ -470,7 +470,7 @@ KeyboardInterrupt"#;
     raise MyCustomError("oops")
 MyCustomError: oops"#;
         let tb = parse(stderr).unwrap();
-        assert_eq!(tb.code, "runtime.unknown");
+        assert_eq!(tb.code, "E_RUNTIME_UNKNOWN");
         assert_eq!(tb.exception_type, "MyCustomError");
     }
 
@@ -510,12 +510,12 @@ ValueError: deep error"#;
     #[test]
     fn map_import_error_with_no_module_message() {
         let code = map_exception_to_code("ImportError", "No module named 'requests'");
-        assert_eq!(code, "runtime.module_not_found");
+        assert_eq!(code, "E_RUNTIME_MODULE_NOT_FOUND");
     }
 
     #[test]
     fn map_import_error_without_no_module_message() {
         let code = map_exception_to_code("ImportError", "cannot import name 'foo' from 'bar'");
-        assert_eq!(code, "runtime.import_error");
+        assert_eq!(code, "E_RUNTIME_IMPORT_ERROR");
     }
 }

--- a/tests/cli_run.rs
+++ b/tests/cli_run.rs
@@ -129,7 +129,7 @@ fn run_json_traceback_diagnostic_matches_mcp_shape() {
         .unwrap_or_else(|| panic!("expected traceback diagnostic, got: {value}"));
 
     assert_eq!(diagnostic["level"], "error");
-    assert_eq!(diagnostic["code"], "runtime.module_not_found");
+    assert_eq!(diagnostic["code"], "E_RUNTIME_MODULE_NOT_FOUND");
     assert_eq!(diagnostic["exception_type"], "ModuleNotFoundError");
     assert_eq!(diagnostic["location"]["file"], "main.py");
     assert_eq!(diagnostic["location"]["line"], 1);
@@ -186,6 +186,41 @@ fn run_inline_code_propagates_nonzero_exit_code() {
         output.status.code(),
         Some(7),
         "pybun must exit with the inline code's exit code"
+    );
+}
+
+// Issue #266: a plain nonzero script exit (no Python traceback on stderr) must
+// still produce a non-empty `diagnostics[]` array with a dedicated E_* code,
+// rather than leaving diagnostics empty while only detail.exit_code signals
+// failure.
+#[test]
+fn run_json_nonzero_exit_without_traceback_has_diagnostic() {
+    let output = bin()
+        .args(["--format=json", "run", "-c", "import sys; sys.exit(7)"])
+        .output()
+        .expect("run pybun");
+    assert_eq!(output.status.code(), Some(7));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("expected valid JSON, got: {stdout}"));
+    assert_eq!(value["status"], "error");
+    assert_eq!(value["detail"]["exit_code"], 7);
+
+    let diagnostics = value["diagnostics"].as_array().expect("diagnostics array");
+    assert!(
+        !diagnostics.is_empty(),
+        "expected a non-empty diagnostics array for nonzero script exit, got: {value}"
+    );
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic["level"], "error");
+    assert_eq!(diagnostic["code"], "E_SCRIPT_EXIT_NONZERO");
+    assert!(
+        diagnostic["message"]
+            .as_str()
+            .expect("message string")
+            .contains('7'),
+        "expected exit_code 7 cross-referenced in message, got: {diagnostic}"
     );
 }
 

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -1266,7 +1266,7 @@ fn run_mcp_pybun_run(code: &str) -> String {
 fn mcp_pybun_run_module_not_found_has_diagnostics() {
     let stdout = run_mcp_pybun_run("import numpy_does_not_exist");
     assert!(
-        stdout.contains("runtime.module_not_found") || stdout.contains("module_not_found"),
+        stdout.contains("E_RUNTIME_MODULE_NOT_FOUND"),
         "Expected structured diagnostic code in response. Got: {stdout}"
     );
 }
@@ -1294,7 +1294,7 @@ fn mcp_pybun_run_success_has_no_diagnostics() {
     let stdout = run_mcp_pybun_run("print('ok')");
     // Diagnostics should be null or absent on success
     assert!(
-        !stdout.contains("runtime."),
+        !stdout.contains("E_RUNTIME_"),
         "Successful run should not have error diagnostics. Got: {stdout}"
     );
 }
@@ -1303,7 +1303,7 @@ fn mcp_pybun_run_success_has_no_diagnostics() {
 fn mcp_pybun_run_syntax_error_has_diagnostics() {
     let stdout = run_mcp_pybun_run("def bad(\n  pass");
     assert!(
-        stdout.contains("runtime.syntax_error") || stdout.contains("syntax_error"),
+        stdout.contains("E_RUNTIME_SYNTAX_ERROR"),
         "Expected syntax_error diagnostic. Got: {stdout}"
     );
 }


### PR DESCRIPTION
Closes #266

## Summary
- Fix Gap 1 (empty `diagnostics: []` on plain script exit failure): `pybun run` now emits an `E_SCRIPT_EXIT_NONZERO` diagnostic when the script/child process exits nonzero and no Python traceback could be parsed from stderr (e.g. `sys.exit(7)` with no exception). The diagnostic message cross-references `detail.exit_code`.
- Fix Gap 2 (inconsistent diagnostic code naming): renamed all lowercase dot-notation codes produced by `src/traceback.rs` to the `E_*` uppercase-underscore convention used everywhere else in the codebase, so `diagnostics[].code` is consistently `E_*` across the whole JSON contract.

### Breaking change
This renames the following diagnostic `code` strings (used by both `pybun run --format=json` and the MCP `pybun_run` tool):

| old | new |
|---|---|
| `runtime.module_not_found` | `E_RUNTIME_MODULE_NOT_FOUND` |
| `runtime.import_error` | `E_RUNTIME_IMPORT_ERROR` |
| `runtime.syntax_error` | `E_RUNTIME_SYNTAX_ERROR` |
| `runtime.type_error` | `E_RUNTIME_TYPE_ERROR` |
| `runtime.attribute_error` | `E_RUNTIME_ATTRIBUTE_ERROR` |
| `runtime.permission_denied` | `E_RUNTIME_PERMISSION_DENIED` |
| `runtime.file_not_found` | `E_RUNTIME_FILE_NOT_FOUND` |
| `runtime.value_error` | `E_RUNTIME_VALUE_ERROR` |
| `runtime.key_error` | `E_RUNTIME_KEY_ERROR` |
| `runtime.index_error` | `E_RUNTIME_INDEX_ERROR` |
| `runtime.name_error` | `E_RUNTIME_NAME_ERROR` |
| `runtime.recursion_error` | `E_RUNTIME_RECURSION_ERROR` |
| `runtime.memory_error` | `E_RUNTIME_MEMORY_ERROR` |
| `runtime.timeout` | `E_RUNTIME_TIMEOUT` |
| `runtime.exit_nonzero` | `E_RUNTIME_EXIT_NONZERO` |
| `runtime.interrupted` | `E_RUNTIME_INTERRUPTED` |
| `runtime.assertion_error` | `E_RUNTIME_ASSERTION_ERROR` |
| `runtime.io_error` | `E_RUNTIME_IO_ERROR` |
| `runtime.connection_error` | `E_RUNTIME_CONNECTION_ERROR` |
| `runtime.unknown` | `E_RUNTIME_UNKNOWN` |

No backwards-compat aliasing was added per repo convention (clean rename).

## Test plan
- [x] Added `run_json_nonzero_exit_without_traceback_has_diagnostic` in `tests/cli_run.rs` — verifies `pybun --format=json run -c "import sys; sys.exit(7)"` now returns a non-empty `diagnostics[]` with code `E_SCRIPT_EXIT_NONZERO` and the exit code cross-referenced in the message.
- [x] Updated `run_json_traceback_diagnostic_matches_mcp_shape` in `tests/cli_run.rs` to assert the renamed `E_RUNTIME_MODULE_NOT_FOUND` code.
- [x] Updated `tests/mcp.rs` assertions (`mcp_pybun_run_module_not_found_has_diagnostics`, `mcp_pybun_run_success_has_no_diagnostics`, `mcp_pybun_run_syntax_error_has_diagnostics`) to check for the `E_*` codes.
- [x] `cargo test` — full suite passes (983 passed, 6 ignored, 0 failed).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.