### PR TITLE
chore(deps): trim tokio feature flags from full to minimal set (Issue #274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,16 +1486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,7 +2317,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,13 @@ ed25519-dalek = { version = "2.1", features = ["std"] }
 fs2 = "0.4"
 # Native file system watcher (optional, for `pybun watch`)
 notify = { version = "8.2", optional = true }
-tokio = { version = "1.48.0", features = [
+tokio = { version = "1.48.0", default-features = false, features = [
   "rt",
   "fs",
   "io-util",
   "io-std",
   "time",
   "sync",
-  "macros",
 ] }
 reqwest = { version = "0.12.25", default-features = false, features = ["blocking", "json", "rustls-tls", "stream"] }
 # Floor pin: reqwest pulls in rustls → rustls-webpki transitively.
@@ -59,3 +58,4 @@ predicates = "3.1"
 tempfile = "3.14"
 httpmock = "0.8"
 regex = "1.11"
+tokio = { version = "1.48.0", default-features = false, features = ["macros", "net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,15 @@ ed25519-dalek = { version = "2.1", features = ["std"] }
 fs2 = "0.4"
 # Native file system watcher (optional, for `pybun watch`)
 notify = { version = "8.2", optional = true }
-tokio = { version = "1.48.0", features = ["full"] }
+tokio = { version = "1.48.0", features = [
+  "rt",
+  "fs",
+  "io-util",
+  "io-std",
+  "time",
+  "sync",
+  "macros",
+] }
 reqwest = { version = "0.12.25", default-features = false, features = ["blocking", "json", "rustls-tls", "stream"] }
 # Floor pin: reqwest pulls in rustls → rustls-webpki transitively.
 # >= 0.103.13 clears RUSTSEC-2026-0104/0098/0099/0049 (Issue #156).

--- a/tests/dependency_features.rs
+++ b/tests/dependency_features.rs
@@ -1,0 +1,46 @@
+use toml::Value;
+
+fn dependency_features<'a>(manifest: &'a Value, section: &str, name: &str) -> Vec<&'a str> {
+    manifest[section][name]["features"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{section}.{name}.features must be an array"))
+        .iter()
+        .map(|feature| {
+            feature
+                .as_str()
+                .unwrap_or_else(|| panic!("{section}.{name} features must be strings"))
+        })
+        .collect()
+}
+
+#[test]
+fn tokio_runtime_and_test_features_are_separated() {
+    let manifest: Value =
+        toml::from_str(include_str!("../Cargo.toml")).expect("Cargo.toml should parse");
+
+    assert_eq!(
+        manifest["dependencies"]["tokio"]["default-features"].as_bool(),
+        Some(false),
+        "production tokio dependency should opt out of implicit defaults"
+    );
+    let runtime_features = dependency_features(&manifest, "dependencies", "tokio");
+    for feature in ["full", "macros", "net"] {
+        assert!(
+            !runtime_features.contains(&feature),
+            "the direct production tokio dependency must not request test-only feature {feature}"
+        );
+    }
+
+    assert_eq!(
+        manifest["dev-dependencies"]["tokio"]["default-features"].as_bool(),
+        Some(false),
+        "test tokio dependency should opt out of implicit defaults"
+    );
+    let test_features = dependency_features(&manifest, "dev-dependencies", "tokio");
+    for feature in ["macros", "net"] {
+        assert!(
+            test_features.contains(&feature),
+            "tests directly require tokio feature {feature}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #274

## Summary
- Replaced Tokio's `full` feature with the production features used directly by PyBun: `rt`, `fs`, `io-util`, `io-std`, `time`, and `sync`.
- Set `default-features = false` explicitly.
- Moved test-only `macros` and `net` features to the dev dependency. This keeps `#[tokio::test]` and the direct `TcpListener` tests declared without shipping `tokio-macros` in production builds.
- Added `tests/dependency_features.rs` to guard the production/dev feature boundary.

## Verification
- `cargo test`: 993 passed, 6 ignored.
- `cargo test --test dependency_features`: passed.
- `cargo check --locked --all-targets --all-features`: passed.
- `cargo build --locked --release --no-default-features`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt -- --check`: passed.
- `cargo audit`: no unallowed vulnerabilities; existing allowed RUSTSEC-2026-0190 warning only.
- `cargo deny check licenses`: passed with existing unmatched-allowance warnings.
- `pip-audit`: no known vulnerabilities.
