### PR TITLE
fix(pypi): document cache directory precedence (Issue #269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ pybun schema check
 | `PYBUN_TELEMETRY` | Override telemetry setting (0/1) |
 | `PYBUN_PROGRESS` | Override `--progress` (auto/always/never) |
 | `PYBUN_PYPI_BASE_URL` | Override the PyPI index base URL |
-| `PYBUN_PYPI_CACHE_DIR` | Override the PyPI metadata cache directory |
+| `PYBUN_PYPI_CACHE_DIR` | Override the PyPI metadata cache directory. By default this uses the platform cache directory plus `pybun/pypi` (for example `~/Library/Caches/pybun/pypi` on macOS). Current binary cache entries use `.bin`; legacy `.json` entries are only read from the same directory as a fallback. |
 | `PYBUN_AUDIT_LOG` | Override the MCP audit log path (`/dev/null` disables it) |
 | `PYBUN_SANDBOX_ALLOW_NETWORK` | Allow network access under `--sandbox` |
 

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -113,7 +113,7 @@ graph TD
 
   * **単一バイナリ:** macOS/Linux では静的リンク優先（openssl, libz は同梱）、Windows は MSVC 再頒布依存のみ。
   * **内蔵CPython:** バイナリ内にバンドル。欠損バージョンは初回起動時に署名付きアーカイブをダウンロードしてキャッシュ。
-  * **データディレクトリ:** `~/.cache/pybun`（環境変数 `PYBUN_HOME` で上書き）。環境、wheel、ログを階層管理。
+  * **データディレクトリ:** `~/.cache/pybun`（環境変数 `PYBUN_HOME` で上書き）。環境、wheel、ログを階層管理。PyPI metadata cache は別契約で、`PYBUN_PYPI_CACHE_DIR` が指定された場合はそのディレクトリを使い、未指定時は OS の platform cache directory 配下の `pybun/pypi`（macOS 例: `~/Library/Caches/pybun/pypi`）を使う。現在の binary cache は `.bin`、同じディレクトリ内の legacy `.json` は fallback としてのみ読む。
   * **自己更新:** `pybun self update` でバージョン取得・署名検証・アトミック置換。
 
 ### 4.1 高速パッケージマネージャ (The Installer)

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -139,18 +139,26 @@ pub struct PyPiClient {
     stale_cache_notices: Arc<Mutex<Vec<String>>>,
 }
 
+fn resolve_pypi_cache_dir(
+    env_override: Option<&str>,
+    platform_cache_dir: Option<PathBuf>,
+) -> Result<PathBuf, PyPiError> {
+    if let Some(path) = env_override {
+        return Ok(PathBuf::from(path));
+    }
+
+    platform_cache_dir
+        .map(|p| p.join("pybun").join("pypi"))
+        .ok_or(PyPiError::CacheDirUnavailable)
+}
+
 impl PyPiClient {
     pub fn from_env(offline: bool) -> Result<Self, PyPiError> {
         let base =
             std::env::var("PYBUN_PYPI_BASE_URL").unwrap_or_else(|_| "https://pypi.org".to_string());
         let normalized = normalize_base(&base)?;
-        let cache_dir = std::env::var("PYBUN_PYPI_CACHE_DIR")
-            .map(PathBuf::from)
-            .or_else(|_| {
-                dirs::cache_dir()
-                    .map(|p| p.join("pybun").join("pypi"))
-                    .ok_or(PyPiError::CacheDirUnavailable)
-            })?;
+        let cache_dir_override = std::env::var("PYBUN_PYPI_CACHE_DIR").ok();
+        let cache_dir = resolve_pypi_cache_dir(cache_dir_override.as_deref(), dirs::cache_dir())?;
         Ok(Self {
             base: normalized,
             cache_dir,
@@ -999,6 +1007,32 @@ mod tests {
         let policy = HttpCachePolicy::from_headers(&headers, 100);
         assert!(policy.is_fresh(160));
         assert!(!policy.is_fresh(161));
+    }
+
+    #[test]
+    fn pypi_cache_dir_defaults_to_platform_cache_pybun_pypi() {
+        let platform_cache = PathBuf::from("/tmp/platform-cache");
+
+        let cache_dir = resolve_pypi_cache_dir(None, Some(platform_cache.clone())).unwrap();
+
+        assert_eq!(cache_dir, platform_cache.join("pybun").join("pypi"));
+    }
+
+    #[test]
+    fn pypi_cache_dir_env_override_takes_precedence() {
+        let override_dir = "/tmp/custom-pypi-cache";
+        let platform_cache = PathBuf::from("/tmp/platform-cache");
+
+        let cache_dir = resolve_pypi_cache_dir(Some(override_dir), Some(platform_cache)).unwrap();
+
+        assert_eq!(cache_dir, PathBuf::from(override_dir));
+    }
+
+    #[test]
+    fn pypi_cache_dir_errors_when_no_override_or_platform_cache_exists() {
+        let err = resolve_pypi_cache_dir(None, None).unwrap_err();
+
+        assert!(matches!(err, PyPiError::CacheDirUnavailable));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #269

## Summary
- Extract PyPI metadata cache directory resolution into a small testable helper while preserving current behavior.
- Add tests for PYBUN_PYPI_CACHE_DIR override precedence, platform cache default, and unavailable cache-dir error handling.
- Document that PyPI metadata cache defaults to the platform cache directory plus pybun/pypi, and that .bin and legacy .json entries share that directory.

## Test plan
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test pypi_cache_dir
- cargo test binary_cache_roundtrip
- cargo test corrupt_legacy_json_cache_is_treated_as_cache_miss
- cargo test
- cargo audit (passes with existing allowed RUSTSEC-2026-0190 warning)

## Review
- reviewer subagent: APPROVE, no blocking correctness or security findings.