### PR TITLE
ci(coverage): add ratcheting threshold gate to coverage job (Issue #348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,12 @@ jobs:
         # (2026-07-24, see docs/PLAN.md Issue #348). The gate is set to baseline - 1 (83%),
         # rounded down, to absorb measurement noise while still catching regressions.
         #
+        # `--exclude-from-report` is not a valid flag on the `report` subcommand (it only
+        # applies at profile-generation time, in the "Generate coverage report" step above);
+        # `cargo llvm-cov report` here reads that same already-filtered profile data, so the
+        # 83% threshold is directly comparable to the 84.51% baseline without repeating the
+        # flag.
+        #
         # Ratchet-up policy: this is a floor, not the target (project policy is 80%+ line
         # coverage, and we're already above that). When coverage improves and stays improved
         # across a few PRs, bump --fail-under-lines upward (and update the baseline comment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,16 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Print coverage summary (report-only, no threshold gate yet)
-        continue-on-error: true
-        run: cargo llvm-cov report 2>&1 | tail -10
+      - name: Enforce coverage ratchet
+        # Baseline measured on main via `cargo llvm-cov report` (line coverage) was 84.51%
+        # (2026-07-24, see docs/PLAN.md Issue #348). The gate is set to baseline - 1 (83%),
+        # rounded down, to absorb measurement noise while still catching regressions.
+        #
+        # Ratchet-up policy: this is a floor, not the target (project policy is 80%+ line
+        # coverage, and we're already above that). When coverage improves and stays improved
+        # across a few PRs, bump --fail-under-lines upward (and update the baseline comment
+        # here plus docs/PLAN.md) manually — there is no automation for raising the ratchet.
+        run: cargo llvm-cov report --fail-under-lines 83
 
   winget-validate:
     name: winget validate

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -251,6 +251,10 @@
 - PR-A8: Runtime catalog hardening（実チェックサム管理 + 3.13 preview）
   - Goal: 埋め込み runtime metadata の完全性・更新性を強化し、3.13 preview を段階導入。
   - Tests: runtime metadata 検証テスト、3.13 install/list の互換テスト。
+- [DONE] PR-A20: coverage job のしきい値ゲート化（report-only → enforced ratchet）(Issue #348)
+  - Goal: #189 で追加した `cargo-llvm-cov` coverage job / Codecov upload / `just coverage` は測定のみで、`.github/workflows/ci.yml` の `Print coverage summary (report-only, no threshold gate yet)` ステップは何も強制していなかった（未完の受け入れ条件: baseline documented; threshold gate added）。このままだと coverage は静かに劣化しうる。
+  - Current: `main` 上で CI と同一コマンド（`cargo llvm-cov --workspace --lcov --output-path lcov.info --exclude-from-report "downloader_integration"` → `cargo llvm-cov report`）をローカル実行し、line coverage baseline = **84.51%**（2026-07-24 計測、TOTAL行 Lines: 24234 total / 3754 missed）を実測。`.github/workflows/ci.yml` の report-only ステップを `Enforce coverage ratchet` に置き換え、`cargo llvm-cov report --fail-under-lines 83`（baseline を切り捨てて -1 した ratchet。測定ノイズを吸収しつつ回帰を検知）を実行するよう変更。既存の `--exclude-from-report "downloader_integration"` 除外はそのまま維持（分母を honest に保つ）。ratchet を上げる運用ルール（coverage 改善時は `--fail-under-lines` の値とこのコメント・baseline を手動で引き上げる。自動化なし）は ci.yml 内のコメントとして明記。プロジェクトの公式ポリシー（80%+ line coverage）は既に達成しているが、ratchet はそれより保守的な「後退させない」ための floor として設定している。
+  - Tests: `cargo llvm-cov report --fail-under-lines 83` をローカルで baseline データに対して実行し exit code 0 を確認（gate が現状のカバレッジに対して green であることの検証）。`cargo clippy --all-targets --all-features -- -D warnings`、`cargo fmt -- --check`、`cargo test --lib`、`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`（YAML 構文検証）。
 
 ## Milestones & PR Tracks
 Milestones follow SPECS.md Phase roadmap. PR numbers are suggested grouping; parallelizable items marked (||).


### PR DESCRIPTION
Closes #348

## Summary

Follow-up to #189, which added the `cargo-llvm-cov` CI job, Codecov upload, and `just coverage`, but never completed the final acceptance item ("Baseline documented; threshold gate added (report-only → enforced)"). The `Print coverage summary` CI step measured coverage but never failed the build on regression.

- Measured line coverage on `main` locally using the exact command the CI coverage job runs (`cargo llvm-cov --workspace --lcov --output-path lcov.info --exclude-from-report "downloader_integration"` followed by `cargo llvm-cov report`).
- **Measured baseline: 84.51% line coverage** (TOTAL row, Lines column: 24234 total lines, 3754 missed).
- Replaced the report-only step in `.github/workflows/ci.yml` with `cargo llvm-cov report --fail-under-lines 83` (baseline floored to 84, minus 1 to absorb measurement noise), so the coverage job now fails CI if a PR drops line coverage below the ratchet.
- Kept the existing `--exclude-from-report "downloader_integration"` exclusion so the denominator stays honest — no exclusions were removed.
- Documented the baseline, how it was measured, and the manual ratchet-up policy (bump `--fail-under-lines` plus the ci.yml comment and docs/PLAN.md when coverage improves — no automation for raising the ratchet) both in a `ci.yml` comment and in `docs/PLAN.md` (new `[DONE] PR-A20` entry under "P2 (Post-GA Improvement)", following the file's existing DONE-entry style).

## Test plan

- [x] `cargo llvm-cov --workspace --lcov --output-path lcov.info --exclude-from-report "downloader_integration"` run locally on `main` to get a real, measured baseline (84.51% line coverage) — never fabricated.
- [x] `cargo llvm-cov report --fail-under-lines 83` run locally against that data — exits 0 (confirms the gate is green at the current baseline).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] `cargo test --lib` — 513 passed, 2 ignored.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML.
- [ ] CI `coverage` job on this PR itself exercises the new `--fail-under-lines 83` gate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)