### PR TITLE
fix(resolver): exclude pre-release versions by default, add --pre opt-in (Issue #341)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,6 +173,10 @@ pub struct InstallArgs {
     /// `[project.optional-dependencies]` then `[dependency-groups]`).
     #[arg(long, value_name = "NAME")]
     pub group: Option<String>,
+    /// Allow pre-release and dev versions when resolving (PEP 440 excludes
+    /// them by default unless a specifier mentions one).
+    #[arg(long)]
+    pub pre: bool,
 }
 
 #[derive(Args, Debug)]
@@ -197,6 +201,10 @@ pub struct PackageArgs {
     /// Use offline mode when cache is sufficient.
     #[arg(long)]
     pub offline: bool,
+    /// Allow pre-release and dev versions when resolving (PEP 440 excludes
+    /// them by default unless a specifier mentions one).
+    #[arg(long)]
+    pub pre: bool,
 }
 
 #[derive(Args, Debug)]
@@ -644,6 +652,10 @@ pub struct UpgradeArgs {
     /// Scope the upgrade to a named dependency group's dependencies.
     #[arg(long, value_name = "NAME")]
     pub group: Option<String>,
+    /// Allow pre-release and dev versions when resolving (PEP 440 excludes
+    /// them by default unless a specifier mentions one).
+    #[arg(long)]
+    pub pre: bool,
 }
 
 /// Render a JSON help envelope when the raw CLI arguments request both

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,9 +16,9 @@ use crate::pypi::{PyPiClient, PyPiIndex};
 use crate::release_manifest::{ReleaseManifest, current_release_target};
 use crate::resolver::parse_version_relaxed;
 use crate::resolver::{
-    PackageIndex, Requirement, compare_versions, cp_tag_to_dotted_version, current_platform_tags,
-    is_wheel_python_compatible, parse_wheel_tags, python_version_to_cp_tag, resolve,
-    select_artifact_for_platform_with_cp,
+    PackageIndex, Requirement, Resolution, ResolveOptions, compare_versions,
+    cp_tag_to_dotted_version, current_platform_tags, is_wheel_python_compatible, parse_wheel_tags,
+    python_version_to_cp_tag, resolve, resolve_with_options, select_artifact_for_platform_with_cp,
 };
 use crate::sandbox;
 use crate::sbom;
@@ -150,6 +150,7 @@ pub async fn execute(cli: Cli) -> Result<()> {
                         workspace: false,
                         member: None,
                         group: None,
+                        pre: args.pre,
                     };
 
                     let packages_json: Vec<serde_json::Value> = packages
@@ -1392,6 +1393,33 @@ fn warn_on_ignored_extras(requirements: &[Requirement], collector: &mut EventCol
     }
 }
 
+/// Emit a `W_PRERELEASE_SELECTED` warning for every package that resolved to
+/// a pre-release version via the fallback path (only pre-releases satisfied
+/// the constraints, without a `--pre` opt-in or a specifier mentioning a
+/// pre-release). PEP 440 excludes pre-releases from version selection by
+/// default, so the fallback is made visible instead of silent (Issue #341).
+fn warn_on_prerelease_fallback(resolution: &Resolution, collector: &mut EventCollector) {
+    for pick in &resolution.prerelease_fallbacks {
+        let message = format!(
+            "selected pre-release version {} {} because only pre-release versions satisfy the constraints",
+            pick.name, pick.version
+        );
+        eprintln!("warning: {}", message);
+        collector.diagnostic(
+            Diagnostic::warning(message)
+                .with_code("W_PRERELEASE_SELECTED")
+                .with_suggestion(
+                    "Pass --pre to opt in to pre-release versions explicitly, or pin a stable version."
+                        .to_string(),
+                )
+                .with_context(json!({
+                    "package": pick.name,
+                    "version": pick.version,
+                })),
+        );
+    }
+}
+
 pub(crate) async fn install(
     args: &crate::cli::InstallArgs,
     collector: &mut EventCollector,
@@ -1444,10 +1472,13 @@ pub(crate) async fn install(
 
     let source_index_url: String;
     let offline = args.offline;
+    let resolve_options = ResolveOptions {
+        allow_prerelease: args.pre,
+    };
     let resolution = if let Some(index_path) = args.index.clone() {
         source_index_url = index_path.display().to_string();
         let index = load_index_from_path(&index_path).map_err(|e| eyre!(e))?;
-        match resolve(requirements.clone(), &index).await {
+        match resolve_with_options(requirements.clone(), &index, resolve_options).await {
             Ok(r) => r,
             Err(e) => {
                 for d in crate::self_heal::diagnostics_for_resolve_error(&requirements, &e) {
@@ -1465,7 +1496,8 @@ pub(crate) async fn install(
             source_index_url, offline
         ));
         let index = PyPiIndex::new(client);
-        let resolve_result = resolve(requirements.clone(), &index).await;
+        let resolve_result =
+            resolve_with_options(requirements.clone(), &index, resolve_options).await;
         for notice in index.take_stale_cache_notices() {
             collector.warning(notice);
         }
@@ -1479,6 +1511,7 @@ pub(crate) async fn install(
             }
         }
     };
+    warn_on_prerelease_fallback(&resolution, collector);
     collector.event_with(EventType::ResolveComplete, |event| {
         event.message = Some("Resolved dependencies".to_string());
         event.progress = Some(40);
@@ -2009,6 +2042,7 @@ async fn lock_dependencies(args: &LockArgs, collector: &mut EventCollector) -> R
             }
         }
     };
+    warn_on_prerelease_fallback(&resolution, collector);
 
     collector.event_with(EventType::ResolveComplete, |event| {
         event.message = Some("Resolved dependencies".to_string());
@@ -3202,6 +3236,7 @@ async fn run_script(
                         }
                         let resolution =
                             resolution.map_err(|e: crate::resolver::ResolveError| eyre!(e))?;
+                        warn_on_prerelease_fallback(&resolution, collector);
 
                         // Prepare site-packages path
                         let major_minor = python_version
@@ -5038,22 +5073,27 @@ async fn run_upgrade(args: &UpgradeArgs, collector: &mut EventCollector) -> Resu
     collector.event(EventType::ResolveStart);
 
     // Re-resolve dependencies
+    let resolve_options = ResolveOptions {
+        allow_prerelease: args.pre,
+    };
     let source_index_url: String;
     let resolution = if let Some(index_path) = &args.index {
         source_index_url = index_path.display().to_string();
         let index = load_index_from_path(index_path)?;
-        resolve(requirements.clone(), &index).await?
+        resolve_with_options(requirements.clone(), &index, resolve_options).await?
     } else {
         let pypi_client = PyPiClient::from_env(args.offline)
             .map_err(|e| eyre!("failed to create PyPI client: {}", e))?;
         source_index_url = pypi_client.index_url();
         let pypi_index = PyPiIndex::new(pypi_client);
-        let resolve_result = resolve(requirements.clone(), &pypi_index).await;
+        let resolve_result =
+            resolve_with_options(requirements.clone(), &pypi_index, resolve_options).await;
         for notice in pypi_index.take_stale_cache_notices() {
             collector.warning(notice);
         }
         resolve_result?
     };
+    warn_on_prerelease_fallback(&resolution, collector);
 
     collector.event(EventType::ResolveComplete);
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -208,6 +208,7 @@ mod tests {
                 workspace: false,
                 member: None,
                 group: None,
+                pre: false,
             }),
         };
         assert!(requires_tokio_runtime(&cli));

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1041,6 +1041,10 @@ impl McpServer {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "List of requirements (e.g., ['requests>=2.28', 'flask'])"
+                        },
+                        "pre": {
+                            "type": "boolean",
+                            "description": "Allow pre-release and dev versions when resolving (PEP 440 excludes them by default unless a specifier mentions one; default: false)"
                         }
                     },
                     "required": ["requirements"]
@@ -1064,6 +1068,10 @@ impl McpServer {
                         "system": {
                             "type": "boolean",
                             "description": "Allow installing into system Python instead of creating a project-local .pybun/venv (default: false)"
+                        },
+                        "pre": {
+                            "type": "boolean",
+                            "description": "Allow pre-release and dev versions when resolving (PEP 440 excludes them by default unless a specifier mentions one; default: false)"
                         },
                         "index": {
                             "type": "string",
@@ -1477,7 +1485,7 @@ impl McpServer {
     // Tool implementations
     async fn call_resolve(&self, args: Value) -> Result<String, String> {
         use crate::index::load_index_from_path;
-        use crate::resolver::{Requirement, resolve};
+        use crate::resolver::{Requirement, ResolveOptions, resolve_with_options};
 
         let requirements: Vec<String> = args
             .get("requirements")
@@ -1498,6 +1506,11 @@ impl McpServer {
             .iter()
             .map(|s| s.parse().unwrap_or_else(|_| Requirement::any(s.trim())))
             .collect();
+
+        // Opt-in to pre-release versions (mirrors the CLI `--pre` flag).
+        let resolve_options = ResolveOptions {
+            allow_prerelease: args.get("pre").and_then(|p| p.as_bool()).unwrap_or(false),
+        };
 
         // Try to load index from common locations
         let index_path = args
@@ -1527,9 +1540,10 @@ impl McpServer {
         };
 
         match index_result {
-            Ok(index) => match resolve(parsed_reqs.clone(), &index).await {
-                Ok(resolution) => {
-                    let packages: Vec<Value> = resolution
+            Ok(index) => {
+                match resolve_with_options(parsed_reqs.clone(), &index, resolve_options).await {
+                    Ok(resolution) => {
+                        let packages: Vec<Value> = resolution
                         .packages
                         .values()
                         .map(|pkg| {
@@ -1541,16 +1555,24 @@ impl McpServer {
                         })
                         .collect();
 
-                    Ok(json!({
-                        "status": "resolved",
-                        "requirements": requirements,
-                        "packages": packages,
-                        "count": resolution.packages.len(),
-                    })
-                    .to_string())
+                        let prerelease_fallbacks: Vec<Value> = resolution
+                            .prerelease_fallbacks
+                            .iter()
+                            .map(|p| json!({ "name": p.name, "version": p.version }))
+                            .collect();
+
+                        Ok(json!({
+                            "status": "resolved",
+                            "requirements": requirements,
+                            "packages": packages,
+                            "count": resolution.packages.len(),
+                            "prerelease_fallbacks": prerelease_fallbacks,
+                        })
+                        .to_string())
+                    }
+                    Err(e) => Err(format!("Resolution failed: {}", e)),
                 }
-                Err(e) => Err(format!("Resolution failed: {}", e)),
-            },
+            }
             Err(e) => {
                 // Return a partial result indicating index is not available
                 Ok(json!({
@@ -1627,6 +1649,9 @@ impl McpServer {
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("pybun.lockb"));
 
+        // Opt-in to pre-release versions (mirrors the CLI `--pre` flag).
+        let pre = args.get("pre").and_then(|p| p.as_bool()).unwrap_or(false);
+
         let install_args = crate::cli::InstallArgs {
             offline,
             system,
@@ -1636,6 +1661,7 @@ impl McpServer {
             workspace: false,
             member: None,
             group: None,
+            pre,
         };
 
         let mut collector = EventCollector::new();

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -594,6 +594,99 @@ pub fn select_artifact_for_platform_with_cp(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Resolution {
     pub packages: BTreeMap<String, ResolvedPackage>,
+    /// Packages that resolved to a pre-release version via the fallback path
+    /// (only pre-releases satisfied the constraints) without an explicit
+    /// opt-in. Callers surface these as `W_PRERELEASE_SELECTED` warnings
+    /// (Issue #341).
+    pub prerelease_fallbacks: Vec<PrereleaseFallback>,
+}
+
+/// A package that resolved to a pre-release version only because no stable
+/// version satisfied the constraints (Issue #341).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrereleaseFallback {
+    pub name: String,
+    pub version: String,
+}
+
+/// Options controlling dependency resolution behavior.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResolveOptions {
+    /// Allow pre-release/dev versions to be selected for every package
+    /// (CLI `--pre` / MCP `pre`). Defaults to `false`, matching the PEP 440
+    /// rule that pre-releases are excluded unless opted in (Issue #341).
+    pub allow_prerelease: bool,
+}
+
+/// Report whether `version` is a PEP 440 pre-release or dev release.
+///
+/// Detects pre-release segments (`a`/`alpha`, `b`/`beta`, `c`, `rc`, `pre`,
+/// `preview`) and dev segments (`dev`) case-insensitively, with `.`/`-`/`_`
+/// or no separator. Post-releases (`post`/`rev`/`r`) are NOT pre-releases,
+/// but a version with both a pre and a post segment (e.g. `1.0a1.post2`) is.
+/// Epoch prefixes (`N!`) and local version labels (`+...`) are ignored.
+///
+/// This is a deliberately small scanner; the full PEP 440 version type is
+/// tracked separately in Issue #340.
+pub fn is_prerelease(version: &str) -> bool {
+    let lower = version.trim().to_ascii_lowercase();
+    // Local version labels (`+...`) never affect pre-release status.
+    let without_local = lower.split('+').next().unwrap_or("");
+    // Strip an epoch prefix (`N!`).
+    let core = match without_local.split_once('!') {
+        Some((epoch, rest)) if !epoch.is_empty() && epoch.bytes().all(|b| b.is_ascii_digit()) => {
+            rest
+        }
+        _ => without_local,
+    };
+
+    let bytes = core.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_alphabetic() {
+            let start = i;
+            while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            match &core[start..i] {
+                // Pre-release spellings (PEP 440 normalizes alpha -> a,
+                // beta -> b, c/pre/preview -> rc) plus dev releases.
+                "a" | "b" | "c" | "rc" | "alpha" | "beta" | "pre" | "preview" | "dev" => {
+                    return true;
+                }
+                // Post-release spellings (post/rev/r) and anything else are
+                // not pre-release markers.
+                _ => {}
+            }
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
+/// The version literal a [`VersionSpec`] compares against, if any.
+fn spec_version(spec: &VersionSpec) -> Option<&str> {
+    match spec {
+        VersionSpec::Exact(v)
+        | VersionSpec::Minimum(v)
+        | VersionSpec::MinimumExclusive(v)
+        | VersionSpec::MaximumInclusive(v)
+        | VersionSpec::Maximum(v)
+        | VersionSpec::NotEqual(v)
+        | VersionSpec::Compatible(v) => Some(v),
+        VersionSpec::Any => None,
+    }
+}
+
+/// PEP 440: a specifier that itself mentions a pre-release version opts the
+/// package into pre-release candidates (e.g. `pkg>=2.0rc1`).
+fn constraints_mention_prerelease(reqs: &[Requirement]) -> bool {
+    reqs.iter().any(|r| {
+        r.specs
+            .iter()
+            .any(|s| spec_version(s).is_some_and(is_prerelease))
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -700,9 +793,22 @@ pub trait PackageIndex {
 }
 
 /// Deterministic resolver that works with exact-version or minimum requirements in parallel.
+///
+/// Pre-release/dev versions are excluded by default per PEP 440; use
+/// [`resolve_with_options`] with [`ResolveOptions::allow_prerelease`] to opt
+/// in (Issue #341).
 pub async fn resolve(
     requirements: Vec<Requirement>,
     index: &impl PackageIndex,
+) -> Result<Resolution, ResolveError> {
+    resolve_with_options(requirements, index, ResolveOptions::default()).await
+}
+
+/// [`resolve`] with explicit [`ResolveOptions`].
+pub async fn resolve_with_options(
+    requirements: Vec<Requirement>,
+    index: &impl PackageIndex,
+    options: ResolveOptions,
 ) -> Result<Resolution, ResolveError> {
     let mut resolved: BTreeMap<String, ResolvedPackage> = BTreeMap::new();
     let mut constraints: BTreeMap<String, Vec<Requirement>> = BTreeMap::new();
@@ -826,6 +932,7 @@ pub async fn resolve(
                     &req.name,
                     &candidates,
                     requested_by.as_deref(),
+                    options.allow_prerelease,
                 ) {
                     batch_resolved.insert(req.name.clone(), pkg.clone());
                     fetch_events.push(FetchEvent {
@@ -864,6 +971,7 @@ pub async fn resolve(
                 &req.name,
                 candidates,
                 requested_by.as_deref(),
+                options.allow_prerelease,
             )?;
 
             batch_resolved.insert(req.name.clone(), pkg.clone());
@@ -937,7 +1045,33 @@ pub async fn resolve(
         pending = next_batch;
     }
 
-    Ok(Resolution { packages: resolved })
+    // Report packages that ended up on a pre-release version without an
+    // explicit opt-in (neither `--pre` nor a specifier mentioning a
+    // pre-release): these were selected via the only-pre-releases-satisfy
+    // fallback and callers surface them as `W_PRERELEASE_SELECTED`
+    // (Issue #341).
+    let prerelease_fallbacks = if options.allow_prerelease {
+        Vec::new()
+    } else {
+        resolved
+            .iter()
+            .filter(|(name, pkg)| {
+                is_prerelease(&pkg.version)
+                    && !constraints
+                        .get(name.as_str())
+                        .is_some_and(|reqs| constraints_mention_prerelease(reqs))
+            })
+            .map(|(name, pkg)| PrereleaseFallback {
+                name: name.clone(),
+                version: pkg.version.clone(),
+            })
+            .collect()
+    };
+
+    Ok(Resolution {
+        packages: resolved,
+        prerelease_fallbacks,
+    })
 }
 
 fn select_with_constraints(
@@ -945,12 +1079,36 @@ fn select_with_constraints(
     name: &str,
     candidates: &[ResolvedPackage],
     requested_by: Option<&str>,
+    allow_prerelease: bool,
 ) -> Result<ResolvedPackage, ResolveError> {
     let constraints = reqs.get(name).cloned().unwrap_or_default();
-    let candidate = candidates
+    let satisfying: Vec<&ResolvedPackage> = candidates
         .iter()
         .filter(|pkg| constraints.iter().all(|r| r.is_satisfied_by(&pkg.version)))
-        .max_by(|a, b| version_cmp(&a.version, &b.version));
+        .collect();
+
+    // PEP 440: pre-release/dev versions are excluded by default. They are
+    // considered when the caller opted in (`--pre`), when a specifier for
+    // this package itself mentions a pre-release version, or as a fallback
+    // when only pre-releases satisfy the constraints (Issue #341).
+    let prereleases_allowed = allow_prerelease || constraints_mention_prerelease(&constraints);
+    let candidate = if prereleases_allowed {
+        satisfying
+            .iter()
+            .max_by(|a, b| version_cmp(&a.version, &b.version))
+    } else {
+        satisfying
+            .iter()
+            .filter(|pkg| !is_prerelease(&pkg.version))
+            .max_by(|a, b| version_cmp(&a.version, &b.version))
+            .or_else(|| {
+                // Fallback: only pre-releases satisfy the constraints.
+                satisfying
+                    .iter()
+                    .max_by(|a, b| version_cmp(&a.version, &b.version))
+            })
+    }
+    .copied();
 
     if let Some(pkg) = candidate {
         Ok(pkg.clone())
@@ -2419,5 +2577,178 @@ mod tests {
                 "py3 wheel should be compatible with {cp_tag}"
             );
         }
+    }
+
+    // --- Pre-release handling (Issue #341) ---
+
+    #[test]
+    fn test_is_prerelease_classification() {
+        // Pre-release / dev versions (PEP 440): must be detected.
+        for v in [
+            "1.0rc1",
+            "1.0.rc1",
+            "1.0.0rc1",
+            "1.0-alpha2",
+            "1.0.alpha2",
+            "1.0b3",
+            "1.0.0b3",
+            "1.0.beta3",
+            "1.0c1",
+            "1.0.preview1",
+            "1.0.pre1",
+            "1.0.dev1",
+            "1.0.0.dev0",
+            "1.0a1",
+            "1.0a1.post2",
+            "1.0.post1.dev2",
+            "1.0.0RC1",
+            "1.0.0A1",
+            "2.0.0.DEV3",
+            "1!2.0a1",
+            "1.0rc1+local.tag",
+        ] {
+            assert!(is_prerelease(v), "{v} should be classified as pre-release");
+        }
+
+        // Final and post releases: NOT pre-releases.
+        for v in [
+            "1.0",
+            "1.0.0",
+            "2.5.0",
+            "1.0.post1",
+            "1.0.0.post2",
+            "1.0.POST1",
+            "1.0.rev1",
+            "1.0.r1",
+            "1!2.0",
+            "1.0+local.abc",
+            "1.0.post1+local",
+        ] {
+            assert!(
+                !is_prerelease(v),
+                "{v} should NOT be classified as pre-release"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_excludes_prereleases_by_default() {
+        let mut index = InMemoryIndex::default();
+        index.add("pkg", "1.0.0", Vec::<String>::new());
+        index.add("pkg", "2.0.0rc1", Vec::<String>::new());
+
+        let req = Requirement::any("pkg");
+        let resolution = resolve(vec![req], &index).await.unwrap();
+
+        assert_eq!(
+            resolution.packages.get("pkg").map(|p| p.version.as_str()),
+            Some("1.0.0"),
+            "pre-release 2.0.0rc1 must be excluded by default"
+        );
+        assert!(
+            resolution.prerelease_fallbacks.is_empty(),
+            "no fallback warning expected when a stable version is selected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_allows_prereleases_with_opt_in() {
+        let mut index = InMemoryIndex::default();
+        index.add("pkg", "1.0.0", Vec::<String>::new());
+        index.add("pkg", "2.0.0rc1", Vec::<String>::new());
+
+        let req = Requirement::any("pkg");
+        let resolution = resolve_with_options(
+            vec![req],
+            &index,
+            ResolveOptions {
+                allow_prerelease: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolution.packages.get("pkg").map(|p| p.version.as_str()),
+            Some("2.0.0rc1"),
+            "--pre opt-in must allow selecting the pre-release"
+        );
+        assert!(
+            resolution.prerelease_fallbacks.is_empty(),
+            "explicit opt-in is not a fallback; no warning expected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_allows_prerelease_when_specifier_mentions_one() {
+        let mut index = InMemoryIndex::default();
+        index.add("pkg", "1.0.0", Vec::<String>::new());
+        index.add("pkg", "2.0.0rc1", Vec::<String>::new());
+
+        // The specifier itself mentions a pre-release version, which opts this
+        // package into pre-release candidates (PEP 440 / pip behavior).
+        let req = Requirement::from_str("pkg>=2.0.0rc1").unwrap();
+        let resolution = resolve(vec![req], &index).await.unwrap();
+
+        assert_eq!(
+            resolution.packages.get("pkg").map(|p| p.version.as_str()),
+            Some("2.0.0rc1"),
+            "a specifier mentioning a pre-release must allow pre-release candidates"
+        );
+        assert!(
+            resolution.prerelease_fallbacks.is_empty(),
+            "specifier-mentioned pre-release is not a fallback; no warning expected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_falls_back_to_prerelease_when_only_prereleases_exist() {
+        let mut index = InMemoryIndex::default();
+        index.add("pkg", "1.0.0rc1", Vec::<String>::new());
+        index.add("pkg", "1.0.0rc2", Vec::<String>::new());
+
+        let req = Requirement::any("pkg");
+        let resolution = resolve(vec![req], &index).await.unwrap();
+
+        assert_eq!(
+            resolution.packages.get("pkg").map(|p| p.version.as_str()),
+            Some("1.0.0rc2"),
+            "when only pre-releases satisfy the constraints, the highest must be selected"
+        );
+        assert_eq!(
+            resolution.prerelease_fallbacks,
+            vec![PrereleaseFallback {
+                name: "pkg".to_string(),
+                version: "1.0.0rc2".to_string(),
+            }],
+            "fallback selection must be reported so callers can emit W_PRERELEASE_SELECTED"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_prerelease_dependency_of_stable_package() {
+        // A stable top-level package whose dependency only ships pre-releases:
+        // the dependency should fall back and be reported.
+        let mut index = InMemoryIndex::default();
+        index.add("app", "1.0.0", vec!["libpre"]);
+        index.add("libpre", "0.9.0b1", Vec::<String>::new());
+
+        let req = Requirement::any("app");
+        let resolution = resolve(vec![req], &index).await.unwrap();
+
+        assert_eq!(
+            resolution
+                .packages
+                .get("libpre")
+                .map(|p| p.version.as_str()),
+            Some("0.9.0b1")
+        );
+        assert_eq!(
+            resolution.prerelease_fallbacks,
+            vec![PrereleaseFallback {
+                name: "libpre".to_string(),
+                version: "0.9.0b1".to_string(),
+            }]
+        );
     }
 }

--- a/tests/cli_install.rs
+++ b/tests/cli_install.rs
@@ -864,3 +864,72 @@ fn install_selects_wheel_for_target_venv_python_not_path_python() {
          not whatever python3/python resolves to on PATH"
     );
 }
+
+// =============================================================================
+// Issue #341: pre-release versions must be excluded by default (PEP 440) and
+// only selected with the `--pre` opt-in, a specifier mentioning a pre-release,
+// or as a fallback when only pre-releases satisfy the constraints.
+// =============================================================================
+
+fn index_prerelease_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_prerelease.json")
+}
+
+#[test]
+fn install_excludes_prerelease_versions_by_default() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_prerelease_path();
+
+    bin()
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "lib>=1.0.0",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let lib = lock.packages.get("lib").expect("lib entry");
+    assert_eq!(
+        lib.version, "1.0.0",
+        "pre-release 2.0.0rc1 must not be selected without --pre"
+    );
+}
+
+#[test]
+fn install_pre_flag_opts_in_to_prerelease_versions() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_prerelease_path();
+
+    bin()
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "lib>=1.0.0",
+            "--pre",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let lib = lock.packages.get("lib").expect("lib entry");
+    assert_eq!(
+        lib.version, "2.0.0rc1",
+        "--pre must allow the pre-release to be selected"
+    );
+}

--- a/tests/fixtures/index_prerelease.json
+++ b/tests/fixtures/index_prerelease.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "lib",
+    "version": "1.0.0",
+    "dependencies": [],
+    "wheels": [
+      {
+        "file": "lib-1.0.0-py3-none-any.whl",
+        "hash": "sha256:lib100"
+      }
+    ]
+  },
+  {
+    "name": "lib",
+    "version": "2.0.0rc1",
+    "dependencies": [],
+    "wheels": [
+      {
+        "file": "lib-2.0.0rc1-py3-none-any.whl",
+        "hash": "sha256:lib200rc1"
+      }
+    ]
+  },
+  {
+    "name": "prelib",
+    "version": "0.9.0b1",
+    "dependencies": [],
+    "wheels": [
+      {
+        "file": "prelib-0.9.0b1-py3-none-any.whl",
+        "hash": "sha256:prelib090b1"
+      }
+    ]
+  }
+]

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -472,3 +472,109 @@ fn index_missing_hash_path() -> std::path::PathBuf {
         .join("fixtures")
         .join("index_missing_hash.json")
 }
+
+// ---------------------------------------------------------------------------
+// Issue #341: when only pre-release versions satisfy the constraints and the
+// user did not opt in via `--pre`, the resolver falls back to the pre-release
+// but the selection must be surfaced as a `W_PRERELEASE_SELECTED` warning
+// diagnostic instead of being silent.
+// ---------------------------------------------------------------------------
+
+fn index_prerelease_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_prerelease.json")
+}
+
+#[test]
+fn install_prerelease_fallback_outputs_w_prerelease_selected_diagnostic() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_prerelease_path();
+
+    let output = bin()
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "prelib",
+            "--lock",
+            lock_path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let parsed: Value = serde_json::from_str(&stdout).expect("json output");
+
+    assert_eq!(parsed["status"], "ok");
+
+    // The only available version (a pre-release) is still installed.
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let prelib = lock.packages.get("prelib").expect("prelib entry");
+    assert_eq!(prelib.version, "0.9.0b1");
+
+    let diags = parsed["diagnostics"].as_array().expect("diagnostics array");
+    let pre_diag = diags
+        .iter()
+        .find(|d| d.get("code") == Some(&Value::from("W_PRERELEASE_SELECTED")))
+        .expect("expected W_PRERELEASE_SELECTED diagnostic");
+
+    assert_eq!(pre_diag["level"], "warning");
+    let message = pre_diag["message"].as_str().expect("message string");
+    assert!(
+        message.contains("prelib") && message.contains("0.9.0b1"),
+        "diagnostic message should name the package and pre-release version: {message}"
+    );
+    assert_eq!(pre_diag["context"]["package"], "prelib");
+    assert_eq!(pre_diag["context"]["version"], "0.9.0b1");
+}
+
+#[test]
+fn install_with_pre_flag_does_not_emit_prerelease_diagnostic() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_prerelease_path();
+
+    let output = bin()
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "prelib",
+            "--pre",
+            "--lock",
+            lock_path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let parsed: Value = serde_json::from_str(&stdout).expect("json output");
+
+    assert_eq!(parsed["status"], "ok");
+    let diags = parsed["diagnostics"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.get("code") == Some(&Value::from("W_PRERELEASE_SELECTED"))),
+        "explicit --pre opt-in must not produce the fallback warning: {diags:?}"
+    );
+}

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -2255,3 +2255,100 @@ fn make_fake_pip_venv(dir: &Path, _pip_list_json: &str) -> std::path::PathBuf {
     // Windows stub — tests guarded by #[cfg(unix)] where needed
     dir.join("fake_venv")
 }
+
+// =============================================================================
+// Issue #341: MCP pybun_resolve mirrors the CLI `--pre` opt-in — pre-release
+// versions are excluded by default and only selected when `"pre": true`.
+// =============================================================================
+
+fn index_prerelease_fixture() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_prerelease.json")
+}
+
+#[test]
+fn mcp_tools_call_resolve_excludes_prereleases_by_default() {
+    let temp = tempdir().unwrap();
+    let index = index_prerelease_fixture();
+
+    let mut child = pybun_bin()
+        .env("PYBUN_HOME", temp.path())
+        .current_dir(temp.path())
+        .args(["mcp", "serve", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to start MCP server");
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let init_req = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}"#;
+        writeln!(stdin, "{}", init_req).ok();
+
+        let call_req = format!(
+            r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_resolve","arguments":{{"requirements":["lib>=1.0.0"],"index":"{}"}}}}}}"#,
+            index.display()
+        );
+        writeln!(stdin, "{}", call_req).ok();
+        stdin.flush().ok();
+    }
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("resolved"),
+        "pybun_resolve should resolve against the fixture index. Got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("2.0.0rc1"),
+        "pre-release 2.0.0rc1 must be excluded by default. Got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("1.0.0"),
+        "stable 1.0.0 should be selected by default. Got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn mcp_tools_call_resolve_pre_opts_in_to_prereleases() {
+    let temp = tempdir().unwrap();
+    let index = index_prerelease_fixture();
+
+    let mut child = pybun_bin()
+        .env("PYBUN_HOME", temp.path())
+        .current_dir(temp.path())
+        .args(["mcp", "serve", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to start MCP server");
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let init_req = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}"#;
+        writeln!(stdin, "{}", init_req).ok();
+
+        let call_req = format!(
+            r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_resolve","arguments":{{"requirements":["lib>=1.0.0"],"index":"{}","pre":true}}}}}}"#,
+            index.display()
+        );
+        writeln!(stdin, "{}", call_req).ok();
+        stdin.flush().ok();
+    }
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("2.0.0rc1"),
+        "\"pre\": true must allow the pre-release to be selected. Got: {}",
+        stdout
+    );
+}

--- a/tests/resolver_basic.rs
+++ b/tests/resolver_basic.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use pybun::resolver::{
-    InMemoryIndex, PackageArtifacts, PackageIndex, Requirement, ResolveError, ResolvedPackage,
-    resolve,
+    InMemoryIndex, PackageArtifacts, PackageIndex, PrereleaseFallback, Requirement, ResolveError,
+    ResolveOptions, ResolvedPackage, resolve, resolve_with_options,
 };
 
 #[tokio::test]
@@ -201,7 +201,9 @@ async fn relaxed_semver_handles_two_segment_requirement() {
 
 #[tokio::test]
 async fn pre_release_treated_as_less_than_final() {
-    // <2.4 should allow 2.4.0rc1 (pre-release) over 2.3.x
+    // 2.4.0rc1 orders below 2.4, so it satisfies `lib<2.4` — but PEP 440
+    // excludes pre-releases from selection by default (Issue #341), so the
+    // stable 2.3.5 wins unless the caller opts in.
     let mut index = InMemoryIndex::default();
     index.add("root", "1.0.0", ["lib<2.4"]);
     index.add("lib", "2.4.0rc1", Vec::<&str>::new());
@@ -211,7 +213,22 @@ async fn pre_release_treated_as_less_than_final() {
         .await
         .unwrap();
     let lib = resolution.packages.get("lib").expect("lib resolved");
-    assert_eq!(lib.version, "2.4.0rc1");
+    assert_eq!(lib.version, "2.3.5");
+
+    let resolution = resolve_with_options(
+        vec![Requirement::exact("root", "1.0.0")],
+        &index,
+        ResolveOptions {
+            allow_prerelease: true,
+        },
+    )
+    .await
+    .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(
+        lib.version, "2.4.0rc1",
+        "with --pre the pre-release still orders below 2.4 and wins over 2.3.5"
+    );
 }
 
 #[tokio::test]
@@ -578,5 +595,85 @@ async fn fetches_sibling_dependency_metadata_concurrently() {
         elapsed < serial_lower_bound / 2,
         "resolve() took {elapsed:?}, expected well under {serial_lower_bound:?} \
          if fetches ran concurrently"
+    );
+}
+
+// --- Pre-release handling (Issue #341) ---
+
+#[tokio::test]
+async fn excludes_prerelease_versions_by_default() {
+    let mut index = InMemoryIndex::default();
+    index.add("app", "1.0.0", ["lib>=1.0.0"]);
+    index.add("lib", "1.0.0", Vec::<&str>::new());
+    index.add("lib", "2.0.0rc1", Vec::<&str>::new());
+
+    let resolution = resolve(vec![Requirement::exact("app", "1.0.0")], &index)
+        .await
+        .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(
+        lib.version, "1.0.0",
+        "pre-release 2.0.0rc1 must be excluded by default (PEP 440)"
+    );
+    assert!(resolution.prerelease_fallbacks.is_empty());
+}
+
+#[tokio::test]
+async fn allows_prerelease_versions_with_opt_in() {
+    let mut index = InMemoryIndex::default();
+    index.add("lib", "1.0.0", Vec::<&str>::new());
+    index.add("lib", "2.0.0rc1", Vec::<&str>::new());
+
+    let resolution = resolve_with_options(
+        vec![Requirement::any("lib")],
+        &index,
+        ResolveOptions {
+            allow_prerelease: true,
+        },
+    )
+    .await
+    .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(lib.version, "2.0.0rc1");
+    assert!(
+        resolution.prerelease_fallbacks.is_empty(),
+        "opt-in selection is not a fallback"
+    );
+}
+
+#[tokio::test]
+async fn specifier_mentioning_prerelease_allows_prereleases_for_that_package() {
+    let mut index = InMemoryIndex::default();
+    index.add("lib", "1.0.0", Vec::<&str>::new());
+    index.add("lib", "2.0.0rc1", Vec::<&str>::new());
+
+    let resolution = resolve(vec![Requirement::minimum("lib", "2.0.0rc1")], &index)
+        .await
+        .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(lib.version, "2.0.0rc1");
+    assert!(
+        resolution.prerelease_fallbacks.is_empty(),
+        "a specifier mentioning a pre-release is an explicit opt-in, not a fallback"
+    );
+}
+
+#[tokio::test]
+async fn falls_back_to_prerelease_when_only_prereleases_satisfy() {
+    let mut index = InMemoryIndex::default();
+    index.add("prelib", "0.9.0b1", Vec::<&str>::new());
+
+    let resolution = resolve(vec![Requirement::any("prelib")], &index)
+        .await
+        .unwrap();
+    let prelib = resolution.packages.get("prelib").expect("prelib resolved");
+    assert_eq!(prelib.version, "0.9.0b1");
+    assert_eq!(
+        resolution.prerelease_fallbacks,
+        vec![PrereleaseFallback {
+            name: "prelib".to_string(),
+            version: "0.9.0b1".to_string(),
+        }],
+        "fallback pre-release selection must be reported for W_PRERELEASE_SELECTED"
     );
 }

--- a/tests/snapshots/compat/help_add.txt
+++ b/tests/snapshots/compat/help_add.txt
@@ -8,6 +8,7 @@ Arguments:
 Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
       --offline              Use offline mode when cache is sufficient
+      --pre                  Allow pre-release and dev versions when resolving (PEP 440 excludes them by default unless a specifier mentions one)
       --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
       --no-progress          Disable progress UI
   -h, --help                 Print help

--- a/tests/snapshots/compat/help_install.txt
+++ b/tests/snapshots/compat/help_install.txt
@@ -14,4 +14,5 @@ Options:
       --workspace                Operate on the whole workspace, merging dependencies from the root and all members. Useful when run from inside a workspace member directory
       --member <NAME>            Operate on a single workspace member by its `[project.name]`
       --group <NAME>             Operate on a named dependency group (checks `[project.optional-dependencies]` then `[dependency-groups]`)
+      --pre                      Allow pre-release and dev versions when resolving (PEP 440 excludes them by default unless a specifier mentions one)
   -h, --help                     Print help

--- a/tests/snapshots/compat/help_remove.txt
+++ b/tests/snapshots/compat/help_remove.txt
@@ -8,6 +8,7 @@ Arguments:
 Options:
       --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
       --offline              Use offline mode when cache is sufficient
+      --pre                  Allow pre-release and dev versions when resolving (PEP 440 excludes them by default unless a specifier mentions one)
       --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
       --no-progress          Disable progress UI
   -h, --help                 Print help


### PR DESCRIPTION
Closes #341

## Summary

`select_with_constraints()` picked the highest version among all satisfying candidates with no pre-release exclusion, so a package whose numerically-highest upload was a beta/rc got silently pinned into `pybun.lockb`. PEP 440 (and pip/uv) exclude pre-releases from version selection by default.

- New `is_prerelease()` scanner classifies PEP 440 pre-release/dev segments (`a`/`alpha`, `b`/`beta`, `c`, `rc`, `pre`, `preview`, `dev`; case-insensitive, any `.`/`-`/`_` or no separator; epochs and local labels ignored). Post-releases are correctly NOT pre-releases, while `1.0a1.post2` is.
- `resolve()` keeps its signature; new `resolve_with_options()` takes `ResolveOptions { allow_prerelease }`. Default selection filters pre-releases, considering them only when:
  1. the caller opts in (`--pre` on `install`/`add`/`upgrade`; `"pre": true` on MCP `pybun_resolve`/`pybun_install`),
  2. a specifier for that package itself mentions a pre-release (e.g. `lib>=2.0rc1`), or
  3. only pre-releases satisfy the constraints (fallback).
- Fallback selections are reported via `Resolution::prerelease_fallbacks` and surfaced as `W_PRERELEASE_SELECTED` warning diagnostics (with a `--pre` hint) from `install`, `lock`, `upgrade`, and PEP 723 `run`; MCP `pybun_resolve` returns them in its JSON payload.
- One existing test (`pre_release_treated_as_less_than_final`) encoded the buggy default (expected `lib<2.4` to select `2.4.0rc1`); it now asserts the PEP 440 default (`2.3.5`) and the `--pre` opt-in path (`2.4.0rc1`).
- The full PEP 440 version type (ordering, epochs) remains tracked in #340; `compare_versions`/`VersionSpec::matches` are untouched here.

## Test plan

- [x] Unit tests in `src/resolver.rs`: `is_prerelease` classification (incl. post/dev/epoch/local/case variants), default exclusion, opt-in, specifier-mention opt-in, fallback reporting
- [x] Integration tests in `tests/resolver_basic.rs` (4 new + 1 updated)
- [x] CLI tests in `tests/cli_install.rs` (`--pre` flag) and `tests/json_output.rs` (`W_PRERELEASE_SELECTED` diagnostic present on fallback, absent with `--pre`)
- [x] MCP tests in `tests/mcp.rs` (`pybun_resolve` default exclusion and `"pre": true` opt-in)
- [x] Help snapshots regenerated (`--pre` on add/install/remove)
- [x] `cargo test` full suite: 1054 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt -- --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)