### PR TITLE
fix(sandbox): close filesystem/network isolation escape vectors (Issue #376)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,7 +207,7 @@ pub struct PackageArgs {
     pub pre: bool,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct RunArgs {
     /// Script or module to execute. Use -c/--code for inline code.
     #[arg(value_name = "TARGET", allow_hyphen_values = true)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -379,7 +379,22 @@ pub async fn execute(cli: Cli) -> Result<()> {
         }
         Commands::Run(args) => {
             collector.event(EventType::ScriptStart);
-            let result = run_script(args, &mut collector, cli.format).await;
+            // PYBUN_SANDBOX_ALLOW_NETWORK is a documented CLI convenience
+            // (equivalent to --allow-network) resolved *only* here, at the
+            // real CLI entry point. `run_script`/`run_python_code` are shared
+            // with the MCP `pybun_run` tool, which builds `RunArgs` directly
+            // from a client-supplied sandbox policy rather than through this
+            // dispatcher; resolving the env var inside those shared functions
+            // would let an ambient env var on the parent pybun process
+            // silently override an MCP client's explicit `allow_network:
+            // false` (Issue #376).
+            let mut args = args.clone();
+            if !args.allow_network {
+                args.allow_network = std::env::var("PYBUN_SANDBOX_ALLOW_NETWORK")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+            }
+            let result = run_script(&args, &mut collector, cli.format).await;
             match result {
                 Ok(RunOutcome {
                     summary,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -895,10 +895,15 @@ pub(crate) async fn run_script(
         if is_uv_runner {
             return Err(eyre!("--sandbox is not supported with uv run backend"));
         }
-        let allow_network = args.allow_network
-            || std::env::var("PYBUN_SANDBOX_ALLOW_NETWORK")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+        // `args.allow_network` is already fully resolved by the caller: the
+        // CLI dispatcher (`commands::execute`) folds in the
+        // PYBUN_SANDBOX_ALLOW_NETWORK env var before calling in, and the MCP
+        // `pybun_run` tool resolves it from the client's sandbox policy. Do
+        // not re-consult the ambient env var here, since this function is
+        // shared by both entry points and MCP callers must not have an
+        // explicit `allow_network: false` silently overridden by the parent
+        // process's environment (Issue #376).
+        let allow_network = args.allow_network;
         collector.info(format!("sandbox enabled (allow_network={})", allow_network));
         let guard = sandbox::apply_python_sandbox(
             &mut cmd,
@@ -1171,10 +1176,15 @@ fn run_python_code(
     let mut sandbox_info: Option<SandboxInfo> = None;
     let mut sandbox_guard: Option<sandbox::SandboxGuard> = None;
     if args.sandbox {
-        let allow_network = args.allow_network
-            || std::env::var("PYBUN_SANDBOX_ALLOW_NETWORK")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+        // `args.allow_network` is already fully resolved by the caller: the
+        // CLI dispatcher (`commands::execute`) folds in the
+        // PYBUN_SANDBOX_ALLOW_NETWORK env var before calling in, and the MCP
+        // `pybun_run` tool resolves it from the client's sandbox policy. Do
+        // not re-consult the ambient env var here, since this function is
+        // shared by both entry points and MCP callers must not have an
+        // explicit `allow_network: false` silently overridden by the parent
+        // process's environment (Issue #376).
+        let allow_network = args.allow_network;
         collector.info(format!(
             "sandbox enabled for inline code (allow_network={})",
             allow_network

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -265,13 +265,16 @@ pub fn apply_python_sandbox(cmd: &mut Command, config: SandboxConfig) -> Result<
         .map_err(|e| eyre!("failed to join PYTHONPATH entries for sandbox: {e}"))?;
     cmd.env("PYTHONPATH", joined);
 
-    // Note: std::env::var reads from the *parent process* environment, not from `cmd`.
-    // env_clear() above only strips the *child's* inherited env, so reading
-    // PYBUN_SANDBOX_ALLOW_NETWORK here correctly reflects the caller's intent.
-    let allow_network = config.allow_network
-        || std::env::var("PYBUN_SANDBOX_ALLOW_NETWORK")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+    // Network access is decided solely by `config.allow_network`. Do not also
+    // consult the parent process's `PYBUN_SANDBOX_ALLOW_NETWORK` here: this
+    // function is the single security-relevant chokepoint shared by both the
+    // CLI and MCP entry points, and an ambient env var on the *parent* pybun
+    // process (inherited from a shell, CI runner, or wrapper script) must
+    // never be able to silently flip an explicit `allow_network: false` to
+    // true. Callers that want the env var to act as a CLI convenience flag
+    // (see `commands/mod.rs`'s CLI dispatcher) resolve it themselves before
+    // building the config, where the decision is explicit and auditable.
+    let allow_network = config.allow_network;
 
     cmd.env("PYBUN_SANDBOX", "1");
     if allow_network {
@@ -538,6 +541,7 @@ pub fn execute_with_optional_sandbox(
 /// static string with no Rust format-macro escaping issues.
 const SITECUSTOMIZE_PY: &str = r#"
 import os
+import io
 import sys
 import json
 import atexit
@@ -546,6 +550,7 @@ import subprocess
 import builtins
 
 _orig_open = builtins.open  # save before any patching
+_orig_os_open = os.open  # save before any patching
 
 ALLOW_NETWORK = os.environ.get("PYBUN_SANDBOX_ALLOW_NETWORK") == "1"
 _AUDIT_FILE = os.environ.get("PYBUN_SANDBOX_AUDIT_FILE", "")
@@ -563,6 +568,16 @@ def _load_policy_paths(name):
 
 
 def _normalize_path(path):
+    # KNOWN RESIDUAL RISK (TOCTOU): realpath() resolves symlinks at the time
+    # of this check, but the actual open()/os.open() call happens afterward.
+    # A symlink swapped in between the check and the syscall (e.g. by a
+    # concurrent process) could redirect an allowed path to a denied one.
+    # Closing this fully would require O_NOFOLLOW plus resolving-then-
+    # opening by file descriptor throughout the stdlib, which is impractical
+    # to retrofit onto every os.* call the sandbox patches. Accepted as a
+    # low-probability gap for now: sandboxed code cannot itself create
+    # symlinks outside its write allowlist (symlink() is checked above), so
+    # exploiting this requires an external actor racing the filesystem.
     return os.path.realpath(os.path.abspath(path))
 
 
@@ -608,13 +623,34 @@ def _deny(reason, audit_key=None):
     raise PermissionError("pybun sandbox: " + reason + " blocked")
 
 
-def _is_allowed(path, allowed_paths):
-    """Return True if path is under any of the allowed directories or sys prefixes."""
+def _is_read_allowed(path):
+    """Return True if path is readable: under the read allowlist or a sys prefix.
+
+    Sys prefixes (the interpreter's own install dirs) are always readable so
+    that Python's own imports keep working even under a restrictive read
+    policy.
+    """
     try:
         normalized_path = _normalize_path(os.fsdecode(os.fspath(path)))
         if any(_path_within(normalized_path, p) for p in _ALWAYS_ALLOW_READ):
             return True
-        return any(_path_within(normalized_path, p) for p in allowed_paths)
+        return any(_path_within(normalized_path, p) for p in _ALLOW_READ)
+    except Exception:
+        return False
+
+
+def _is_write_allowed(path):
+    """Return True if path is under the write allowlist.
+
+    Deliberately does NOT consult _ALWAYS_ALLOW_READ: sys prefixes must stay
+    readable for imports but are not implicitly writable just because an
+    explicit write allowlist was configured. Treating them as always-writable
+    let sandboxed code overwrite interpreter/stdlib files whenever a write
+    policy was set (the policy was meant to restrict writes, not widen them).
+    """
+    try:
+        normalized_path = _normalize_path(os.fsdecode(os.fspath(path)))
+        return any(_path_within(normalized_path, p) for p in _ALLOW_WRITE)
     except Exception:
         return False
 
@@ -716,6 +752,17 @@ def _block_network():
     if hasattr(socket, "socketpair"):
         socket.socketpair = _blocked
 
+    # connect/connect_ex only cover connection-oriented (TCP) sockets. A
+    # connectionless UDP socket can send and receive datagrams to arbitrary
+    # remote addresses via sendto/sendmsg/recvfrom/recvmsg without ever
+    # calling connect, which previously bypassed the network block entirely.
+    for _name in ("sendto", "sendmsg"):
+        if hasattr(socket.socket, _name):
+            setattr(socket.socket, _name, _blocked_connect)
+    for _name in ("recvfrom", "recvmsg"):
+        if hasattr(socket.socket, _name):
+            setattr(socket.socket, _name, _blocked_connect)
+
 
 def _patch_filesystem():
     def _check_write_path(path, action):
@@ -727,7 +774,7 @@ def _patch_filesystem():
         if _AUDIT_FILE_PATH and _normalize_path(decoded) == _AUDIT_FILE_PATH:
             _deny(action + " sandbox audit file", "blocked_file_writes")
         if _HAS_WRITE_POLICY:
-            if not _is_allowed(decoded, _ALLOW_WRITE):
+            if not _is_write_allowed(decoded):
                 _deny(action + " " + decoded, "blocked_file_writes")
         elif _HAS_DEFAULT_DENY_WRITE:
             if _is_in_denied(decoded, _DEFAULT_DENY_WRITE):
@@ -741,13 +788,37 @@ def _patch_filesystem():
         if not path:
             return _orig_open(file, mode, *args, **kwargs)
         if _HAS_READ_POLICY and _mode_needs_read(mode):
-            if not _is_allowed(path, _ALLOW_READ):
+            if not _is_read_allowed(path):
                 _deny("read from " + path, "blocked_file_reads")
         if _mode_needs_write(mode):
             _check_write_path(path, "write to")
         return _orig_open(file, mode, *args, **kwargs)
 
     builtins.open = _checked_open
+    # io.open is the same underlying function as builtins.open in CPython,
+    # but code that does `from io import open` or `io.open(...)` binds it
+    # directly and previously kept a reference to the unpatched original,
+    # bypassing every check above.
+    io.open = _checked_open
+
+    def _checked_os_open(path, flags, *args, **kwargs):
+        accmode = flags & os.O_ACCMODE
+        wants_read = accmode in (os.O_RDONLY, os.O_RDWR)
+        wants_write = (
+            accmode in (os.O_WRONLY, os.O_RDWR)
+            or bool(flags & (os.O_CREAT | os.O_TRUNC | os.O_APPEND))
+        )
+        if not isinstance(path, (str, bytes, os.PathLike)):
+            return _orig_os_open(path, flags, *args, **kwargs)
+        decoded = os.fsdecode(os.fspath(path))
+        if decoded:
+            if _HAS_READ_POLICY and wants_read and not _is_read_allowed(decoded):
+                _deny("read from " + decoded, "blocked_file_reads")
+            if wants_write:
+                _check_write_path(decoded, "write to")
+        return _orig_os_open(path, flags, *args, **kwargs)
+
+    os.open = _checked_os_open
 
     def _wrap_single_path_mutation(fn, action):
         def _wrapped(path, *args, **kwargs):

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -1152,6 +1152,132 @@ fn mcp_pybun_run_sandbox_policy_preserves_allow_network() {
     );
 }
 
+#[test]
+fn mcp_pybun_run_ambient_allow_network_env_does_not_override_explicit_false() {
+    // Issue #376: PYBUN_SANDBOX_ALLOW_NETWORK set in the *parent* pybun
+    // process environment (e.g. inherited from a shell or CI runner) must
+    // not silently override an explicit `allow_network: false` sandbox
+    // policy sent by the MCP client.
+    let call_req = r#"{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"pybun_run","arguments":{"code":"import os\nprint(os.environ.get('PYBUN_SANDBOX_ALLOW_NETWORK', 'missing'))","sandbox_policy":{"allow_network":false}}}}"#;
+    let project = tempdir().unwrap();
+    let stdout = mcp_call_in(
+        &[call_req],
+        project.path(),
+        &[("PYBUN_SANDBOX_ALLOW_NETWORK", OsString::from("1"))],
+    );
+    let result = tool_result_json(&stdout, 2);
+
+    assert_eq!(result["sandboxed"].as_bool(), Some(true), "{result}");
+    assert!(
+        result["stdout"]
+            .as_str()
+            .is_some_and(|stdout| stdout.trim() == "missing"),
+        "ambient PYBUN_SANDBOX_ALLOW_NETWORK=1 on the parent process must not leak into a \
+         sandbox whose policy explicitly disabled network access: {result}"
+    );
+}
+
+#[test]
+fn mcp_pybun_run_blocks_io_open_bypass() {
+    // Issue #376: `io.open` previously kept an unpatched reference even
+    // after `builtins.open` was patched, letting sandboxed code bypass the
+    // read allowlist via `import io; io.open(...)`.
+    let secret = tempdir().unwrap();
+    let secret_path = secret.path().join("secret.txt");
+    fs::write(&secret_path, "top secret").unwrap();
+    let readable = tempdir().unwrap();
+
+    let secret_json = serde_json::to_string(secret_path.to_str().unwrap()).unwrap();
+    let allow_read_json = serde_json::to_string(readable.path().to_str().unwrap()).unwrap();
+    let code = format!(
+        "import io\ntry:\n    io.open({secret_json}).read()\n    print('bypassed')\nexcept PermissionError:\n    print('blocked')"
+    );
+    let code_json = serde_json::to_string(&code).unwrap();
+    let call_req = format!(
+        r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_run","arguments":{{"code":{code_json},"sandbox_policy":{{"allow_read":[{allow_read_json}]}}}}}}}}"#
+    );
+    let stdout = mcp_call(&[&call_req]);
+    let result = tool_result_json(&stdout, 2);
+
+    assert!(
+        result["stdout"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("blocked")),
+        "io.open must be subject to the same read policy as builtins.open: {result}"
+    );
+}
+
+#[test]
+fn mcp_pybun_run_blocks_os_open_bypass() {
+    // Issue #376: `os.open` was left unpatched, letting sandboxed code
+    // bypass both the read and write allowlists via the raw os-level API.
+    let secret = tempdir().unwrap();
+    let secret_path = secret.path().join("secret.txt");
+    fs::write(&secret_path, "top secret").unwrap();
+    let readable = tempdir().unwrap();
+
+    let secret_json = serde_json::to_string(secret_path.to_str().unwrap()).unwrap();
+    let allow_read_json = serde_json::to_string(readable.path().to_str().unwrap()).unwrap();
+    let code = format!(
+        "import os\ntry:\n    os.close(os.open({secret_json}, os.O_RDONLY))\n    print('bypassed')\nexcept PermissionError:\n    print('blocked')"
+    );
+    let code_json = serde_json::to_string(&code).unwrap();
+    let call_req = format!(
+        r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_run","arguments":{{"code":{code_json},"sandbox_policy":{{"allow_read":[{allow_read_json}]}}}}}}}}"#
+    );
+    let stdout = mcp_call(&[&call_req]);
+    let result = tool_result_json(&stdout, 2);
+
+    assert!(
+        result["stdout"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("blocked")),
+        "os.open must be subject to the same read policy as builtins.open: {result}"
+    );
+}
+
+#[test]
+fn mcp_pybun_run_blocks_udp_sendto_when_network_disabled() {
+    // Issue #376: only connect/connect_ex were patched, so a connectionless
+    // UDP socket could send/receive datagrams via sendto/recvfrom without
+    // ever calling connect, bypassing the network block entirely.
+    let call_req = r#"{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"pybun_run","arguments":{"code":"import socket\ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\ntry:\n    s.sendto(b'x', ('8.8.8.8', 53))\n    print('bypassed')\nexcept PermissionError:\n    print('blocked')","sandbox_policy":{"allow_network":false}}}}"#;
+    let stdout = mcp_call(&[call_req]);
+    let result = tool_result_json(&stdout, 2);
+
+    assert!(
+        result["stdout"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("blocked")),
+        "UDP sendto must be blocked alongside TCP connect when network access is disabled: {result}"
+    );
+}
+
+#[test]
+fn mcp_pybun_run_write_policy_denies_sys_prefix_despite_always_allow_read() {
+    // Issue #376: `_is_allowed` was shared between read and write checks, so
+    // sys-prefix directories (always readable, for imports) were also always
+    // writable once an explicit write allowlist was configured -- letting
+    // sandboxed code overwrite interpreter/stdlib files under an explicit
+    // write policy meant to restrict writes to a single directory.
+    let writable = tempdir().unwrap();
+    let allow_write_json = serde_json::to_string(writable.path().to_str().unwrap()).unwrap();
+    let code = "import sys\ntry:\n    open(sys.executable, 'wb').write(b'tampered')\n    print('bypassed')\nexcept PermissionError:\n    print('blocked')";
+    let code_json = serde_json::to_string(code).unwrap();
+    let call_req = format!(
+        r#"{{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{{"name":"pybun_run","arguments":{{"code":{code_json},"sandbox_policy":{{"allow_write":[{allow_write_json}]}}}}}}}}"#
+    );
+    let stdout = mcp_call(&[&call_req]);
+    let result = tool_result_json(&stdout, 2);
+
+    assert!(
+        result["stdout"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("blocked")),
+        "an explicit write allowlist must not implicitly grant write access to sys prefixes: {result}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn mcp_pybun_run_default_sandbox_reports_process_and_file_size_limits() {


### PR DESCRIPTION
## Summary
- Route `io.open`/`os.open` through the same read/write policy checks as `builtins.open`, closing a bypass of the sandbox file-access controls.
- Block UDP `sendto`/`sendmsg`/`recvfrom`/`recvmsg` when network access is disabled — only `connect`/`connect_ex` were previously patched.
- Split the shared allowlist logic into `_is_read_allowed`/`_is_write_allowed` so an explicit write allowlist no longer implicitly grants write access to sys-prefix directories via the always-allow-read list.
- Stop `apply_python_sandbox` and the shared `run_script`/`run_python_code` from re-consulting the ambient `PYBUN_SANDBOX_ALLOW_NETWORK` env var. It's now resolved once, only at the real CLI entry point (`commands/mod.rs`), so it can no longer silently override an MCP client's explicit `allow_network: false` (MCP builds `RunArgs` directly and never passes through that dispatcher).
- Document the residual TOCTOU symlink-race window in `_normalize_path` as an accepted, low-probability gap.

Fixes #376

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo fmt -- --check` (clean)
- [x] `cargo test --lib` (513 passed)
- [x] `cargo test --test mcp` including 5 new regression tests covering each escape vector
- [x] `cargo test --test cli_smoke --test json_schema`

Note: a handful of pre-existing `cli_run.rs`/`mcp.rs` failures were observed locally, all caused by an unrelated Homebrew Python 3.14.5→3.14.6 upgrade breaking this checkout's `.venv` dyld reference — not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)