### PR TITLE
fix(profiles): remove dead PYBUN_LOG configuration (Issue #361)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,8 +333,6 @@ Diagnostics / dry-run testing:
 - `PYBUN_X_DRY_RUN`: Dry-run override used in tests
 - `PYBUN_X_DRY_RUN_EXIT_CODE`: Simulated exit code override used in tests
 
-Note: `PYBUN_LOG` is currently only *set* by `pybun profile` (to record the profile's configured log level); no code path reads it back to control logging output, so it does not yet do anything if set manually.
-
 ## Common Tasks
 
 ### Adding a New Command

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -381,8 +381,8 @@ Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; par
   - Risk: 運用/セキュリティ（bind addr, auth）を詰める必要があるので、後回しでもよい。
 - [DONE] PR4.4: Observability layer (structured logging defaults, `PYBUN_TRACE=1` tracing/trace-id propagation, redaction hooks).  
   - Depends on: PR4.1.  
-  - Current: Full observability via `src/schema.rs`. PYBUN_TRACE=1 enables UUID trace IDs. Event streaming with timestamps. Diagnostics array. Schema version tracking. PYBUN_LOG for log level control. Sensitive env vars not leaked in output.
-  - Tests: 9 observability E2E tests (trace_id presence/absence, event timestamps, duration_ms, schema version, diagnostics, env var redaction, log level, event types).
+  - Current: Full observability via `src/schema.rs`. PYBUN_TRACE=1 enables UUID trace IDs. Event streaming with timestamps. Diagnostics array. Schema version tracking. Sensitive env vars not leaked in output. Note: the `PYBUN_LOG`/profile `log_level` field was removed (Issue #361) — it was set but never read back to control logging, so it was dead/misleading configuration.
+  - Tests: 9 observability E2E tests (trace_id presence/absence, event timestamps, duration_ms, schema version, diagnostics, env var redaction, event types).
 
 ### M5: Builder & Security (Phase 3/4)
 - [DONE] PR5.0 (bootstrap): `pybun build` の “まず動く” 実装（`python -m build` の薄いラッパー + `--sbom` はスタブ出力）  

--- a/src/commands/tooling.rs
+++ b/src/commands/tooling.rs
@@ -637,14 +637,12 @@ pub(super) fn run_profile(
                 "base": {
                     "hot_reload": base_config.hot_reload,
                     "lazy_imports": base_config.lazy_imports,
-                    "log_level": base_config.log_level,
                     "tracing": base_config.tracing,
                     "optimization_level": base_config.optimization_level,
                 },
                 "compare": {
                     "hot_reload": other_config.hot_reload,
                     "lazy_imports": other_config.lazy_imports,
-                    "log_level": other_config.log_level,
                     "tracing": other_config.tracing,
                     "optimization_level": other_config.optimization_level,
                 },
@@ -693,8 +691,6 @@ pub(super) fn run_profile(
                     "hot_reload": config.hot_reload,
                     "lazy_imports": config.lazy_imports,
                     "module_cache": config.module_cache,
-                    "log_level": config.log_level,
-                    "log_level_str": config.log_level_str(),
                     "tracing": config.tracing,
                     "timing": config.timing,
                     "debug_checks": config.debug_checks,
@@ -722,7 +718,6 @@ pub(super) fn run_profile(
             "config": {
                 "hot_reload": config.hot_reload,
                 "lazy_imports": config.lazy_imports,
-                "log_level": config.log_level,
             },
         }),
     ))

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -4,8 +4,8 @@
 //! environments: dev, prod, and benchmark.
 //!
 //! ## Profiles
-//! - **dev**: Development mode with hot reload, lazy imports disabled, verbose logging
-//! - **prod**: Production mode with optimizations enabled, minimal logging
+//! - **dev**: Development mode with hot reload, lazy imports disabled
+//! - **prod**: Production mode with optimizations enabled
 //! - **benchmark**: Benchmarking mode with tracing enabled, timing output
 
 use serde::{Deserialize, Serialize};
@@ -16,10 +16,10 @@ use std::path::Path;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Profile {
-    /// Development profile - verbose, hot reload enabled.
+    /// Development profile - hot reload enabled.
     #[default]
     Dev,
-    /// Production profile - optimized, minimal logging.
+    /// Production profile - optimized.
     Prod,
     /// Benchmark profile - timing and tracing enabled.
     Benchmark,
@@ -62,8 +62,6 @@ pub struct ProfileConfig {
     pub lazy_imports: bool,
     /// Enable module finder cache.
     pub module_cache: bool,
-    /// Logging verbosity: 0 = quiet, 1 = normal, 2 = verbose, 3 = debug.
-    pub log_level: u8,
     /// Enable performance tracing.
     pub tracing: bool,
     /// Enable timing output for benchmarks.
@@ -84,7 +82,6 @@ impl ProfileConfig {
             hot_reload: true,
             lazy_imports: false,
             module_cache: true,
-            log_level: 2,
             tracing: false,
             timing: false,
             debug_checks: true,
@@ -100,7 +97,6 @@ impl ProfileConfig {
             hot_reload: false,
             lazy_imports: true,
             module_cache: true,
-            log_level: 1,
             tracing: false,
             timing: false,
             debug_checks: false,
@@ -116,7 +112,6 @@ impl ProfileConfig {
             hot_reload: false,
             lazy_imports: false,
             module_cache: false, // Disable cache for accurate benchmarking
-            log_level: 1,
             tracing: true,
             timing: true,
             debug_checks: false,
@@ -143,17 +138,6 @@ impl ProfileConfig {
         }
     }
 
-    /// Get log level as a string for PYBUN_LOG environment variable.
-    pub fn log_level_str(&self) -> &str {
-        match self.log_level {
-            0 => "error",
-            1 => "warn",
-            2 => "info",
-            3 => "debug",
-            _ => "trace",
-        }
-    }
-
     /// Check if this is a development profile.
     pub fn is_dev(&self) -> bool {
         self.profile == Profile::Dev
@@ -175,7 +159,6 @@ impl ProfileConfig {
         // SAFETY: Single-threaded CLI context
         unsafe {
             std::env::set_var("PYBUN_PROFILE", self.profile.to_string());
-            std::env::set_var("PYBUN_LOG", self.log_level_str());
 
             if self.tracing {
                 std::env::set_var("PYBUN_TRACE", "1");
@@ -191,7 +174,7 @@ impl ProfileConfig {
     /// Generate a summary of the profile settings.
     pub fn summary(&self) -> String {
         format!(
-            "Profile: {}\n  Hot reload: {}\n  Lazy imports: {}\n  Module cache: {}\n  Log level: {} ({})\n  Tracing: {}\n  Timing: {}\n  Debug checks: {}\n  Python optimization: -O{}",
+            "Profile: {}\n  Hot reload: {}\n  Lazy imports: {}\n  Module cache: {}\n  Tracing: {}\n  Timing: {}\n  Debug checks: {}\n  Python optimization: -O{}",
             self.profile,
             if self.hot_reload {
                 "enabled"
@@ -208,8 +191,6 @@ impl ProfileConfig {
             } else {
                 "disabled"
             },
-            self.log_level,
-            self.log_level_str(),
             if self.tracing { "enabled" } else { "disabled" },
             if self.timing { "enabled" } else { "disabled" },
             if self.debug_checks {
@@ -240,7 +221,6 @@ impl ProfileConfig {
         self.hot_reload = other.hot_reload;
         self.lazy_imports = other.lazy_imports;
         self.module_cache = other.module_cache;
-        self.log_level = other.log_level;
         self.tracing = other.tracing;
         self.timing = other.timing;
         self.debug_checks = other.debug_checks;
@@ -386,16 +366,16 @@ mod tests {
     }
 
     #[test]
-    fn test_log_level_str() {
-        let mut config = ProfileConfig::dev();
-        config.log_level = 0;
-        assert_eq!(config.log_level_str(), "error");
-        config.log_level = 1;
-        assert_eq!(config.log_level_str(), "warn");
-        config.log_level = 2;
-        assert_eq!(config.log_level_str(), "info");
-        config.log_level = 3;
-        assert_eq!(config.log_level_str(), "debug");
+    fn apply_to_env_does_not_set_pybun_log() {
+        // PYBUN_LOG was previously set here but never read back anywhere,
+        // making it dead/misleading configuration (Issue #361). Removed.
+        // SAFETY: test runs single-threaded within this process for this var.
+        unsafe {
+            std::env::remove_var("PYBUN_LOG");
+        }
+        let config = ProfileConfig::dev();
+        config.apply_to_env();
+        assert!(std::env::var("PYBUN_LOG").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #361

## Summary
- `pybun profile` set `PYBUN_LOG` (via `ProfileConfig::apply_to_env()`) based on the profile's `log_level`, but no code path anywhere read `PYBUN_LOG` back to control logging output/verbosity — this made the profile system's log-level modeling misleading/dead configuration.
- Removed the `log_level` field, `log_level_str()`, and the `set_var("PYBUN_LOG", ...)` call from `src/profiles.rs`, plus the now-unused `log_level`/`log_level_str` entries from `pybun profile`'s JSON output in `src/commands/tooling.rs`.
- Updated the stale doc note in `CLAUDE.md` and the observability summary in `docs/PLAN.md` to reflect the removal.

## Scope note
`ProfileConfig::apply_to_env()` itself turns out to have zero callers anywhere in the codebase (it only sets `PYBUN_PROFILE`/`PYBUN_TRACE`/custom env vars, none of which anything reads back either). That's a broader dead-code issue outside #361's stated scope (which was specifically about `PYBUN_LOG`), so it's left as-is here — flagging for a possible follow-up issue.

## Test plan
- [x] Added a regression unit test (`profiles::tests::apply_to_env_does_not_set_pybun_log`) verifying `apply_to_env()` no longer sets `PYBUN_LOG` (TDD: confirmed it failed against the old code, then passed after the fix)
- [x] `cargo test` — 1125 passed, 7 ignored, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt` — no diff