### PR TITLE
fix(pypi): correct PEP 440/508 marker comparison and error propagation (Issue #381)

### DIFF
--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -315,7 +315,9 @@ impl PyPiClient {
             .map_err(|e| PyPiError::Parse(e.to_string()))?;
         let resp = self.http.get(url).send().await?;
         if !resp.status().is_success() {
-            return Ok(Vec::new());
+            return Err(PyPiError::Http(
+                resp.error_for_status().unwrap_err().to_string(),
+            ));
         }
         let body: VersionResponse = resp.json().await?;
         Ok(body.info.requires_dist.unwrap_or_default())
@@ -675,10 +677,9 @@ pub(crate) fn marker_allows(marker: &str, py_version: &str) -> bool {
         return false;
     }
 
-    // Handle simple python_version comparisons; if parsing fails, allow by default
-    if marker.contains("python_version")
-        && matches!(eval_python_version_marker(&marker, py_version), Some(false))
-    {
+    // Handle simple python_version/python_full_version comparisons; if
+    // parsing fails, allow by default
+    if matches!(eval_python_version_marker(&marker, py_version), Some(false)) {
         return false;
     }
 
@@ -690,15 +691,35 @@ fn eval_python_version_marker(marker: &str, py_version: &str) -> Option<bool> {
     let ops = ["<=", ">=", "==", "!=", "<", ">"];
     for op in ops {
         if let Some(idx) = marker.find(op) {
-            if !marker[..idx].contains("python_version") {
-                continue;
-            }
+            // The marker variable is the identifier immediately preceding
+            // the operator (e.g. `os_name == "nt" and python_version >= "3.8"`
+            // must not match on `os_name`).
+            let lhs_var = marker[..idx]
+                .trim()
+                .rsplit(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .next()
+                .unwrap_or("");
             let rhs = marker[idx + op.len()..].trim();
             let rhs = rhs.trim_matches(|c: char| c == '"' || c == '\'' || c.is_whitespace());
-            return Some(compare_versions(py_version, rhs, op));
+            match lhs_var {
+                "python_version" => {
+                    return Some(compare_versions(&major_minor(py_version), rhs, op));
+                }
+                "python_full_version" => {
+                    return Some(compare_versions(py_version, rhs, op));
+                }
+                _ => continue,
+            }
         }
     }
     None
+}
+
+fn major_minor(version: &str) -> String {
+    let mut parts = version.splitn(3, '.');
+    let major = parts.next().unwrap_or("0");
+    let minor = parts.next().unwrap_or("0");
+    format!("{major}.{minor}")
 }
 
 fn compare_versions(lhs: &str, rhs: &str, op: &str) -> bool {
@@ -1022,6 +1043,39 @@ mod tests {
     fn marker_respects_python_version() {
         assert!(!marker_allows(r#"python_version >= "3.14""#, "3.11"));
         assert!(marker_allows(r#"python_version < "3.14""#, "3.11"));
+    }
+
+    #[test]
+    fn marker_python_version_matches_any_patch_level() {
+        assert!(marker_allows(r#"python_version == "3.10""#, "3.10.7"));
+        assert!(!marker_allows(r#"python_version == "3.10""#, "3.9.7"));
+    }
+
+    #[test]
+    fn marker_distinguishes_python_full_version_from_python_version() {
+        assert!(marker_allows(
+            r#"python_full_version >= "3.11.4""#,
+            "3.11.4"
+        ));
+        assert!(!marker_allows(
+            r#"python_full_version >= "3.11.4""#,
+            "3.11.3"
+        ));
+        // A python_version marker must not be evaluated against the full
+        // patch-level precision that python_full_version requires.
+        assert!(marker_allows(r#"python_version >= "3.11""#, "3.11.0"));
+    }
+
+    #[test]
+    fn marker_extracts_python_version_token_from_compound_marker() {
+        assert!(!marker_allows(
+            r#"os_name == "nt" and python_version >= "3.99""#,
+            "3.11"
+        ));
+        assert!(marker_allows(
+            r#"os_name == "nt" and python_version >= "3.8""#,
+            "3.11"
+        ));
     }
 
     #[test]

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -315,9 +315,7 @@ impl PyPiClient {
             .map_err(|e| PyPiError::Parse(e.to_string()))?;
         let resp = self.http.get(url).send().await?;
         if !resp.status().is_success() {
-            return Err(PyPiError::Http(
-                resp.error_for_status().unwrap_err().to_string(),
-            ));
+            return Err(PyPiError::Http(resp.status().to_string()));
         }
         let body: VersionResponse = resp.json().await?;
         Ok(body.info.requires_dist.unwrap_or_default())
@@ -703,7 +701,11 @@ fn eval_python_version_marker(marker: &str, py_version: &str) -> Option<bool> {
             let rhs = rhs.trim_matches(|c: char| c == '"' || c == '\'' || c.is_whitespace());
             match lhs_var {
                 "python_version" => {
-                    return Some(compare_versions(&major_minor(py_version), rhs, op));
+                    return Some(compare_versions(
+                        &major_minor(py_version),
+                        &major_minor(rhs),
+                        op,
+                    ));
                 }
                 "python_full_version" => {
                     return Some(compare_versions(py_version, rhs, op));
@@ -1064,6 +1066,15 @@ mod tests {
         // A python_version marker must not be evaluated against the full
         // patch-level precision that python_full_version requires.
         assert!(marker_allows(r#"python_version >= "3.11""#, "3.11.0"));
+    }
+
+    #[test]
+    fn marker_python_version_truncates_nonstandard_three_part_rhs() {
+        // python_version markers are major.minor per PEP 508, but some
+        // real-world metadata uses a 3-part rhs. Both sides must be
+        // truncated to major.minor so the comparison is still meaningful.
+        assert!(marker_allows(r#"python_version == "3.10.7""#, "3.10.2"));
+        assert!(marker_allows(r#"python_version >= "3.10.1""#, "3.10.5"));
     }
 
     #[test]

--- a/tests/pypi_integration.rs
+++ b/tests/pypi_integration.rs
@@ -216,6 +216,57 @@ async fn concurrent_metadata_fetch_is_deduped() {
     assert_eq!(meta_mock.calls(), 1);
 }
 
+#[tokio::test]
+async fn version_metadata_server_error_surfaces_as_error() {
+    // Issue #381: a non-success status from the per-version metadata
+    // endpoint must propagate as an error instead of silently resolving to
+    // an empty dependency list, which would corrupt dependency resolution.
+    let temp = tempdir().unwrap();
+    let cache_dir = temp.path().join("cache");
+    let server = MockServer::start();
+    let base = server.base_url();
+    let wheel_sha256 = wheel_sha256();
+
+    let project_body = json!({
+        "info": { "name": "app", "version": "1.0.0" },
+        "releases": {
+            "1.0.0": [
+                {
+                    "filename": "app-1.0.0-py3-none-any.whl",
+                    "packagetype": "bdist_wheel",
+                    "url": format!("{}/files/app-1.0.0-py3-none-any.whl", base),
+                    "yanked": false,
+                    "digests": { "sha256": wheel_sha256 }
+                }
+            ]
+        }
+    })
+    .to_string();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/pypi/app/json");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .body(project_body.clone());
+    });
+
+    server.mock(|when, then| {
+        when.method(GET).path("/pypi/app/1.0.0/json");
+        then.status(500);
+    });
+
+    let client = PyPiClient::with_config(&base, cache_dir, false).unwrap();
+    let index = PyPiIndex::new(client);
+
+    let result = index.get("app", "1.0.0").await;
+    assert!(
+        result.is_err(),
+        "expected a 500 from the version metadata endpoint to surface as an \
+         error, got {:?}",
+        result
+    );
+}
+
 #[test]
 fn install_does_not_prefetch_all_version_metadata() {
     let temp = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- `python_version == "X.Y"` markers now match a major.minor prefix per PEP 440, instead of requiring exact major.minor.patch tuple equality (so `python_version == "3.10"` correctly matches `3.10.7`).
- `python_version` and `python_full_version` marker variables are now distinguished by tokenizing the identifier immediately preceding the comparison operator, instead of substring-matching — previously a `python_full_version` marker could be mistakenly evaluated as `python_version`, and compound markers like `os_name == "nt" and python_version >= "3.8"` could match the wrong variable.
- `fetch_requires_dist` now propagates non-success HTTP responses (e.g. 500/503) as a `PyPiError::Http` error instead of silently returning an empty dependency list, which previously could corrupt dependency resolution.

Closes #381

## Test plan
- [x] Added unit tests in `src/pypi.rs` covering major.minor prefix matching, `python_version`/`python_full_version` disambiguation, and marker-variable tokenization in compound markers
- [x] Added integration test `version_metadata_server_error_surfaces_as_error` in `tests/pypi_integration.rs` covering HTTP 500 propagation
- [x] `cargo test --lib` — all pass (22/22 new + existing)
- [x] `cargo test --test '*'` — all suites pass except `cli_run` (pre-existing failures unrelated to this change, caused by a broken local Python 3.14 framework install: `dyld: Library not loaded`)
- [x] `cargo test --test e2e_general` — 9/9 pass
- [x] `just lint` (clippy `-D warnings`) — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)