### PR TITLE
refactor: consolidate copy-paste constructor clusters (Issue #345)

### DIFF
--- a/src/proc_exec.rs
+++ b/src/proc_exec.rs
@@ -99,10 +99,10 @@ pub fn join_pipe_reader(handle: Option<thread::JoinHandle<Vec<u8>>>) -> Option<V
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
-    fn successful_command() -> Command {
+    pub(crate) fn successful_command() -> Command {
         #[cfg(unix)]
         {
             let mut cmd = Command::new("sh");

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -82,76 +82,45 @@ pub struct Requirement {
 }
 
 impl Requirement {
-    pub fn exact(name: impl Into<String>, version: impl Into<String>) -> Self {
+    fn with_spec(name: impl Into<String>, spec: VersionSpec) -> Self {
         Self {
             name: name.into(),
-            specs: vec![VersionSpec::Exact(version.into())],
+            specs: vec![spec],
             marker: None,
             extras: Vec::new(),
         }
+    }
+
+    pub fn exact(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self::with_spec(name, VersionSpec::Exact(version.into()))
     }
 
     pub fn minimum(name: impl Into<String>, version: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::Minimum(version.into())],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::Minimum(version.into()))
     }
 
     pub fn minimum_exclusive(name: impl Into<String>, version: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::MinimumExclusive(version.into())],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::MinimumExclusive(version.into()))
     }
 
     pub fn maximum_inclusive(name: impl Into<String>, version: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::MaximumInclusive(version.into())],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::MaximumInclusive(version.into()))
     }
 
     pub fn maximum(name: impl Into<String>, version: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::Maximum(version.into())],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::Maximum(version.into()))
     }
 
     pub fn not_equal(name: impl Into<String>, version: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::NotEqual(version.into())],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::NotEqual(version.into()))
     }
 
     pub fn compatible(name: impl Into<String>, version: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::Compatible(version.into())],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::Compatible(version.into()))
     }
 
     pub fn any(name: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            specs: vec![VersionSpec::Any],
-            marker: None,
-            extras: Vec::new(),
-        }
+        Self::with_spec(name, VersionSpec::Any)
     }
 
     fn constraint_display(&self) -> String {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -823,21 +823,7 @@ except Exception as exc:  # pragma: no cover - defensive, should not happen
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn successful_command() -> Command {
-        #[cfg(unix)]
-        {
-            let mut cmd = Command::new("sh");
-            cmd.arg("-c").arg("exit 0");
-            cmd
-        }
-        #[cfg(windows)]
-        {
-            let mut cmd = Command::new("cmd");
-            cmd.arg("/C").arg("exit 0");
-            cmd
-        }
-    }
+    use crate::proc_exec::tests::successful_command;
 
     fn output_command(message: &str) -> Command {
         #[cfg(unix)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -138,9 +138,9 @@ pub struct Diagnostic {
 }
 
 impl Diagnostic {
-    pub fn error(message: impl Into<String>) -> Self {
+    fn with_severity(level: DiagnosticLevel, message: impl Into<String>) -> Self {
         Self {
-            level: DiagnosticLevel::Error,
+            level,
             code: None,
             message: message.into(),
             file: None,
@@ -152,54 +152,22 @@ impl Diagnostic {
             next_action: None,
             fix_candidates: None,
         }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::with_severity(DiagnosticLevel::Error, message)
     }
 
     pub fn warning(message: impl Into<String>) -> Self {
-        Self {
-            level: DiagnosticLevel::Warning,
-            code: None,
-            message: message.into(),
-            file: None,
-            line: None,
-            suggestion: None,
-            context: None,
-            exception_type: None,
-            location: None,
-            next_action: None,
-            fix_candidates: None,
-        }
+        Self::with_severity(DiagnosticLevel::Warning, message)
     }
 
     pub fn info(message: impl Into<String>) -> Self {
-        Self {
-            level: DiagnosticLevel::Info,
-            code: None,
-            message: message.into(),
-            file: None,
-            line: None,
-            suggestion: None,
-            context: None,
-            exception_type: None,
-            location: None,
-            next_action: None,
-            fix_candidates: None,
-        }
+        Self::with_severity(DiagnosticLevel::Info, message)
     }
 
     pub fn hint(message: impl Into<String>) -> Self {
-        Self {
-            level: DiagnosticLevel::Hint,
-            code: None,
-            message: message.into(),
-            file: None,
-            line: None,
-            suggestion: None,
-            context: None,
-            exception_type: None,
-            location: None,
-            next_action: None,
-            fix_candidates: None,
-        }
+        Self::with_severity(DiagnosticLevel::Hint, message)
     }
 
     pub fn with_code(mut self, code: impl Into<String>) -> Self {


### PR DESCRIPTION
Closes #345

## Summary
- `Diagnostic::error/warning/info/hint` now delegate to a private `with_severity(level, message)` helper instead of repeating the same struct-literal 4 times.
- `Requirement`'s 8 version-spec constructors (`exact`, `minimum`, `minimum_exclusive`, `maximum_inclusive`, `maximum`, `not_equal`, `compatible`, `any`) now delegate to a private `with_spec(name, spec)` helper.
- `sandbox.rs`'s test module now imports the canonical `successful_command()` helper from `proc_exec::tests` instead of keeping a byte-identical duplicate left over from the Issue #273 process-management extraction.
- No public API or JSON output changes — purely internal, behavior-preserving refactors.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — no diff
- [x] `cargo test` — all suites pass except `cli_run`, which fails identically on unmodified `main` due to a pre-existing local Python venv issue (`dyld: Library not loaded ... Python.framework`), unrelated to these changes (verified by stashing this diff and re-running `cargo test --test cli_run` against `main`'s code)