### PR TITLE
ci(benchmark): run uv_comparison scenario in UX gate benchmark step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Build pybun (release)
         run: cargo build --release
 
-      - name: Run benchmarks (B3)
+      - name: Run benchmarks (B3, C-series)
         run: |
           cd scripts/benchmark
-          python bench.py -s run --config config_ci.toml --format json -o results-ci
+          python bench.py -s run,uv_comparison --config config_ci.toml --format json -o results-ci
 
       - name: UX gate
         run: |

--- a/scripts/benchmark/config_ci.toml
+++ b/scripts/benchmark/config_ci.toml
@@ -25,3 +25,11 @@ pep723_fixture = "fixtures/pep723.py"
 pep723_clear_envs = true
 pep723_clear_fs_cache = false
 
+[scenarios.uv_comparison]
+enabled = true
+iterations = 5
+warmup = 1
+trim_ratio = 0.1
+cv_threshold = 0.15
+adhoc_package = "ruff"
+


### PR DESCRIPTION
## Summary
- Fixes CI run [29632024321](https://github.com/VOID-TECHNOLOGY-INC/PyBun/actions/runs/29632024321), where the `ux gate` job failed with `missing_result` for `C4_startup [pybun]`, `C1_warm [pybun]`, and `C1_cold [pybun]` on both macOS and Ubuntu runners.
- Root cause: the CI benchmark step only ran the legacy `run` scenario. `ux_criteria.toml` requires C4_startup/C1_warm/C1_cold results, which are only produced by the `uv_comparison` scenario. Since that scenario was never enabled in `config_ci.toml` nor invoked in the workflow, the gate had nothing to evaluate for those checks and failed as `missing_result`.
- Fix: enable `uv_comparison` in `scripts/benchmark/config_ci.toml` and update `.github/workflows/benchmark.yml` to run `bench.py -s run,uv_comparison`.

## Known open risk (flagging transparently)
Local verification (5 iterations, 1 warmup, on this dev machine) showed the gate now produces real ratio results instead of `missing_result` — but `C1_warm [pybun]` measured at ~2.19x vs uv's warm run, exceeding the `ux_criteria.toml` threshold of 2.0x. C4_startup and C1_cold passed comfortably.

This local number may not be representative (low iteration count, non-CI hardware). Rather than speculatively adjusting the threshold or chasing a possible pybun warm-cache perf regression without a confirmed signal, this PR is intentionally pushed as-is to see whether CI's actual runners reproduce the C1_warm ratio failure. If CI now fails on `max_ratio_exceeded` for `C1_warm`, that's a distinct, real finding to investigate/decide on separately (not silently patched over here).

## Test plan
- [x] Confirmed original CI failure (run 29632024321) was 100% `missing_result`, no `max_ratio_exceeded`, via `gh run view --log`
- [x] Verified `bench.py -s run,uv_comparison --config config_ci.toml` produces C4_startup/C1_warm/C1_cold/C5_resolution/C3_adhoc results locally
- [ ] Confirm `ux gate` job passes (or reveals C1_warm ratio issue) on both macOS and Ubuntu CI runners