### PR TITLE
fix(resolver): honor requires-python metadata when selecting candidates (Issue #342)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1509,8 +1509,10 @@ pub(crate) async fn install(
     let working_dir = std::env::current_dir()?;
     let target_env_probe = crate::env::find_python_env(&working_dir)?;
     let python_version_override = python_version_env_override();
-    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
-    // bypassing interpreter detection entirely.
+    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically.
+    // Note it no longer bypasses interpreter detection on its own: the detected version
+    // is also needed for `requires-python` filtering, so detection is only skipped when
+    // PYBUN_PYPI_PYTHON_VERSION covers that too.
     let forced_cp_tag = std::env::var("PYBUN_FORCE_CP_TAG")
         .ok()
         .filter(|v| !v.trim().is_empty());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::resolver::parse_version_relaxed;
 use crate::resolver::{
     PackageIndex, Requirement, Resolution, ResolveOptions, compare_versions,
     cp_tag_to_dotted_version, current_platform_tags, is_wheel_python_compatible, parse_wheel_tags,
-    python_version_to_cp_tag, resolve, resolve_with_options, select_artifact_for_platform_with_cp,
+    python_version_to_cp_tag, resolve_with_options, select_artifact_for_platform_with_cp,
 };
 use crate::sandbox;
 use crate::sbom;
@@ -1420,6 +1420,29 @@ fn warn_on_prerelease_fallback(resolution: &Resolution, collector: &mut EventCol
     }
 }
 
+/// Explicit `PYBUN_PYPI_PYTHON_VERSION` override for the resolution target
+/// Python version, if set and non-empty.
+fn python_version_env_override() -> Option<String> {
+    std::env::var("PYBUN_PYPI_PYTHON_VERSION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Python version used for `requires-python` candidate filtering during
+/// resolution (Issue #342): the `PYBUN_PYPI_PYTHON_VERSION` override wins,
+/// otherwise the interpreter detected for the current working directory
+/// (`PYBUN_ENV` / project venv / system Python). `None` — for example when
+/// no interpreter can be found — disables the filter.
+pub(crate) fn resolve_target_python_version() -> Option<String> {
+    if let Some(version) = python_version_env_override() {
+        return Some(version);
+    }
+    let cwd = std::env::current_dir().ok()?;
+    let probe = crate::env::find_python_env(&cwd).ok()?;
+    get_python_version(&probe.python_path).ok()
+}
+
 pub(crate) async fn install(
     args: &crate::cli::InstallArgs,
     collector: &mut EventCollector,
@@ -1470,10 +1493,45 @@ pub(crate) async fn install(
         });
     }
 
+    // Detect the CPython tag of the actual install target (PYBUN_ENV / PYBUN_PYTHON /
+    // project venv / system Python) *before* selecting wheels, so artifact selection
+    // matches the Python interpreter packages will actually be installed into.
+    // Selecting wheels against whatever `python3`/`python` happens to resolve on PATH
+    // (the previous behavior) can silently pick wheels for the wrong CPython ABI
+    // (Issue #291). This is read-only detection only — creating a project-local venv
+    // (and the associated system-Python safe-install-target guard) is deferred to the
+    // later "Install wheels" step below, so a resolve-only or failed install doesn't
+    // have the side effect of mutating the filesystem.
+    //
+    // Detection happens before resolution because the same interpreter version also
+    // drives `requires-python` candidate filtering (Issue #342). The interpreter is
+    // only spawned when no environment override makes it unnecessary.
+    let working_dir = std::env::current_dir()?;
+    let target_env_probe = crate::env::find_python_env(&working_dir)?;
+    let python_version_override = python_version_env_override();
+    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
+    // bypassing interpreter detection entirely.
+    let forced_cp_tag = std::env::var("PYBUN_FORCE_CP_TAG")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let detected_python_version = if python_version_override.is_none() || forced_cp_tag.is_none() {
+        get_python_version(&target_env_probe.python_path).ok()
+    } else {
+        None
+    };
+    let active_cp_tag = forced_cp_tag
+        .or_else(|| {
+            detected_python_version
+                .as_deref()
+                .and_then(python_version_to_cp_tag)
+        })
+        .unwrap_or_else(|| "cp311".to_string());
+
     let source_index_url: String;
     let offline = args.offline;
     let resolve_options = ResolveOptions {
         allow_prerelease: args.pre,
+        python_version: python_version_override.or(detected_python_version),
     };
     let resolution = if let Some(index_path) = args.index.clone() {
         source_index_url = index_path.display().to_string();
@@ -1516,30 +1574,6 @@ pub(crate) async fn install(
         event.message = Some("Resolved dependencies".to_string());
         event.progress = Some(40);
     });
-
-    // Detect the CPython tag of the actual install target (PYBUN_ENV / PYBUN_PYTHON /
-    // project venv / system Python) *before* selecting wheels, so artifact selection
-    // matches the Python interpreter packages will actually be installed into.
-    // Selecting wheels against whatever `python3`/`python` happens to resolve on PATH
-    // (the previous behavior) can silently pick wheels for the wrong CPython ABI
-    // (Issue #291). This is read-only detection only — creating a project-local venv
-    // (and the associated system-Python safe-install-target guard) is deferred to the
-    // later "Install wheels" step below, so a resolve-only or failed install doesn't
-    // have the side effect of mutating the filesystem.
-    let working_dir = std::env::current_dir()?;
-    let target_env_probe = crate::env::find_python_env(&working_dir)?;
-
-    // PYBUN_FORCE_CP_TAG lets tests (and users) pin the CPython tag deterministically,
-    // bypassing interpreter detection entirely.
-    let active_cp_tag = std::env::var("PYBUN_FORCE_CP_TAG")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .or_else(|| {
-            get_python_version(&target_env_probe.python_path)
-                .ok()
-                .and_then(|v| python_version_to_cp_tag(&v))
-        })
-        .unwrap_or_else(|| "cp311".to_string());
 
     let platform_tags = current_platform_tags();
     let mut lock = Lockfile::new(
@@ -2007,10 +2041,14 @@ async fn lock_dependencies(args: &LockArgs, collector: &mut EventCollector) -> R
 
     let source_index_url: String;
     let offline = args.offline;
+    let resolve_options = ResolveOptions {
+        python_version: resolve_target_python_version(),
+        ..Default::default()
+    };
     let resolution = if let Some(index_path) = args.index.clone() {
         source_index_url = index_path.display().to_string();
         let index = load_index_from_path(&index_path).map_err(|e| eyre!(e))?;
-        match resolve(requirements.clone(), &index).await {
+        match resolve_with_options(requirements.clone(), &index, resolve_options).await {
             Ok(r) => r,
             Err(e) => {
                 for d in crate::self_heal::diagnostics_for_resolve_error(&requirements, &e) {
@@ -2028,7 +2066,8 @@ async fn lock_dependencies(args: &LockArgs, collector: &mut EventCollector) -> R
             source_index_url, offline
         ));
         let index = PyPiIndex::new(client);
-        let resolve_result = resolve(requirements.clone(), &index).await;
+        let resolve_result =
+            resolve_with_options(requirements.clone(), &index, resolve_options).await;
         for notice in index.take_stale_cache_notices() {
             collector.warning(notice);
         }
@@ -3230,7 +3269,16 @@ async fn run_script(
                         // But PyPiClient::from_env handles env vars.
                         let client = PyPiClient::from_env(false).map_err(|e| eyre!(e))?;
                         let index = PyPiIndex::new(client);
-                        let resolution = resolve(requirements, &index).await;
+                        let resolution = resolve_with_options(
+                            requirements,
+                            &index,
+                            ResolveOptions {
+                                python_version: python_version_env_override()
+                                    .or_else(|| Some(python_version.clone())),
+                                ..Default::default()
+                            },
+                        )
+                        .await;
                         for notice in index.take_stale_cache_notices() {
                             collector.warning(notice);
                         }
@@ -5075,6 +5123,7 @@ async fn run_upgrade(args: &UpgradeArgs, collector: &mut EventCollector) -> Resu
     // Re-resolve dependencies
     let resolve_options = ResolveOptions {
         allow_prerelease: args.pre,
+        python_version: resolve_target_python_version(),
     };
     let source_index_url: String;
     let resolution = if let Some(index_path) = &args.index {

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,6 +14,9 @@ pub struct IndexPackage {
     pub wheels: Vec<IndexWheel>,
     #[serde(default)]
     pub sdist: Option<String>,
+    /// PEP 440 `requires-python` specifier for this release (Issue #342).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_python: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -81,7 +84,13 @@ fn build_index(packages: Vec<IndexPackage>) -> InMemoryIndex {
                 sdist: pkg.sdist.clone(),
             }
         };
-        index.add_with_artifacts(pkg.name, pkg.version, pkg.dependencies, artifacts);
+        index.add_entry(
+            pkg.name,
+            pkg.version,
+            pkg.dependencies,
+            artifacts,
+            pkg.requires_python.as_deref(),
+        );
     }
     index
 }
@@ -252,6 +261,23 @@ mod tests {
             .expect("package");
         assert_eq!(pkg.dependencies.len(), 1);
         assert_eq!(pkg.dependencies[0].to_string(), "dep==2.0.0");
+        assert_eq!(pkg.requires_python, None);
+    }
+
+    #[tokio::test]
+    async fn index_fixture_carries_requires_python() {
+        let index = build_index(vec![IndexPackage {
+            name: "app".into(),
+            version: "1.0.0".into(),
+            requires_python: Some(">=3.10".into()),
+            ..Default::default()
+        }]);
+        let pkg = index
+            .get("app", "1.0.0")
+            .await
+            .expect("no error")
+            .expect("package");
+        assert_eq!(pkg.requires_python.as_deref(), Some(">=3.10"));
     }
 
     // ==========================================================================

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1510,6 +1510,7 @@ impl McpServer {
         // Opt-in to pre-release versions (mirrors the CLI `--pre` flag).
         let resolve_options = ResolveOptions {
             allow_prerelease: args.get("pre").and_then(|p| p.as_bool()).unwrap_or(false),
+            python_version: crate::commands::resolve_target_python_version(),
         };
 
         // Try to load index from common locations

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -389,6 +389,7 @@ impl PyPiClient {
             dependencies: deps,
             source: Some(source.clone()),
             artifacts,
+            requires_python: pkg.requires_python.clone(),
         }
     }
 
@@ -502,6 +503,10 @@ struct ReleaseFile {
     yanked: Option<bool>,
     #[serde(default)]
     digests: Option<HashMap<String, String>>,
+    /// PEP 440 `requires-python` specifier published per release file
+    /// (Issue #342). PyPI serves the same value for every file of a release.
+    #[serde(default)]
+    requires_python: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -536,6 +541,8 @@ struct CachedPackage {
     wheels: Vec<CachedWheel>,
     #[serde(default)]
     sdist: Option<String>,
+    #[serde(default)]
+    requires_python: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -935,6 +942,12 @@ fn build_cached_packages(
         }
         let mut wheels = Vec::new();
         let mut sdist = None;
+        // PyPI publishes the same requires_python for every file of a
+        // release; take it from the first file that carries it (Issue #342).
+        let requires_python = files
+            .iter()
+            .filter(|file| !file.yanked.unwrap_or(false))
+            .find_map(|file| file.requires_python.clone());
         for file in files {
             if file.yanked.unwrap_or(false) {
                 continue;
@@ -976,6 +989,7 @@ fn build_cached_packages(
             dependencies,
             wheels,
             sdist,
+            requires_python,
         });
     }
     packages

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -340,6 +340,10 @@ pub struct ResolvedPackage {
     pub dependencies: Vec<Requirement>,
     pub source: Option<PackageSource>,
     pub artifacts: PackageArtifacts,
+    /// PEP 440 specifier from the package's `requires-python` metadata
+    /// (PyPI `requires_python` / index fixture `requires_python`). `None`
+    /// means the package declares no interpreter constraint (Issue #342).
+    pub requires_python: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -610,12 +614,35 @@ pub struct PrereleaseFallback {
 }
 
 /// Options controlling dependency resolution behavior.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ResolveOptions {
     /// Allow pre-release/dev versions to be selected for every package
     /// (CLI `--pre` / MCP `pre`). Defaults to `false`, matching the PEP 440
     /// rule that pre-releases are excluded unless opted in (Issue #341).
     pub allow_prerelease: bool,
+    /// Python version of the resolution target interpreter (e.g. `3.9.18`).
+    /// When set, candidates whose `requires-python` specifier does not match
+    /// are skipped during selection; `None` disables the filter (Issue #342).
+    pub python_version: Option<String>,
+}
+
+/// Report whether a `requires-python` specifier admits `python_version`.
+///
+/// Comma-separated PEP 440 clauses are all required to match. Clauses this
+/// resolver cannot evaluate — wildcards (`!=3.0.*`) or otherwise unparseable
+/// parts — are treated as satisfied, so imperfect metadata can only ever
+/// widen the candidate set, never wrongly exclude a version (Issue #342).
+pub fn requires_python_allows(requires_python: &str, python_version: &str) -> bool {
+    requires_python.split(',').all(|part| {
+        let part = part.trim();
+        if part.is_empty() || part.contains('*') {
+            return true;
+        }
+        match parse_version_spec(part) {
+            Ok(spec) => spec.matches(python_version),
+            Err(_) => true,
+        }
+    })
 }
 
 /// Report whether `version` is a PEP 440 pre-release or dev release.
@@ -778,6 +805,30 @@ pub enum ResolveError {
     },
     #[error("io error: {0}")]
     Io(String),
+    #[error(
+        "no version of {} matching {} supports Python {} (newest matching release {} requires Python {})",
+        .0.name, .0.constraint, .0.python_version, .0.rejected_version, .0.rejected_requires_python
+    )]
+    PythonIncompatible(Box<PythonIncompatibility>),
+}
+
+/// Details of a `requires-python` resolution failure (Issue #342). Boxed in
+/// [`ResolveError::PythonIncompatible`] to keep the error type small.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonIncompatibility {
+    pub name: String,
+    pub constraint: String,
+    /// The resolution target interpreter version the candidates were
+    /// checked against.
+    pub python_version: String,
+    pub requested_by: Option<String>,
+    /// Highest version that satisfied the version constraints but was
+    /// rejected by its `requires-python` specifier.
+    pub rejected_version: String,
+    pub rejected_requires_python: String,
+    /// Newest release (ignoring the version constraints) that does support
+    /// the target Python, for the diagnostic hint.
+    pub newest_compatible: Option<String>,
 }
 
 pub trait PackageIndex {
@@ -933,6 +984,7 @@ pub async fn resolve_with_options(
                     &candidates,
                     requested_by.as_deref(),
                     options.allow_prerelease,
+                    options.python_version.as_deref(),
                 ) {
                     batch_resolved.insert(req.name.clone(), pkg.clone());
                     fetch_events.push(FetchEvent {
@@ -972,6 +1024,7 @@ pub async fn resolve_with_options(
                 candidates,
                 requested_by.as_deref(),
                 options.allow_prerelease,
+                options.python_version.as_deref(),
             )?;
 
             batch_resolved.insert(req.name.clone(), pkg.clone());
@@ -1080,11 +1133,28 @@ fn select_with_constraints(
     candidates: &[ResolvedPackage],
     requested_by: Option<&str>,
     allow_prerelease: bool,
+    python_version: Option<&str>,
 ) -> Result<ResolvedPackage, ResolveError> {
     let constraints = reqs.get(name).cloned().unwrap_or_default();
-    let satisfying: Vec<&ResolvedPackage> = candidates
+    let matching: Vec<&ResolvedPackage> = candidates
         .iter()
         .filter(|pkg| constraints.iter().all(|r| r.is_satisfied_by(&pkg.version)))
+        .collect();
+
+    // Drop candidates whose `requires-python` metadata excludes the
+    // resolution target interpreter (Issue #342). Packages without the
+    // metadata are always kept.
+    let python_compatible = |pkg: &ResolvedPackage| {
+        python_version.is_none_or(|py| {
+            pkg.requires_python
+                .as_deref()
+                .is_none_or(|spec| requires_python_allows(spec, py))
+        })
+    };
+    let satisfying: Vec<&ResolvedPackage> = matching
+        .iter()
+        .copied()
+        .filter(|pkg| python_compatible(pkg))
         .collect();
 
     // PEP 440: pre-release/dev versions are excluded by default. They are
@@ -1111,24 +1181,55 @@ fn select_with_constraints(
     .copied();
 
     if let Some(pkg) = candidate {
-        Ok(pkg.clone())
-    } else {
-        let constraint_display = if constraints.is_empty() {
-            "*".to_string()
-        } else {
-            constraints
-                .iter()
-                .map(|r| r.constraint_display())
-                .collect::<Vec<_>>()
-                .join(" & ")
-        };
-        Err(ResolveError::Missing {
-            name: name.to_string(),
-            constraint: constraint_display,
-            requested_by: requested_by.map(ToString::to_string),
-            available_versions: candidates.iter().map(|p| p.version.clone()).collect(),
-        })
+        return Ok(pkg.clone());
     }
+
+    let constraint_display = if constraints.is_empty() {
+        "*".to_string()
+    } else {
+        constraints
+            .iter()
+            .map(|r| r.constraint_display())
+            .collect::<Vec<_>>()
+            .join(" & ")
+    };
+
+    // Versions matched the constraints but every one of them was rejected
+    // by `requires-python`: report the interpreter conflict, not a generic
+    // "missing" error (Issue #342).
+    if let (Some(py), Some(rejected)) = (
+        python_version,
+        matching
+            .iter()
+            .max_by(|a, b| version_cmp(&a.version, &b.version)),
+    ) {
+        let newest_compatible = candidates
+            .iter()
+            .filter(|pkg| python_compatible(pkg))
+            .max_by(|a, b| version_cmp(&a.version, &b.version))
+            .map(|pkg| pkg.version.clone());
+        return Err(ResolveError::PythonIncompatible(Box::new(
+            PythonIncompatibility {
+                name: name.to_string(),
+                constraint: constraint_display,
+                python_version: py.to_string(),
+                requested_by: requested_by.map(ToString::to_string),
+                rejected_version: rejected.version.clone(),
+                rejected_requires_python: rejected
+                    .requires_python
+                    .clone()
+                    .unwrap_or_else(|| "*".to_string()),
+                newest_compatible,
+            },
+        )));
+    }
+
+    Err(ResolveError::Missing {
+        name: name.to_string(),
+        constraint: constraint_display,
+        requested_by: requested_by.map(ToString::to_string),
+        available_versions: candidates.iter().map(|p| p.version.clone()).collect(),
+    })
 }
 
 #[derive(Default)]
@@ -1149,12 +1250,36 @@ impl InMemoryIndex {
         self.add_with_artifacts(name, version, deps, artifacts);
     }
 
+    pub fn add_with_requires_python(
+        &mut self,
+        name: impl Into<String>,
+        version: impl Into<String>,
+        deps: impl IntoIterator<Item = impl AsRef<str>>,
+        requires_python: Option<&str>,
+    ) {
+        let name = name.into();
+        let version = version.into();
+        let artifacts = PackageArtifacts::universal(&name, &version);
+        self.add_entry(name, version, deps, artifacts, requires_python);
+    }
+
     pub fn add_with_artifacts(
         &mut self,
         name: impl Into<String>,
         version: impl Into<String>,
         deps: impl IntoIterator<Item = impl AsRef<str>>,
         artifacts: PackageArtifacts,
+    ) {
+        self.add_entry(name, version, deps, artifacts, None);
+    }
+
+    pub fn add_entry(
+        &mut self,
+        name: impl Into<String>,
+        version: impl Into<String>,
+        deps: impl IntoIterator<Item = impl AsRef<str>>,
+        artifacts: PackageArtifacts,
+        requires_python: Option<&str>,
     ) {
         let name = name.into();
         let version = version.into();
@@ -1168,6 +1293,7 @@ impl InMemoryIndex {
             dependencies: deps,
             source: None,
             artifacts,
+            requires_python: requires_python.map(ToString::to_string),
         };
         self.pkgs.insert((name, version), pkg);
     }
@@ -2454,6 +2580,7 @@ mod tests {
     #[test]
     fn select_artifact_prefers_cp311_wheel_over_cp310_on_python_311() {
         let pkg = ResolvedPackage {
+            requires_python: None,
             name: "pyarrow".to_string(),
             version: "14.0.0".to_string(),
             dependencies: vec![],
@@ -2491,6 +2618,7 @@ mod tests {
     #[test]
     fn select_artifact_prefers_cp310_wheel_over_cp311_on_python_310() {
         let pkg = ResolvedPackage {
+            requires_python: None,
             name: "pyarrow".to_string(),
             version: "14.0.0".to_string(),
             dependencies: vec![],
@@ -2529,6 +2657,7 @@ mod tests {
     fn select_artifact_excludes_incompatible_python_version() {
         // Only cp310 wheel available, but we're on cp311
         let pkg = ResolvedPackage {
+            requires_python: None,
             name: "pyarrow".to_string(),
             version: "14.0.0".to_string(),
             dependencies: vec![],
@@ -2557,6 +2686,7 @@ mod tests {
     fn select_artifact_uses_abi3_wheel_as_fallback() {
         // abi3 wheel available in addition to cp311
         let pkg = ResolvedPackage {
+            requires_python: None,
             name: "cryptography".to_string(),
             version: "41.0.0".to_string(),
             dependencies: vec![],
@@ -2601,6 +2731,7 @@ mod tests {
     #[test]
     fn select_artifact_py3_wheel_is_always_compatible() {
         let pkg = ResolvedPackage {
+            requires_python: None,
             name: "requests".to_string(),
             version: "2.28.0".to_string(),
             dependencies: vec![],
@@ -2711,6 +2842,7 @@ mod tests {
             &index,
             ResolveOptions {
                 allow_prerelease: true,
+                ..Default::default()
             },
         )
         .await
@@ -2867,5 +2999,27 @@ mod tests {
         assert!(!VersionSpec::Exact("1.2.3".to_string()).matches("1.2.3.4"));
         assert!(VersionSpec::NotEqual("1.2.3".to_string()).matches("1.2.3.4"));
         assert!(VersionSpec::Exact("1.2.3.0".to_string()).matches("1.2.3"));
+    }
+
+    #[test]
+    fn requires_python_allows_basic_specifiers() {
+        assert!(requires_python_allows(">=3.8", "3.9.18"));
+        assert!(!requires_python_allows(">=3.10", "3.9.18"));
+        assert!(requires_python_allows(">=3.8,<3.13", "3.12.1"));
+        assert!(!requires_python_allows(">=3.8,<3.13", "3.13.0"));
+        assert!(requires_python_allows("<=3.9", "3.9"));
+        assert!(!requires_python_allows("!=3.9", "3.9.0"));
+    }
+
+    #[test]
+    fn requires_python_allows_is_lenient_on_unsupported_clauses() {
+        // Wildcards are outside this resolver's specifier support: skip
+        // the clause rather than wrongly reject the candidate.
+        assert!(requires_python_allows("!=3.0.*, >=2.7", "3.9.18"));
+        // Unparseable clauses (bad metadata) must never exclude a version.
+        assert!(requires_python_allows("garbage", "3.9.18"));
+        assert!(requires_python_allows("", "3.9.18"));
+        // ...but valid clauses alongside them still apply.
+        assert!(!requires_python_allows("garbage, >=3.10", "3.9.18"));
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -978,7 +978,7 @@ pub async fn resolve_with_options(
                 }
                 // Try to select a version that satisfies all constraints seen so far
                 let candidates = version_cache.get(&req.name).cloned().unwrap_or_default();
-                if let Ok(pkg) = select_with_constraints(
+                match select_with_constraints(
                     &constraints,
                     &req.name,
                     &candidates,
@@ -986,24 +986,30 @@ pub async fn resolve_with_options(
                     options.allow_prerelease,
                     options.python_version.as_deref(),
                 ) {
-                    batch_resolved.insert(req.name.clone(), pkg.clone());
-                    fetch_events.push(FetchEvent {
-                        name: req.name.clone(),
-                        candidate: pkg,
-                        requested_by: requested_by.clone(),
-                        kind: FetchKind::Reconcile,
-                    });
-                } else {
-                    let existing_chain = build_chain(&parents, &req.name);
-                    let requested_chain =
-                        build_requested_chain(&parents, &req.name, requested_by.clone());
-                    return Err(ResolveError::Conflict {
-                        name: req.name.clone(),
-                        existing: existing.version.clone(),
-                        requested: req.constraint_display(),
-                        existing_chain,
-                        requested_chain,
-                    });
+                    Ok(pkg) => {
+                        batch_resolved.insert(req.name.clone(), pkg.clone());
+                        fetch_events.push(FetchEvent {
+                            name: req.name.clone(),
+                            candidate: pkg,
+                            requested_by: requested_by.clone(),
+                            kind: FetchKind::Reconcile,
+                        });
+                    }
+                    // Keep the interpreter-conflict detail instead of
+                    // degrading it to a generic version conflict (Issue #342).
+                    Err(err @ ResolveError::PythonIncompatible(_)) => return Err(err),
+                    Err(_) => {
+                        let existing_chain = build_chain(&parents, &req.name);
+                        let requested_chain =
+                            build_requested_chain(&parents, &req.name, requested_by.clone());
+                        return Err(ResolveError::Conflict {
+                            name: req.name.clone(),
+                            existing: existing.version.clone(),
+                            requested: req.constraint_display(),
+                            existing_chain,
+                            requested_chain,
+                        });
+                    }
                 }
                 continue;
             }

--- a/src/self_heal.rs
+++ b/src/self_heal.rs
@@ -172,7 +172,8 @@ pub fn diagnostics_for_resolve_error(
             if let Some(newest) = newest_compatible {
                 diags.push(
                     Diagnostic::hint(format!(
-                        "newest {name} release compatible with Python {python_version} is {newest}"
+                        "newest {name} release compatible with Python {python_version} is \
+                         {newest} (ignoring the version constraint {constraint})"
                     ))
                     .with_code("H_RESOLVE_PYTHON_NEWEST_COMPATIBLE")
                     .with_context(json!({ "name": name, "version": newest })),

--- a/src/self_heal.rs
+++ b/src/self_heal.rs
@@ -136,6 +136,50 @@ pub fn diagnostics_for_resolve_error(
                 .with_context(json!({ "error": msg })),
             ]
         }
+        ResolveError::PythonIncompatible(details) => {
+            let crate::resolver::PythonIncompatibility {
+                name,
+                constraint,
+                python_version,
+                requested_by,
+                rejected_version,
+                rejected_requires_python,
+                newest_compatible,
+            } = details.as_ref();
+            let mut diags = Vec::new();
+            diags.push(
+                Diagnostic::error(format!(
+                    "Could not resolve dependencies: no version of {name} matching {constraint} \
+                     supports Python {python_version} ({name} {rejected_version} requires \
+                     Python {rejected_requires_python})"
+                ))
+                .with_code("E_RESOLVE_PYTHON_INCOMPATIBLE")
+                .with_suggestion(
+                    "Upgrade the target Python interpreter, or loosen the version constraint \
+                     to allow an older, compatible release.",
+                )
+                .with_context(json!({
+                    "name": name,
+                    "constraint": constraint,
+                    "python_version": python_version,
+                    "requested_by": requested_by,
+                    "rejected_version": rejected_version,
+                    "rejected_requires_python": rejected_requires_python,
+                    "newest_compatible": newest_compatible,
+                    "root_requirements": root_reqs,
+                })),
+            );
+            if let Some(newest) = newest_compatible {
+                diags.push(
+                    Diagnostic::hint(format!(
+                        "newest {name} release compatible with Python {python_version} is {newest}"
+                    ))
+                    .with_code("H_RESOLVE_PYTHON_NEWEST_COMPATIBLE")
+                    .with_context(json!({ "name": name, "version": newest })),
+                );
+            }
+            diags
+        }
     }
 }
 

--- a/tests/cli_install.rs
+++ b/tests/cli_install.rs
@@ -933,3 +933,69 @@ fn install_pre_flag_opts_in_to_prerelease_versions() {
         "--pre must allow the pre-release to be selected"
     );
 }
+
+// =============================================================================
+// Issue #342: candidates whose requires-python excludes the target interpreter
+// must be skipped, resolving the newest release that supports it instead.
+// =============================================================================
+
+fn index_requires_python_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_requires_python.json")
+}
+
+#[test]
+fn install_skips_versions_incompatible_with_target_python() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_requires_python_path();
+
+    bin()
+        .env("PYBUN_PYPI_PYTHON_VERSION", "3.9.18")
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "lib",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let lib = lock.packages.get("lib").expect("lib entry");
+    assert_eq!(
+        lib.version, "1.13.1",
+        "lib 2.0.0 requires Python >=3.10 and must be skipped on 3.9"
+    );
+}
+
+#[test]
+fn install_keeps_newest_version_when_target_python_matches() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_requires_python_path();
+
+    bin()
+        .env("PYBUN_PYPI_PYTHON_VERSION", "3.12.1")
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "lib",
+            "--lock",
+            lock_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let lock = Lockfile::load_from_path(&lock_path).expect("lock loads");
+    let lib = lock.packages.get("lib").expect("lib entry");
+    assert_eq!(lib.version, "2.0.0");
+}

--- a/tests/fixtures/index_requires_python.json
+++ b/tests/fixtures/index_requires_python.json
@@ -1,0 +1,5 @@
+[
+  {"name":"lib","version":"1.13.1","dependencies":[],"requires_python":">=3.8","wheels":[{"file":"lib-1.13.1-py3-none-any.whl","hash":"sha256:lib1131"}]},
+  {"name":"lib","version":"2.0.0","dependencies":[],"requires_python":">=3.10","wheels":[{"file":"lib-2.0.0-py3-none-any.whl","hash":"sha256:lib200"}]},
+  {"name":"strictlib","version":"3.0.0","dependencies":[],"requires_python":">=3.12","wheels":[{"file":"strictlib-3.0.0-py3-none-any.whl","hash":"sha256:strictlib300"}]}
+]

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -578,3 +578,99 @@ fn install_with_pre_flag_does_not_emit_prerelease_diagnostic() {
         "explicit --pre opt-in must not produce the fallback warning: {diags:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #342: requires-python metadata must filter candidates; when no
+// version supports the target Python the failure is a structured
+// E_RESOLVE_PYTHON_INCOMPATIBLE diagnostic, not a generic missing error.
+// ---------------------------------------------------------------------------
+
+fn index_requires_python_path() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_requires_python.json")
+}
+
+#[test]
+fn install_python_incompatible_outputs_structured_diagnostic() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_requires_python_path();
+
+    let output = bin()
+        .env("PYBUN_PYPI_PYTHON_VERSION", "3.9.18")
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "strictlib",
+            "--lock",
+            lock_path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let parsed: Value = serde_json::from_str(&stdout).expect("json output");
+
+    assert_eq!(parsed["status"], "error");
+    let diags = parsed["diagnostics"].as_array().expect("diagnostics array");
+    let diag = diags
+        .iter()
+        .find(|d| d.get("code") == Some(&Value::from("E_RESOLVE_PYTHON_INCOMPATIBLE")))
+        .expect("expected E_RESOLVE_PYTHON_INCOMPATIBLE diagnostic");
+    let message = diag["message"].as_str().expect("message string");
+    assert!(
+        message.contains("strictlib") && message.contains("3.9.18") && message.contains(">=3.12"),
+        "diagnostic should name package, target Python, and the requires-python spec: {message}"
+    );
+    assert_eq!(diag["context"]["python_version"], "3.9.18");
+    assert_eq!(diag["context"]["rejected_version"], "3.0.0");
+    assert_eq!(diag["context"]["rejected_requires_python"], ">=3.12");
+}
+
+#[test]
+fn install_python_incompatible_hint_names_newest_compatible_release() {
+    let temp = tempdir().unwrap();
+    let lock_path = temp.path().join("pybun.lockb");
+    let index = index_requires_python_path();
+
+    // lib>=2.0.0 forces the 3.10-only release while an older 3.8-compatible
+    // release exists: the hint should point at it.
+    let output = bin()
+        .env("PYBUN_PYPI_PYTHON_VERSION", "3.9.18")
+        .args([
+            "install",
+            "--index",
+            index.to_str().unwrap(),
+            "--require",
+            "lib>=2.0.0",
+            "--lock",
+            lock_path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let parsed: Value = serde_json::from_str(&stdout).expect("json output");
+
+    let diags = parsed["diagnostics"].as_array().expect("diagnostics array");
+    let hint = diags
+        .iter()
+        .find(|d| d.get("code") == Some(&Value::from("H_RESOLVE_PYTHON_NEWEST_COMPATIBLE")))
+        .expect("expected H_RESOLVE_PYTHON_NEWEST_COMPATIBLE hint");
+    assert_eq!(hint["context"]["version"], "1.13.1");
+}

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -2352,3 +2352,59 @@ fn mcp_tools_call_resolve_pre_opts_in_to_prereleases() {
         stdout
     );
 }
+
+// =============================================================================
+// Issue #342: pybun_resolve must skip candidates whose requires-python
+// excludes the resolution target interpreter.
+// =============================================================================
+
+fn index_requires_python_fixture() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir");
+    std::path::Path::new(&manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("index_requires_python.json")
+}
+
+#[test]
+fn mcp_tools_call_resolve_filters_by_requires_python() {
+    let temp = tempdir().unwrap();
+    let index = index_requires_python_fixture();
+
+    let mut child = pybun_bin()
+        .env("PYBUN_HOME", temp.path())
+        .env("PYBUN_PYPI_PYTHON_VERSION", "3.9.18")
+        .current_dir(temp.path())
+        .args(["mcp", "serve", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to start MCP server");
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let init_req = r#"{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}"#;
+        writeln!(stdin, "{}", init_req).ok();
+
+        let call_req = format!(
+            r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_resolve","arguments":{{"requirements":["lib"],"index":"{}"}}}}}}"#,
+            index.display()
+        );
+        writeln!(stdin, "{}", call_req).ok();
+        stdin.flush().ok();
+    }
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("1.13.1"),
+        "the newest Python-3.9-compatible release should be selected. Got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("\"2.0.0\""),
+        "lib 2.0.0 (requires-python >=3.10) must be skipped on Python 3.9. Got: {}",
+        stdout
+    );
+}

--- a/tests/resolver_basic.rs
+++ b/tests/resolver_basic.rs
@@ -869,3 +869,37 @@ async fn unparseable_requires_python_specs_are_lenient() {
         "wildcard/unparseable parts must never reject a candidate"
     );
 }
+
+#[tokio::test]
+async fn reconciliation_preserves_python_incompatible_error() {
+    // Diamond: a picks lib 2.0.0 first; b then narrows to lib<2.0.0, whose
+    // only candidate is rejected by requires-python on the target Python.
+    // The interpreter conflict must surface, not a generic version conflict.
+    let mut index = InMemoryIndex::default();
+    index.add("a", "1.0.0", ["lib"]);
+    index.add("b", "1.0.0", ["lib<2.0.0"]);
+    index.add("lib", "2.0.0", Vec::<&str>::new());
+    index.add_with_requires_python("lib", "1.13.1", Vec::<&str>::new(), Some(">=3.10"));
+
+    let err = resolve_with_options(
+        vec![
+            Requirement::exact("a", "1.0.0"),
+            Requirement::exact("b", "1.0.0"),
+        ],
+        &index,
+        ResolveOptions {
+            python_version: Some("3.9.18".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err();
+    match err {
+        ResolveError::PythonIncompatible(details) => {
+            assert_eq!(details.name, "lib");
+            assert_eq!(details.rejected_version, "1.13.1");
+            assert_eq!(details.rejected_requires_python, ">=3.10");
+        }
+        other => panic!("expected PythonIncompatible, got {other:?}"),
+    }
+}

--- a/tests/resolver_basic.rs
+++ b/tests/resolver_basic.rs
@@ -722,7 +722,6 @@ async fn falls_back_to_prerelease_when_only_prereleases_satisfy() {
     );
 }
 
-
 // --- Issue #340: PEP 440 ordering (post-releases, epochs, numeric pre-release order) ---
 
 #[tokio::test]

--- a/tests/resolver_basic.rs
+++ b/tests/resolver_basic.rs
@@ -220,6 +220,7 @@ async fn pre_release_treated_as_less_than_final() {
         &index,
         ResolveOptions {
             allow_prerelease: true,
+            ..Default::default()
         },
     )
     .await
@@ -272,6 +273,7 @@ async fn resolves_dependencies_fetched_after_selection() {
     all_map.insert(
         "app".to_string(),
         vec![ResolvedPackage {
+            requires_python: None,
             name: "app".to_string(),
             version: "1.0.0".to_string(),
             dependencies: Vec::new(),
@@ -282,6 +284,7 @@ async fn resolves_dependencies_fetched_after_selection() {
     all_map.insert(
         "dep".to_string(),
         vec![ResolvedPackage {
+            requires_python: None,
             name: "dep".to_string(),
             version: "1.0.0".to_string(),
             dependencies: Vec::new(),
@@ -294,6 +297,7 @@ async fn resolves_dependencies_fetched_after_selection() {
     get_map.insert(
         ("app".to_string(), "1.0.0".to_string()),
         ResolvedPackage {
+            requires_python: None,
             name: "app".to_string(),
             version: "1.0.0".to_string(),
             dependencies: vec![Requirement::exact("dep", "1.0.0")],
@@ -511,6 +515,7 @@ async fn fetches_sibling_dependency_metadata_concurrently() {
     all_map.insert(
         "app".to_string(),
         vec![ResolvedPackage {
+            requires_python: None,
             name: "app".to_string(),
             version: "1.0.0".to_string(),
             dependencies: Vec::new(),
@@ -521,6 +526,7 @@ async fn fetches_sibling_dependency_metadata_concurrently() {
     get_map.insert(
         ("app".to_string(), "1.0.0".to_string()),
         ResolvedPackage {
+            requires_python: None,
             name: "app".to_string(),
             version: "1.0.0".to_string(),
             dependencies: sibling_names
@@ -536,6 +542,7 @@ async fn fetches_sibling_dependency_metadata_concurrently() {
         all_map.insert(
             name.clone(),
             vec![ResolvedPackage {
+                requires_python: None,
                 name: name.clone(),
                 version: "1.0.0".to_string(),
                 dependencies: Vec::new(),
@@ -546,6 +553,7 @@ async fn fetches_sibling_dependency_metadata_concurrently() {
         get_map.insert(
             (name.clone(), "1.0.0".to_string()),
             ResolvedPackage {
+                requires_python: None,
                 name: name.clone(),
                 version: "1.0.0".to_string(),
                 dependencies: Vec::new(),
@@ -664,6 +672,7 @@ async fn allows_prerelease_versions_with_opt_in() {
         &index,
         ResolveOptions {
             allow_prerelease: true,
+            ..Default::default()
         },
     )
     .await
@@ -710,5 +719,153 @@ async fn falls_back_to_prerelease_when_only_prereleases_satisfy() {
             version: "0.9.0b1".to_string(),
         }],
         "fallback pre-release selection must be reported for W_PRERELEASE_SELECTED"
+    );
+}
+
+// --- Issue #342: requires-python metadata filters incompatible candidates ---
+
+#[tokio::test]
+async fn filters_versions_incompatible_with_target_python() {
+    let mut index = InMemoryIndex::default();
+    index.add_with_requires_python("lib", "1.13.1", Vec::<&str>::new(), Some(">=3.8"));
+    index.add_with_requires_python("lib", "2.0.0", Vec::<&str>::new(), Some(">=3.10"));
+
+    let resolution = resolve_with_options(
+        vec![Requirement::any("lib")],
+        &index,
+        ResolveOptions {
+            python_version: Some("3.9.18".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(
+        lib.version, "1.13.1",
+        "2.0.0 requires Python >=3.10 and must be skipped on 3.9"
+    );
+}
+
+#[tokio::test]
+async fn no_target_python_means_no_requires_python_filtering() {
+    let mut index = InMemoryIndex::default();
+    index.add_with_requires_python("lib", "1.13.1", Vec::<&str>::new(), Some(">=3.8"));
+    index.add_with_requires_python("lib", "2.0.0", Vec::<&str>::new(), Some(">=3.10"));
+
+    let resolution = resolve_with_options(
+        vec![Requirement::any("lib")],
+        &index,
+        ResolveOptions {
+            python_version: None,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(lib.version, "2.0.0");
+}
+
+#[tokio::test]
+async fn missing_requires_python_metadata_is_always_compatible() {
+    let mut index = InMemoryIndex::default();
+    index.add("lib", "2.5.0", Vec::<&str>::new());
+    index.add_with_requires_python("lib", "3.0.0", Vec::<&str>::new(), Some(">=3.10"));
+
+    let resolution = resolve_with_options(
+        vec![Requirement::any("lib")],
+        &index,
+        ResolveOptions {
+            python_version: Some("3.8.10".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(lib.version, "2.5.0");
+}
+
+#[tokio::test]
+async fn errors_when_no_version_supports_target_python() {
+    let mut index = InMemoryIndex::default();
+    index.add_with_requires_python("lib", "2.0.0", Vec::<&str>::new(), Some(">=3.10"));
+    index.add_with_requires_python("lib", "2.1.0", Vec::<&str>::new(), Some(">=3.11"));
+
+    let err = resolve_with_options(
+        vec![Requirement::any("lib")],
+        &index,
+        ResolveOptions {
+            python_version: Some("3.8.10".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err();
+    match err {
+        ResolveError::PythonIncompatible(details) => {
+            assert_eq!(details.name, "lib");
+            assert_eq!(details.python_version, "3.8.10");
+            assert_eq!(details.rejected_version, "2.1.0");
+            assert_eq!(details.rejected_requires_python, ">=3.11");
+            assert_eq!(details.newest_compatible, None);
+        }
+        other => panic!("expected PythonIncompatible, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn python_incompatible_error_names_newest_compatible_release() {
+    let mut index = InMemoryIndex::default();
+    index.add_with_requires_python("lib", "1.13.1", Vec::<&str>::new(), Some(">=3.8"));
+    index.add_with_requires_python("lib", "2.0.0", Vec::<&str>::new(), Some(">=3.10"));
+
+    let err = resolve_with_options(
+        vec![Requirement::minimum("lib", "2.0.0")],
+        &index,
+        ResolveOptions {
+            python_version: Some("3.8.10".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap_err();
+    match err {
+        ResolveError::PythonIncompatible(details) => {
+            assert_eq!(
+                details.newest_compatible,
+                Some("1.13.1".to_string()),
+                "hint should name the newest release usable on the target Python"
+            );
+        }
+        other => panic!("expected PythonIncompatible, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unparseable_requires_python_specs_are_lenient() {
+    let mut index = InMemoryIndex::default();
+    index.add_with_requires_python(
+        "lib",
+        "1.0.0",
+        Vec::<&str>::new(),
+        Some("!=3.0.*, >=2.7, not-a-spec"),
+    );
+
+    let resolution = resolve_with_options(
+        vec![Requirement::any("lib")],
+        &index,
+        ResolveOptions {
+            python_version: Some("3.9.18".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let lib = resolution.packages.get("lib").expect("lib resolved");
+    assert_eq!(
+        lib.version, "1.0.0",
+        "wildcard/unparseable parts must never reject a candidate"
     );
 }


### PR DESCRIPTION
Closes #342

## Summary

- Capture the per-release `requires_python` field from the PyPI JSON API (`ReleaseFile` → `CachedPackage` → `ResolvedPackage`) and from index JSON fixtures (`requires_python`, optional and backward-compatible; old binary caches that predate the field are already discarded gracefully by the existing unreadable-cache path).
- `select_with_constraints` now drops candidates whose `requires-python` specifier excludes the resolution target interpreter, so e.g. on Python 3.9 `pybun add scipy` resolves the newest 3.9-compatible release instead of a latest release that fails at build/import time.
- Target version selection: `PYBUN_PYPI_PYTHON_VERSION` override first, then the interpreter detected for the install target. Wired into `install` (detection hoisted before resolution and shared with the Issue #291 cp-tag probe — no extra interpreter spawn), `lock`, `upgrade`, `run` (PEP 723 native path, which already knows its venv's Python), and MCP `pybun_resolve`. `None` (no interpreter found) disables the filter.
- Leniency rule: wildcard (`!=3.0.*`) or unparseable clauses in the metadata are treated as satisfied — imperfect metadata can only widen the candidate set, never wrongly exclude a version.
- When every constraint-matching version is rejected by `requires-python`, resolution fails with a dedicated `ResolveError::PythonIncompatible` (boxed payload to keep the error type small), surfaced as:
  - `E_RESOLVE_PYTHON_INCOMPATIBLE` — names the package, constraint, target Python, and the offending `requires-python` spec
  - `H_RESOLVE_PYTHON_NEWEST_COMPATIBLE` — names the newest release (ignoring constraints) that does support the target Python

## Test plan

- [x] 6 integration tests in `tests/resolver_basic.rs` (filtering, no-target passthrough, missing-metadata compatibility, error payload, newest-compatible hint, leniency)
- [x] 2 unit tests for `requires_python_allows` + 2 index fixture tests
- [x] 2 CLI tests in `tests/cli_install.rs` (skip incompatible / keep newest when compatible)
- [x] 2 JSON diagnostics tests in `tests/json_output.rs` (E_RESOLVE_PYTHON_INCOMPATIBLE, hint)
- [x] 1 MCP test in `tests/mcp.rs` (pybun_resolve filters by PYBUN_PYPI_PYTHON_VERSION)
- [x] Full suite: 1079 passed, 6 ignored (52 suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)