### PR TITLE
refactor: extract shared spawn/timeout/kill logic into proc_exec (Issue #273)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod once_map;
 pub mod paths;
 pub mod pep723;
 pub mod pep723_cache;
+pub mod proc_exec;
 pub mod profiles;
 pub mod progress;
 pub mod project;

--- a/src/proc_exec.rs
+++ b/src/proc_exec.rs
@@ -1,0 +1,178 @@
+//! Shared process spawn/timeout/kill helper.
+//!
+//! `sandbox::execute_sandboxed` and `test_executor::run_with_timeout` used to
+//! independently implement the same ~40 lines of process-management logic:
+//! spawn a child, drain its stdout/stderr on background threads (so a chatty
+//! process can't deadlock on a full pipe buffer), poll for exit, and kill the
+//! child if it exceeds a wall-clock timeout. This module is the single
+//! implementation both call sites delegate to (Issue #273).
+
+use std::io::Read;
+use std::process::{Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Outcome of running a command to completion, possibly subject to a
+/// wall-clock timeout.
+pub enum ProcExecOutcome {
+    /// The process exited on its own (or no timeout was configured).
+    Completed {
+        status: ExitStatus,
+        /// `Some` only when `capture` was requested by the caller.
+        stdout: Option<Vec<u8>>,
+        stderr: Option<Vec<u8>>,
+    },
+    /// The process was killed because it exceeded the configured timeout.
+    TimedOut,
+}
+
+/// Spawn `cmd`, optionally capturing stdout/stderr, and kill it if it runs
+/// longer than `timeout_secs` (`None` or `Some(0)` means unlimited). Reader
+/// threads drain the pipes concurrently so a chatty process can't deadlock on
+/// a full pipe buffer while we poll for exit.
+pub fn spawn_with_timeout(
+    cmd: &mut Command,
+    timeout_secs: Option<u64>,
+    capture: bool,
+) -> std::io::Result<ProcExecOutcome> {
+    if capture {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+    }
+
+    let mut child = cmd.spawn()?;
+
+    let stdout_handle = child.stdout.take().map(spawn_pipe_reader);
+    let stderr_handle = child.stderr.take().map(spawn_pipe_reader);
+
+    let timeout = timeout_secs
+        .filter(|&secs| secs > 0)
+        .map(Duration::from_secs);
+    let poll_interval = Duration::from_millis(50);
+    let start = Instant::now();
+
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+
+        if let Some(timeout) = timeout
+            && start.elapsed() >= timeout
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            join_pipe_reader(stdout_handle);
+            join_pipe_reader(stderr_handle);
+            return Ok(ProcExecOutcome::TimedOut);
+        }
+
+        thread::sleep(poll_interval);
+    };
+
+    let stdout = join_pipe_reader(stdout_handle);
+    let stderr = join_pipe_reader(stderr_handle);
+
+    Ok(ProcExecOutcome::Completed {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+/// Spawn a thread that reads a child process pipe to completion.
+pub fn spawn_pipe_reader<R>(mut reader: R) -> thread::JoinHandle<Vec<u8>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    })
+}
+
+/// Join a pipe reader thread, discarding the handle. Returns `None` if there
+/// was no pipe to read or the thread panicked.
+pub fn join_pipe_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Option<Vec<u8>> {
+    handle.and_then(|h| h.join().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completes_normally_before_timeout() {
+        let mut cmd = Command::new("true");
+        let outcome = spawn_with_timeout(&mut cmd, Some(5), false).expect("spawn should succeed");
+        match outcome {
+            ProcExecOutcome::Completed { status, .. } => {
+                assert!(status.success());
+            }
+            ProcExecOutcome::TimedOut => panic!("expected process to complete, not time out"),
+        }
+    }
+
+    #[test]
+    fn captures_stdout_and_stderr_when_requested() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("echo out; echo err 1>&2");
+        let outcome = spawn_with_timeout(&mut cmd, None, true).expect("spawn should succeed");
+        match outcome {
+            ProcExecOutcome::Completed {
+                status,
+                stdout,
+                stderr,
+            } => {
+                assert!(status.success());
+                assert_eq!(stdout.unwrap(), b"out\n");
+                assert_eq!(stderr.unwrap(), b"err\n");
+            }
+            ProcExecOutcome::TimedOut => panic!("expected process to complete, not time out"),
+        }
+    }
+
+    #[test]
+    fn does_not_capture_when_capture_is_false() {
+        let mut cmd = Command::new("true");
+        let outcome = spawn_with_timeout(&mut cmd, None, false).expect("spawn should succeed");
+        match outcome {
+            ProcExecOutcome::Completed { stdout, stderr, .. } => {
+                assert!(stdout.is_none());
+                assert!(stderr.is_none());
+            }
+            ProcExecOutcome::TimedOut => panic!("expected process to complete, not time out"),
+        }
+    }
+
+    #[test]
+    fn kills_process_that_exceeds_timeout() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        let start = Instant::now();
+        let outcome = spawn_with_timeout(&mut cmd, Some(1), false).expect("spawn should succeed");
+        assert!(matches!(outcome, ProcExecOutcome::TimedOut));
+        // Should return well before the process's own 30s duration.
+        assert!(start.elapsed() < Duration::from_secs(10));
+    }
+
+    #[test]
+    fn zero_timeout_means_unlimited() {
+        let mut cmd = Command::new("true");
+        let outcome = spawn_with_timeout(&mut cmd, Some(0), false).expect("spawn should succeed");
+        match outcome {
+            ProcExecOutcome::Completed { status, .. } => assert!(status.success()),
+            ProcExecOutcome::TimedOut => panic!("timeout_secs=0 must mean unlimited"),
+        }
+    }
+
+    #[test]
+    fn no_timeout_runs_to_completion() {
+        let mut cmd = Command::new("true");
+        let outcome = spawn_with_timeout(&mut cmd, None, false).expect("spawn should succeed");
+        match outcome {
+            ProcExecOutcome::Completed { status, .. } => assert!(status.success()),
+            ProcExecOutcome::TimedOut => panic!("no timeout must mean unlimited"),
+        }
+    }
+}

--- a/src/proc_exec.rs
+++ b/src/proc_exec.rs
@@ -27,9 +27,12 @@ pub enum ProcExecOutcome {
 }
 
 /// Spawn `cmd`, optionally capturing stdout/stderr, and kill it if it runs
-/// longer than `timeout_secs` (`None` or `Some(0)` means unlimited). Reader
-/// threads drain the pipes concurrently so a chatty process can't deadlock on
-/// a full pipe buffer while we poll for exit.
+/// longer than `timeout_secs` (`None` means unlimited; `Some(secs)` — including
+/// `Some(0)` — applies a `Duration::from_secs(secs)` wall-clock timeout).
+/// Callers that want a "0 = unlimited" convention (e.g. `sandbox`) must map
+/// that to `None` themselves before calling this function. Reader threads
+/// drain the pipes concurrently so a chatty process can't deadlock on a full
+/// pipe buffer while we poll for exit.
 pub fn spawn_with_timeout(
     cmd: &mut Command,
     timeout_secs: Option<u64>,
@@ -45,9 +48,7 @@ pub fn spawn_with_timeout(
     let stdout_handle = child.stdout.take().map(spawn_pipe_reader);
     let stderr_handle = child.stderr.take().map(spawn_pipe_reader);
 
-    let timeout = timeout_secs
-        .filter(|&secs| secs > 0)
-        .map(Duration::from_secs);
+    let timeout = timeout_secs.map(Duration::from_secs);
     let poll_interval = Duration::from_millis(50);
     let start = Instant::now();
 
@@ -101,9 +102,54 @@ pub fn join_pipe_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Option<V
 mod tests {
     use super::*;
 
+    fn successful_command() -> Command {
+        #[cfg(unix)]
+        {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg("exit 0");
+            cmd
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/C").arg("exit 0");
+            cmd
+        }
+    }
+
+    fn output_command() -> Command {
+        #[cfg(unix)]
+        {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg("echo out; echo err 1>&2");
+            cmd
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/C").arg("echo out & echo err 1>&2");
+            cmd
+        }
+    }
+
+    fn long_running_command() -> Command {
+        #[cfg(unix)]
+        {
+            let mut cmd = Command::new("sleep");
+            cmd.arg("30");
+            cmd
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = Command::new("ping");
+            cmd.args(["-n", "31", "127.0.0.1"]);
+            cmd
+        }
+    }
+
     #[test]
     fn completes_normally_before_timeout() {
-        let mut cmd = Command::new("true");
+        let mut cmd = successful_command();
         let outcome = spawn_with_timeout(&mut cmd, Some(5), false).expect("spawn should succeed");
         match outcome {
             ProcExecOutcome::Completed { status, .. } => {
@@ -115,8 +161,7 @@ mod tests {
 
     #[test]
     fn captures_stdout_and_stderr_when_requested() {
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg("echo out; echo err 1>&2");
+        let mut cmd = output_command();
         let outcome = spawn_with_timeout(&mut cmd, None, true).expect("spawn should succeed");
         match outcome {
             ProcExecOutcome::Completed {
@@ -125,8 +170,8 @@ mod tests {
                 stderr,
             } => {
                 assert!(status.success());
-                assert_eq!(stdout.unwrap(), b"out\n");
-                assert_eq!(stderr.unwrap(), b"err\n");
+                assert_eq!(String::from_utf8_lossy(&stdout.unwrap()).trim(), "out");
+                assert_eq!(String::from_utf8_lossy(&stderr.unwrap()).trim(), "err");
             }
             ProcExecOutcome::TimedOut => panic!("expected process to complete, not time out"),
         }
@@ -134,7 +179,7 @@ mod tests {
 
     #[test]
     fn does_not_capture_when_capture_is_false() {
-        let mut cmd = Command::new("true");
+        let mut cmd = successful_command();
         let outcome = spawn_with_timeout(&mut cmd, None, false).expect("spawn should succeed");
         match outcome {
             ProcExecOutcome::Completed { stdout, stderr, .. } => {
@@ -147,8 +192,7 @@ mod tests {
 
     #[test]
     fn kills_process_that_exceeds_timeout() {
-        let mut cmd = Command::new("sleep");
-        cmd.arg("30");
+        let mut cmd = long_running_command();
         let start = Instant::now();
         let outcome = spawn_with_timeout(&mut cmd, Some(1), false).expect("spawn should succeed");
         assert!(matches!(outcome, ProcExecOutcome::TimedOut));
@@ -157,18 +201,17 @@ mod tests {
     }
 
     #[test]
-    fn zero_timeout_means_unlimited() {
-        let mut cmd = Command::new("true");
+    fn zero_timeout_is_immediate_for_optional_timeout_callers() {
+        let mut cmd = long_running_command();
+        let start = Instant::now();
         let outcome = spawn_with_timeout(&mut cmd, Some(0), false).expect("spawn should succeed");
-        match outcome {
-            ProcExecOutcome::Completed { status, .. } => assert!(status.success()),
-            ProcExecOutcome::TimedOut => panic!("timeout_secs=0 must mean unlimited"),
-        }
+        assert!(matches!(outcome, ProcExecOutcome::TimedOut));
+        assert!(start.elapsed() < Duration::from_secs(5));
     }
 
     #[test]
     fn no_timeout_runs_to_completion() {
-        let mut cmd = Command::new("true");
+        let mut cmd = successful_command();
         let outcome = spawn_with_timeout(&mut cmd, None, false).expect("spawn should succeed");
         match outcome {
             ProcExecOutcome::Completed { status, .. } => assert!(status.success()),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,12 +1,9 @@
 use color_eyre::eyre::{Result, eyre};
 use std::fs;
-use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
-use std::process::{Command, ExitStatus, Stdio};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::process::{Command, ExitStatus};
 use tempfile::TempDir;
 
 /// Default wall-clock timeout (in seconds) applied to sandboxed runs.
@@ -425,55 +422,28 @@ pub enum SandboxExecOutcome {
     TimedOut,
 }
 
-/// Run `cmd` to completion, optionally capturing stdout/stderr, killing it if it
-/// exceeds `timeout_secs` (0 = unlimited). Mirrors
-/// `test_executor::run_with_timeout`'s spawn/poll/kill pattern so a chatty
+/// Run `cmd` to completion, optionally capturing stdout/stderr, killing it if
+/// it exceeds `timeout_secs` (0 = unlimited). Delegates to
+/// [`crate::proc_exec::spawn_with_timeout`], the shared spawn/poll/kill helper
+/// also used by `test_executor::run_with_timeout` (Issue #273), so a chatty
 /// process can't deadlock on a full pipe buffer while we wait for exit.
 pub fn execute_sandboxed(
     cmd: &mut Command,
     timeout_secs: u64,
     capture: bool,
 ) -> std::io::Result<SandboxExecOutcome> {
-    if capture {
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
+    match crate::proc_exec::spawn_with_timeout(cmd, Some(timeout_secs), capture)? {
+        crate::proc_exec::ProcExecOutcome::Completed {
+            status,
+            stdout,
+            stderr,
+        } => Ok(SandboxExecOutcome::Completed {
+            status,
+            stdout,
+            stderr,
+        }),
+        crate::proc_exec::ProcExecOutcome::TimedOut => Ok(SandboxExecOutcome::TimedOut),
     }
-
-    let mut child = cmd.spawn()?;
-
-    let stdout_handle = child.stdout.take().map(spawn_pipe_reader);
-    let stderr_handle = child.stderr.take().map(spawn_pipe_reader);
-
-    let timeout = (timeout_secs > 0).then(|| Duration::from_secs(timeout_secs));
-    let poll_interval = Duration::from_millis(50);
-    let start = Instant::now();
-
-    let status = loop {
-        if let Some(status) = child.try_wait()? {
-            break status;
-        }
-
-        if let Some(timeout) = timeout
-            && start.elapsed() >= timeout
-        {
-            let _ = child.kill();
-            let _ = child.wait();
-            join_pipe_reader(stdout_handle);
-            join_pipe_reader(stderr_handle);
-            return Ok(SandboxExecOutcome::TimedOut);
-        }
-
-        thread::sleep(poll_interval);
-    };
-
-    let stdout = join_pipe_reader(stdout_handle);
-    let stderr = join_pipe_reader(stderr_handle);
-
-    Ok(SandboxExecOutcome::Completed {
-        status,
-        stdout,
-        stderr,
-    })
 }
 
 /// Synthesize an `ExitStatus` representing a timed-out process: exit code 124,
@@ -559,24 +529,6 @@ pub fn execute_with_optional_sandbox(
         stderr,
         timed_out,
     })
-}
-
-/// Spawn a thread that reads a child process pipe to completion.
-fn spawn_pipe_reader<R>(mut reader: R) -> thread::JoinHandle<Vec<u8>>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = reader.read_to_end(&mut buf);
-        buf
-    })
-}
-
-/// Join a pipe reader thread, discarding the handle. Returns `None` if there
-/// was no pipe to read or the thread panicked.
-fn join_pipe_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Option<Vec<u8>> {
-    handle.and_then(|h| h.join().ok())
 }
 
 /// The sitecustomize.py injected into every sandboxed Python process.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -432,7 +432,8 @@ pub fn execute_sandboxed(
     timeout_secs: u64,
     capture: bool,
 ) -> std::io::Result<SandboxExecOutcome> {
-    match crate::proc_exec::spawn_with_timeout(cmd, Some(timeout_secs), capture)? {
+    let timeout = (timeout_secs > 0).then_some(timeout_secs);
+    match crate::proc_exec::spawn_with_timeout(cmd, timeout, capture)? {
         crate::proc_exec::ProcExecOutcome::Completed {
             status,
             stdout,

--- a/src/test_executor.rs
+++ b/src/test_executor.rs
@@ -8,13 +8,12 @@
 
 use crate::test_discovery::{TestItem, TestItemType};
 use serde::{Deserialize, Serialize};
-use std::io::Read;
 use std::path::PathBuf;
-use std::process::{Command, Output, Stdio};
+use std::process::{Command, Output};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Configuration for the test executor
 #[derive(Debug, Clone)]
@@ -68,68 +67,27 @@ enum RunOutcome {
 }
 
 /// Spawn `command`, capturing stdout/stderr, and kill it if it runs longer
-/// than `timeout_secs`. Reader threads drain the pipes concurrently so a
-/// chatty test can't deadlock on a full pipe buffer while we poll for exit.
+/// than `timeout_secs`. Delegates to [`crate::proc_exec::spawn_with_timeout`],
+/// the shared spawn/poll/kill helper also used by
+/// `sandbox::execute_sandboxed` (Issue #273), whose reader threads drain the
+/// pipes concurrently so a chatty test can't deadlock on a full pipe buffer
+/// while we poll for exit.
 fn run_with_timeout(
     mut command: Command,
     timeout_secs: Option<u64>,
 ) -> std::io::Result<RunOutcome> {
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-
-    let mut child = command.spawn()?;
-
-    let stdout_handle = child.stdout.take().map(spawn_pipe_reader);
-    let stderr_handle = child.stderr.take().map(spawn_pipe_reader);
-
-    let timeout = timeout_secs.map(Duration::from_secs);
-    let poll_interval = Duration::from_millis(50);
-    let start = Instant::now();
-
-    let status = loop {
-        if let Some(status) = child.try_wait()? {
-            break status;
-        }
-
-        if let Some(timeout) = timeout
-            && start.elapsed() >= timeout
-        {
-            let _ = child.kill();
-            let _ = child.wait();
-            join_pipe_reader(stdout_handle);
-            join_pipe_reader(stderr_handle);
-            return Ok(RunOutcome::TimedOut);
-        }
-
-        thread::sleep(poll_interval);
-    };
-
-    let stdout = join_pipe_reader(stdout_handle).unwrap_or_default();
-    let stderr = join_pipe_reader(stderr_handle).unwrap_or_default();
-
-    Ok(RunOutcome::Completed(Output {
-        status,
-        stdout,
-        stderr,
-    }))
-}
-
-/// Spawn a thread that reads a child process pipe to completion.
-fn spawn_pipe_reader<R>(mut reader: R) -> thread::JoinHandle<Vec<u8>>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = reader.read_to_end(&mut buf);
-        buf
-    })
-}
-
-/// Join a pipe reader thread, discarding the handle. Returns `None` if there
-/// was no pipe to read or the thread panicked.
-fn join_pipe_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Option<Vec<u8>> {
-    handle.and_then(|h| h.join().ok())
+    match crate::proc_exec::spawn_with_timeout(&mut command, timeout_secs, true)? {
+        crate::proc_exec::ProcExecOutcome::Completed {
+            status,
+            stdout,
+            stderr,
+        } => Ok(RunOutcome::Completed(Output {
+            status,
+            stdout: stdout.unwrap_or_default(),
+            stderr: stderr.unwrap_or_default(),
+        })),
+        crate::proc_exec::ProcExecOutcome::TimedOut => Ok(RunOutcome::TimedOut),
+    }
 }
 
 /// Result of executing a single test


### PR DESCRIPTION
Closes #273

## Summary
- Extracted the duplicated spawn/poll/timeout/kill/output-capture logic into `src/proc_exec.rs::spawn_with_timeout`.
- Delegated both `sandbox::execute_sandboxed` and `test_executor::run_with_timeout` to the shared helper.
- Preserved each caller's existing zero-timeout contract: `Some(0)` remains an immediate timeout for the optional per-test timeout, while sandbox `timeout_secs=0` is adapted to `None` and remains unlimited.
- Replaced race-prone zero-timeout coverage with a long-running process and added Unix/Windows command fixtures.

## Verification
- `cargo test`: 998 passed, 6 ignored.
- `cargo test proc_exec::tests --lib`: 6 passed.
- `cargo test --test sandbox sandbox_timeout_zero_disables_timeout`: passed.
- `cargo test --test observability duration_ms_in_response`: passed in isolation.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt -- --check`: passed.
- `cargo audit`: no unallowed vulnerabilities; existing allowed RUSTSEC-2026-0190 warning only.
- `cargo deny check licenses`: passed with existing unmatched-allowance warnings.

The direct-child process-tree kill behavior and unbounded output capture are inherited from the previous implementations and are not changed by this refactor.
