### PR TITLE
fix(mcp): gate unsafe_no_sandbox behind server opt-in + prevent script path traversal (Issue #377)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -411,6 +411,11 @@ pub struct McpServeArgs {
     /// Use stdio mode for MCP communication.
     #[arg(long)]
     pub stdio: bool,
+    /// Allow clients to set `unsafe_no_sandbox: true` on `pybun_run` calls.
+    /// Disabled by default; client-supplied JSON-RPC arguments alone can
+    /// never disable the sandbox (Issue #377).
+    #[arg(long)]
+    pub allow_unsafe_no_sandbox: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -643,6 +643,13 @@ pub async fn execute(cli: Cli) -> Result<()> {
         }
         Commands::Mcp(cmd) => match cmd {
             McpCommands::Serve(args) => {
+                if args.allow_unsafe_no_sandbox {
+                    // SAFETY: single-threaded at startup, before any concurrent
+                    // access to the environment begins.
+                    unsafe {
+                        std::env::set_var("PYBUN_MCP_ALLOW_UNSAFE_NO_SANDBOX", "1");
+                    }
+                }
                 if args.stdio {
                     // Run MCP server in stdio mode - this blocks until shutdown
                     if let Err(e) = crate::mcp::run_stdio_server().await {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -238,6 +238,7 @@ mod tests {
             command: Commands::Mcp(McpCommands::Serve(McpServeArgs {
                 port: 9999,
                 stdio: true,
+                allow_unsafe_no_sandbox: false,
             })),
         };
         assert!(requires_tokio_runtime(&cli));

--- a/src/mcp/audit.rs
+++ b/src/mcp/audit.rs
@@ -756,6 +756,15 @@ pub(super) fn sandbox_policy_json(config: &crate::sandbox::SandboxConfig) -> Val
     })
 }
 
+/// Server-side gate for `unsafe_no_sandbox`. Client-supplied JSON-RPC arguments
+/// alone must never disable the sandbox; the operator must also opt in via
+/// `pybun mcp serve --allow-unsafe-no-sandbox` (which sets this env var).
+pub(super) fn mcp_allow_unsafe_no_sandbox() -> bool {
+    std::env::var("PYBUN_MCP_ALLOW_UNSAFE_NO_SANDBOX")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
 pub(super) fn unsafe_no_sandbox_warning(enabled: bool) -> Vec<Value> {
     if enabled {
         vec![json!({
@@ -767,6 +776,15 @@ pub(super) fn unsafe_no_sandbox_warning(enabled: bool) -> Vec<Value> {
     } else {
         vec![]
     }
+}
+
+pub(super) fn unsafe_no_sandbox_denied_warning() -> Vec<Value> {
+    vec![json!({
+        "level": "warning",
+        "code": "W_MCP_UNSAFE_NO_SANDBOX_DENIED",
+        "message": "unsafe_no_sandbox=true was requested but denied because the MCP server was not started with --allow-unsafe-no-sandbox",
+        "suggestion": "Restart `pybun mcp serve` with --allow-unsafe-no-sandbox if you intend to allow sandbox opt-out."
+    })]
 }
 
 pub(super) fn describe_run_target(script: Option<&str>, code: Option<&str>) -> String {

--- a/src/mcp/schema.rs
+++ b/src/mcp/schema.rs
@@ -87,7 +87,7 @@ pub(super) fn build_tools_list() -> Vec<Tool> {
                     },
                     "unsafe_no_sandbox": {
                         "type": "boolean",
-                        "description": "Disable the default MCP sandbox. Use only in controlled environments."
+                        "description": "Request disabling the default MCP sandbox. Only takes effect if the server was started with `pybun mcp serve --allow-unsafe-no-sandbox`; otherwise this request is denied and the sandbox remains enabled."
                     },
                     "sandbox_policy": {
                         "type": "object",

--- a/src/mcp/tools/run.rs
+++ b/src/mcp/tools/run.rs
@@ -52,21 +52,32 @@ pub(crate) async fn call_run(args: Value) -> Result<String, String> {
     if script.is_none() && code.is_none() {
         return Err("Either 'script' or 'code' must be provided".to_string());
     }
-    if let Some(script_path) = script {
-        let path = PathBuf::from(script_path);
-        if !path.exists() {
-            return Err(format!("Script not found: {}", script_path));
+    // Resolve `script` to its canonicalized form up front and use that
+    // resolved path everywhere downstream (including the actual execution
+    // target), rather than re-deriving it from the untrusted raw string.
+    // Re-resolving later would reopen a TOCTOU window between this
+    // containment check and execution (e.g. a symlink swapped in after the
+    // check but before the run).
+    let canonical_script = match script {
+        Some(script_path) => {
+            let path = PathBuf::from(script_path);
+            if !path.exists() {
+                return Err(format!("Script not found: {}", script_path));
+            }
+            let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+            let canonical_cwd = cwd.canonicalize().map_err(|e| e.to_string())?;
+            let canonical_path = path.canonicalize().map_err(|e| e.to_string())?;
+            if canonical_path.strip_prefix(&canonical_cwd).is_err() {
+                return Err(format!(
+                    "Script path resolves outside the current project directory: {}",
+                    script_path
+                ));
+            }
+            Some(canonical_path.to_string_lossy().to_string())
         }
-        let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-        let canonical_cwd = cwd.canonicalize().map_err(|e| e.to_string())?;
-        let canonical_path = path.canonicalize().map_err(|e| e.to_string())?;
-        if canonical_path.strip_prefix(&canonical_cwd).is_err() {
-            return Err(format!(
-                "Script path resolves outside the current project directory: {}",
-                script_path
-            ));
-        }
-    }
+        None => None,
+    };
+    let script = canonical_script.as_deref();
     if dry_run {
         let (risk_level, risk_reasons) = estimate_run_risk(script, code, use_sandbox);
         return Ok(json!({

--- a/src/mcp/tools/run.rs
+++ b/src/mcp/tools/run.rs
@@ -3,7 +3,8 @@
 //! Extracted from `mcp.rs` (Issue #344).
 
 use super::super::audit::{
-    describe_run_target, estimate_run_risk, mcp_sandbox_config_from_policy, sandbox_policy_json,
+    describe_run_target, estimate_run_risk, mcp_allow_unsafe_no_sandbox,
+    mcp_sandbox_config_from_policy, sandbox_policy_json, unsafe_no_sandbox_denied_warning,
     unsafe_no_sandbox_warning,
 };
 use serde_json::{Value, json};
@@ -25,17 +26,24 @@ pub(crate) async fn call_run(args: Value) -> Result<String, String> {
         })
         .unwrap_or_default();
 
-    let unsafe_no_sandbox = args
+    let unsafe_no_sandbox_requested = args
         .get("unsafe_no_sandbox")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    // Client-supplied JSON-RPC arguments alone must never disable the sandbox;
+    // the server operator must also opt in via `--allow-unsafe-no-sandbox`.
+    let unsafe_no_sandbox = unsafe_no_sandbox_requested && mcp_allow_unsafe_no_sandbox();
     let use_sandbox = !unsafe_no_sandbox;
     let policy = args
         .get("sandbox_policy")
         .cloned()
         .unwrap_or_else(|| json!({}));
     let effective_sandbox_config = mcp_sandbox_config_from_policy(&policy);
-    let warnings = unsafe_no_sandbox_warning(unsafe_no_sandbox);
+    let warnings = if unsafe_no_sandbox_requested && !unsafe_no_sandbox {
+        unsafe_no_sandbox_denied_warning()
+    } else {
+        unsafe_no_sandbox_warning(unsafe_no_sandbox)
+    };
 
     let dry_run = args
         .get("dry_run")
@@ -44,10 +52,20 @@ pub(crate) async fn call_run(args: Value) -> Result<String, String> {
     if script.is_none() && code.is_none() {
         return Err("Either 'script' or 'code' must be provided".to_string());
     }
-    if let Some(script_path) = script
-        && !PathBuf::from(script_path).exists()
-    {
-        return Err(format!("Script not found: {}", script_path));
+    if let Some(script_path) = script {
+        let path = PathBuf::from(script_path);
+        if !path.exists() {
+            return Err(format!("Script not found: {}", script_path));
+        }
+        let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+        let canonical_cwd = cwd.canonicalize().map_err(|e| e.to_string())?;
+        let canonical_path = path.canonicalize().map_err(|e| e.to_string())?;
+        if canonical_path.strip_prefix(&canonical_cwd).is_err() {
+            return Err(format!(
+                "Script path resolves outside the current project directory: {}",
+                script_path
+            ));
+        }
     }
     if dry_run {
         let (risk_level, risk_reasons) = estimate_run_risk(script, code, use_sandbox);

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -979,8 +979,13 @@ fn mcp_pybun_run_defaults_to_sandbox_without_policy() {
 
 #[test]
 fn mcp_pybun_run_unsafe_no_sandbox_allows_explicit_opt_out_with_warning() {
+    let temp = tempdir().unwrap();
     let call_req = r#"{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"pybun_run","arguments":{"code":"import subprocess, sys\nsubprocess.run([sys.executable, '-c', \"print('optout-child')\"])", "unsafe_no_sandbox": true}}}"#;
-    let stdout = mcp_call(&[call_req]);
+    let stdout = mcp_call_in(
+        &[call_req],
+        temp.path(),
+        &[("PYBUN_MCP_ALLOW_UNSAFE_NO_SANDBOX", OsString::from("1"))],
+    );
     let result = tool_result_json(&stdout, 2);
 
     assert_eq!(result["sandboxed"].as_bool(), Some(false), "{result}");
@@ -994,6 +999,50 @@ fn mcp_pybun_run_unsafe_no_sandbox_allows_explicit_opt_out_with_warning() {
         result["warnings"][0]["code"].as_str(),
         Some("W_MCP_UNSAFE_NO_SANDBOX"),
         "{result}"
+    );
+}
+
+#[test]
+fn mcp_pybun_run_unsafe_no_sandbox_denied_without_server_gate() {
+    // Without PYBUN_MCP_ALLOW_UNSAFE_NO_SANDBOX set, a client-requested
+    // unsafe_no_sandbox=true must be denied and the sandbox must stay enabled
+    // (Issue #377: unauthenticated sandbox disable).
+    let call_req = r#"{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"pybun_run","arguments":{"code":"print('should-be-sandboxed')", "unsafe_no_sandbox": true}}}"#;
+    let stdout = mcp_call(&[call_req]);
+    let result = tool_result_json(&stdout, 2);
+
+    assert_eq!(result["sandboxed"].as_bool(), Some(true), "{result}");
+    assert_eq!(
+        result["warnings"][0]["code"].as_str(),
+        Some("W_MCP_UNSAFE_NO_SANDBOX_DENIED"),
+        "{result}"
+    );
+}
+
+#[test]
+fn mcp_pybun_run_script_path_traversal_rejected() {
+    // A script path that resolves outside the current working directory must
+    // be rejected (Issue #377: path traversal via `script`).
+    let project = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let outside_script = outside.path().join("outside.py");
+    fs::write(&outside_script, "print('should-not-run')").unwrap();
+
+    let script_json = serde_json::to_string(outside_script.to_str().unwrap()).unwrap();
+    let call_req = format!(
+        r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_run","arguments":{{"script":{script_json}}}}}}}"#
+    );
+    let stdout = mcp_call_in(&[&call_req], project.path(), &[]);
+
+    let responses = json_rpc_lines(&stdout);
+    let response = responses
+        .iter()
+        .find(|value| value["id"].as_i64() == Some(2))
+        .unwrap_or_else(|| panic!("tools/call response with id 2 should be present: {stdout}"));
+    assert_eq!(
+        response["result"]["isError"].as_bool(),
+        Some(true),
+        "expected an error response for path traversal, got: {response}"
     );
 }
 

--- a/tests/snapshots/compat/help_mcp_serve.txt
+++ b/tests/snapshots/compat/help_mcp_serve.txt
@@ -3,9 +3,10 @@ Start MCP server for programmatic control
 Usage: pybun mcp serve [OPTIONS]
 
 Options:
-      --format <FORMAT>      Output format for machine readability [default: text] [possible values: text, json]
-      --port <PORT>          Port to bind (for HTTP mode) [default: 9999]
-      --progress <PROGRESS>  Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
-      --stdio                Use stdio mode for MCP communication
-      --no-progress          Disable progress UI
-  -h, --help                 Print help
+      --format <FORMAT>          Output format for machine readability [default: text] [possible values: text, json]
+      --port <PORT>              Port to bind (for HTTP mode) [default: 9999]
+      --progress <PROGRESS>      Progress UI mode (auto hides on non-TTY) [env: PYBUN_PROGRESS=] [default: auto] [possible values: auto, always, never]
+      --stdio                    Use stdio mode for MCP communication
+      --allow-unsafe-no-sandbox  Allow clients to set `unsafe_no_sandbox: true` on `pybun_run` calls. Disabled by default; client-supplied JSON-RPC arguments alone can never disable the sandbox (Issue #377)
+      --no-progress              Disable progress UI
+  -h, --help                     Print help


### PR DESCRIPTION
Closes #377

## Summary
- `pybun_run`'s `unsafe_no_sandbox: true` argument previously disabled the MCP sandbox unconditionally whenever a client requested it — any MCP client could remotely bypass the sandbox with no server-side authorization.
- `unsafe_no_sandbox` is now only honored if the server operator explicitly started `pybun mcp serve` with a new `--allow-unsafe-no-sandbox` flag (wired through `PYBUN_MCP_ALLOW_UNSAFE_NO_SANDBOX`). If the client requests it but the server wasn't opted in, the request is denied, the sandbox stays enabled, and a new `W_MCP_UNSAFE_NO_SANDBOX_DENIED` warning is returned.
- The `script` argument to `pybun_run` is now canonicalized and checked for containment within the current working directory, rejecting path traversal attempts (e.g. absolute/relative paths resolving outside the project root).
- Updated the `pybun_run` tool schema description for `unsafe_no_sandbox` to document the new gating requirement.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] New test: `mcp_pybun_run_unsafe_no_sandbox_denied_without_server_gate` — asserts default-deny behavior
- [x] Updated test: `mcp_pybun_run_unsafe_no_sandbox_allows_explicit_opt_out_with_warning` — now passes the gating env var explicitly
- [x] New test: `mcp_pybun_run_script_path_traversal_rejected` — asserts a script path outside the project directory is rejected
- [x] `cargo test --test mcp` (18 mcp tests pass; 4 unrelated pre-existing failures reproduce identically on `main` due to a broken local Python 3.14 install, confirmed via `git stash`)