### PR TITLE
fix(downloader): fail fast on 4xx and preserve retry cause (Issue #343)

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -10,6 +10,10 @@ use thiserror::Error;
 use tokio::fs::{self, File};
 use tokio::io::{AsyncWriteExt, BufWriter};
 
+/// Upper bound on a server-supplied `Retry-After` value, so a malicious or
+/// misconfigured index cannot stall a download indefinitely.
+const MAX_RETRY_AFTER_SECS: u64 = 5;
+
 #[derive(Debug, Clone)]
 pub struct SignatureSpec {
     pub signature: String,
@@ -230,13 +234,15 @@ impl Downloader {
                             source: Box::new(e),
                         });
                     }
-                    // Respect Retry-After on 429/503 when the server sends one;
-                    // otherwise fall back to exponential backoff: 1s, 2s, 4s.
+                    // Respect Retry-After on 429/503 when the server sends one,
+                    // capped to avoid a malicious/misconfigured server stalling
+                    // the download indefinitely; otherwise fall back to
+                    // exponential backoff: 1s, 2s, 4s.
                     let backoff = match &e {
                         DownloadError::HttpStatus {
                             retry_after: Some(secs),
                             ..
-                        } => Duration::from_secs(*secs),
+                        } => Duration::from_secs((*secs).min(MAX_RETRY_AFTER_SECS)),
                         _ => Duration::from_secs(1 << (attempt - 1)),
                     };
                     eprintln!("retrying download {} (attempt {}): {}", url, attempt + 1, e);
@@ -509,6 +515,36 @@ mod tests {
             }
             other => panic!("expected MaxRetriesExceeded, got {other:?}"),
         }
+    }
+
+    /// A server-supplied `Retry-After` must be capped so a malicious or
+    /// misconfigured index cannot stall a download indefinitely.
+    #[tokio::test]
+    async fn retry_after_is_capped() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/slow.whl");
+            then.status(429)
+                .header("Retry-After", "999999999")
+                .body("slow down");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("slow.whl");
+        let downloader = Downloader::new();
+
+        let start = Instant::now();
+        let result = downloader
+            .download_file(&server.url("/slow.whl"), &dest, None)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        mock.assert_calls(3);
+        assert!(
+            elapsed < Duration::from_secs(MAX_RETRY_AFTER_SECS * 2 + 5),
+            "Retry-After should be capped at {MAX_RETRY_AFTER_SECS}s per attempt, took {elapsed:?}"
+        );
     }
 
     /// A successful download should not be affected by the new classification

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -48,6 +48,17 @@ pub enum DownloadError {
     Network(String),
     #[error("io error: {0}")]
     Io(String),
+    /// An HTTP response with a non-success status code (e.g. 404, 401, 500).
+    ///
+    /// `retry_after` carries the parsed `Retry-After` header (in seconds), if
+    /// the server sent one on a 429/503 response.
+    #[error("http error {status} for {url}: {message}")]
+    HttpStatus {
+        status: u16,
+        url: String,
+        message: String,
+        retry_after: Option<u64>,
+    },
     #[error("missing checksum for {path}: {checksum}")]
     MissingChecksum { path: PathBuf, checksum: String },
     #[error("checksum mismatch for {path}: expected {expected}, got {actual}")]
@@ -58,8 +69,35 @@ pub enum DownloadError {
     },
     #[error("signature verification failed for {path}: {message}")]
     SignatureVerificationFailed { path: PathBuf, message: String },
-    #[error("max retries exceeded for {url}")]
-    MaxRetriesExceeded { url: String },
+    #[error("max retries exceeded for {url} after {attempts} attempts: {source}")]
+    MaxRetriesExceeded {
+        url: String,
+        attempts: u32,
+        #[source]
+        source: Box<DownloadError>,
+    },
+}
+
+impl DownloadError {
+    /// Whether this failure is worth retrying with backoff.
+    ///
+    /// Transport-level failures (connection refused, DNS, timeout) and
+    /// server-side/rate-limit HTTP statuses (408, 429, 5xx) are transient and
+    /// retried. Client errors like 404/401/403 are not — retrying them just
+    /// burns time waiting for a response that will never change.
+    fn is_retryable(&self) -> bool {
+        match self {
+            DownloadError::Network(_) => true,
+            DownloadError::Io(_) => true,
+            DownloadError::HttpStatus { status, .. } => {
+                matches!(*status, 408 | 429 | 500..=599)
+            }
+            DownloadError::MissingChecksum { .. }
+            | DownloadError::ChecksumMismatch { .. }
+            | DownloadError::SignatureVerificationFailed { .. }
+            | DownloadError::MaxRetriesExceeded { .. } => false,
+        }
+    }
 }
 
 impl From<reqwest::Error> for DownloadError {
@@ -177,15 +215,32 @@ impl Downloader {
                     return Ok(destination.to_path_buf());
                 }
                 Err(e) => {
+                    // Fail fast on non-retryable errors (e.g. 404/401/403):
+                    // retrying them just burns time waiting for a response
+                    // that can never change.
+                    if !e.is_retryable() {
+                        return Err(e);
+                    }
+
                     attempt += 1;
                     if attempt >= max_retries {
                         return Err(DownloadError::MaxRetriesExceeded {
                             url: url.to_string(),
+                            attempts: attempt,
+                            source: Box::new(e),
                         });
                     }
-                    // Simple exponential backoff: 1s, 2s, 4s
-                    tokio::time::sleep(Duration::from_secs(1 << (attempt - 1))).await;
+                    // Respect Retry-After on 429/503 when the server sends one;
+                    // otherwise fall back to exponential backoff: 1s, 2s, 4s.
+                    let backoff = match &e {
+                        DownloadError::HttpStatus {
+                            retry_after: Some(secs),
+                            ..
+                        } => Duration::from_secs(*secs),
+                        _ => Duration::from_secs(1 << (attempt - 1)),
+                    };
                     eprintln!("retrying download {} (attempt {}): {}", url, attempt + 1, e);
+                    tokio::time::sleep(backoff).await;
                 }
             }
         }
@@ -193,7 +248,21 @@ impl Downloader {
 
     async fn download_attempt(&self, url: &str, destination: &Path) -> Result<(), DownloadError> {
         let response = self.client.get(url).send().await?;
-        let response = response.error_for_status()?;
+
+        if let Err(status_err) = response.error_for_status_ref() {
+            let status = response.status();
+            let retry_after = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok());
+            return Err(DownloadError::HttpStatus {
+                status: status.as_u16(),
+                url: url.to_string(),
+                message: status_err.to_string(),
+                retry_after,
+            });
+        }
 
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent).await?;
@@ -302,5 +371,169 @@ impl Downloader {
         }));
 
         stream.buffer_unordered(concurrency).collect().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use std::time::Instant;
+    use tempfile::tempdir;
+
+    /// A 404 (package/version genuinely missing) must fail immediately,
+    /// without burning the 1s/2s exponential backoff (Issue #343, defect 1).
+    #[tokio::test]
+    async fn not_found_fails_fast_without_backoff() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/missing.whl");
+            then.status(404).body("not found");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("missing.whl");
+        let downloader = Downloader::new();
+
+        let start = Instant::now();
+        let result = downloader
+            .download_file(&server.url("/missing.whl"), &dest, None)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "expected 404 to fail");
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "expected fail-fast (<500ms), took {elapsed:?}"
+        );
+        // Only a single attempt should have been made — no retries for 404.
+        mock.assert_calls(1);
+    }
+
+    /// A 401/403 (private index without auth) is also a client error and
+    /// must not be retried.
+    #[tokio::test]
+    async fn unauthorized_fails_fast_without_retry() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/private.whl");
+            then.status(401).body("unauthorized");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("private.whl");
+        let downloader = Downloader::new();
+
+        let result = downloader
+            .download_file(&server.url("/private.whl"), &dest, None)
+            .await;
+
+        assert!(result.is_err());
+        mock.assert_calls(1);
+    }
+
+    /// A 500 is a transient server error and should be retried up to the
+    /// configured max_retries (3 attempts total).
+    #[tokio::test]
+    async fn server_error_is_retried() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/flaky.whl");
+            then.status(500).body("internal error");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("flaky.whl");
+        let downloader = Downloader::new();
+
+        let result = downloader
+            .download_file(&server.url("/flaky.whl"), &dest, None)
+            .await;
+
+        assert!(result.is_err());
+        mock.assert_calls(3);
+    }
+
+    /// A 429 (rate limited) should also be retried like a 5xx.
+    #[tokio::test]
+    async fn rate_limited_is_retried() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/ratelimited.whl");
+            then.status(429).body("slow down");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("ratelimited.whl");
+        let downloader = Downloader::new();
+
+        let result = downloader
+            .download_file(&server.url("/ratelimited.whl"), &dest, None)
+            .await;
+
+        assert!(result.is_err());
+        mock.assert_calls(3);
+    }
+
+    /// The terminal MaxRetriesExceeded error must carry the underlying
+    /// cause in its Display output, not just "max retries exceeded for
+    /// {url}" (Issue #343, defect 2).
+    #[tokio::test]
+    async fn max_retries_exceeded_includes_underlying_cause() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/flaky.whl");
+            then.status(503).body("service unavailable");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("flaky.whl");
+        let downloader = Downloader::new();
+
+        let result = downloader
+            .download_file(&server.url("/flaky.whl"), &dest, None)
+            .await;
+        mock.assert_calls(3);
+
+        match result {
+            Err(err @ DownloadError::MaxRetriesExceeded { .. }) => {
+                let message = err.to_string();
+                assert!(
+                    message.contains("503"),
+                    "expected underlying HTTP status in message, got: {message}"
+                );
+                // Ensure the error chain (source()) also carries the cause,
+                // not just the Display string.
+                use std::error::Error as _;
+                assert!(err.source().is_some(), "expected a wrapped source error");
+            }
+            other => panic!("expected MaxRetriesExceeded, got {other:?}"),
+        }
+    }
+
+    /// A successful download should not be affected by the new classification
+    /// logic.
+    #[tokio::test]
+    async fn successful_download_still_works() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/ok.whl");
+            then.status(200).body("wheel-bytes");
+        });
+
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("ok.whl");
+        let downloader = Downloader::new();
+
+        let result = downloader
+            .download_file(&server.url("/ok.whl"), &dest, None)
+            .await;
+
+        assert!(result.is_ok());
+        mock.assert_calls(1);
+        assert_eq!(
+            tokio::fs::read_to_string(&dest).await.unwrap(),
+            "wheel-bytes"
+        );
     }
 }


### PR DESCRIPTION
Closes #343

## Summary
`Downloader::download_file_with_signature` had two related defects:

1. **Non-retryable HTTP errors were retried with backoff.** `download_attempt` mapped every failure — including a 4xx from `error_for_status()` — into a single retryable bucket. A `404` (missing package/version) or `401`/`403` (private index without auth) burned all 3 attempts with 1s + 2s of guaranteed-futile backoff before the caller saw an error. Under `download_parallel` against a misconfigured index this multiplied across every artifact.
2. **`MaxRetriesExceeded` discarded the root cause.** The last underlying error was only `eprintln!`-ed on intermediate retries, then thrown away. The terminal error/diagnostic said only `"max retries exceeded for {url}"`, with no indication of whether the real cause was DNS failure, a 403, a checksum mismatch, or something else.

### Fix
- Added `DownloadError::HttpStatus { status, url, message, retry_after }` so HTTP response failures carry their status code instead of being flattened into `Network`.
- Added `DownloadError::is_retryable()`: retries connect/timeout errors (`Network`), `Io`, and HTTP `408`/`429`/`5xx`; fails immediately on other 4xx statuses (returns the original error straight to the caller, skipping the retry loop entirely).
- `MaxRetriesExceeded` now carries `attempts: u32` and `source: Box<DownloadError>` (thiserror `#[source]`), and its `#[error(...)]` message interpolates the source so the underlying cause shows up in `Display`/JSON diagnostics without touching any call sites — existing call sites (`wheel_cache.rs`'s `#[from]` conversion, `commands/mod.rs`'s `eprintln!("... {}", e)`) automatically pick up the richer message.
- **Bonus (optional item from the issue):** honors a numeric `Retry-After` header on 429/503 responses for the next backoff delay, falling back to the existing exponential backoff (1s/2s/4s) when absent.

### Judgment calls
- Followed the codebase's existing `thiserror` + `#[source]`/`#[from]` conventions (seen in `build.rs`, `cache.rs`, `lockfile.rs`, etc.) rather than introducing a new error-wrapping pattern.
- Kept `Io` errors retryable (matches prior behavior) since a transient disk/FS hiccup during download setup is plausibly transient; only newly-classified `HttpStatus` errors got fail-fast treatment, since that's what the issue specifically calls out.
- No call sites needed changes: `WheelCacheError::Download` uses `#[from]` (still compiles unchanged), and `commands/mod.rs` prints `DownloadError` via `Display`, which now includes the cause automatically because the format string interpolates `{source}`.
- Did not need a `docs/PLAN.md` update — this issue isn't tracked as one of the PR-A tracks there.

## Test plan
- [x] New unit tests in `src/downloader.rs` (`#[cfg(test)] mod tests`, using `httpmock`):
  - `not_found_fails_fast_without_backoff` — 404 fails in <500ms with exactly 1 request (no retries/backoff).
  - `unauthorized_fails_fast_without_retry` — 401 fails with exactly 1 request.
  - `server_error_is_retried` — 500 is retried up to `max_retries` (3 total requests).
  - `rate_limited_is_retried` — 429 is retried like a 5xx.
  - `max_retries_exceeded_includes_underlying_cause` — the terminal `MaxRetriesExceeded` error's `Display` includes the HTTP status, and `source()` returns the wrapped cause.
  - `successful_download_still_works` — a normal 200 download is unaffected.
- [x] `cargo test` (full suite): **1035 passed, 6 ignored, 0 failed** (52 suites, 167.56s).
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: no issues.
- [x] `cargo fmt -- --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)