### PR TITLE
fix(install): close supply-chain signature-verification gaps (Issue #378)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,43 @@ $IsMacOS = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
 $AliasName = "pybun-cli"
 $AliasBinaryName = if ($IsWindows) { "pybun-cli.exe" } else { "pybun-cli" }
 
+# Trusted minisign public key for verifying release artifacts (matches
+# security/pybun-release.pub). Baked into the script so a compromised/MITM'd
+# manifest cannot supply its own key and self-sign a malicious artifact.
+$TrustedMinisignPublicKey = if ($env:PYBUN_INSTALL_TRUSTED_PUBKEY) {
+    $env:PYBUN_INSTALL_TRUSTED_PUBKEY
+} else {
+    "RWQtfZNEyNnATcgzxfwDB+iNwGwW8bwflfnjHMizq6H84B1VRXO92yZ5"
+}
+
+# Hosts allowed for asset download URLs (comma separated).
+$AssetUrlHostAllowlist = if ($env:PYBUN_INSTALL_ASSET_HOST_ALLOWLIST) {
+    $env:PYBUN_INSTALL_ASSET_HOST_ALLOWLIST
+} else {
+    "github.com"
+}
+
+# Test-only escape hatch to allow http:// asset URLs against an allowlisted
+# host (e.g. a local mock server in integration tests). Defaults to disabled;
+# never set this in production use.
+$AssetUrlAllowInsecure = $env:PYBUN_INSTALL_ASSET_ALLOW_INSECURE -eq "1"
+
+function Test-AssetUrl {
+    param([string]$Url)
+    if ($Url -match "^https://") {
+        # ok
+    } elseif ($Url -match "^http://" -and $AssetUrlAllowInsecure) {
+        # ok (test-only)
+    } else {
+        throw "insecure asset URL rejected (must be https): $Url"
+    }
+    $uri = [System.Uri]$Url
+    $allowed = $AssetUrlHostAllowlist -split "," | ForEach-Object { $_.Trim() }
+    if ($allowed -notcontains $uri.Host) {
+        throw "asset URL host not in allowlist ($AssetUrlHostAllowlist): $($uri.Host)"
+    }
+}
+
 function Write-Log {
     param([string]$Message)
     if ($Format -eq "json") {
@@ -210,12 +247,16 @@ if ($Version) {
     $AssetUrl = "https://github.com/VOID-TECHNOLOGY-INC/PyBun/releases/latest/download/$AssetName"
 }
 
+if ($ManifestSource -match "^http://") {
+    throw "insecure manifest source rejected (http): use https:// or file://, got $ManifestSource"
+}
+
 $ManifestPath = $null
 if ($ManifestSource -like "file://*") {
     $ManifestPath = $ManifestSource.Substring(7)
 } elseif (Test-Path $ManifestSource) {
     $ManifestPath = $ManifestSource
-} elseif ($ManifestSource -match "^https?://") {
+} elseif ($ManifestSource -match "^https://") {
     if ($env:PYBUN_INSTALL_FETCH -eq "1" -or (-not $NoVerify -and -not $DryRun)) {
         $ManifestPath = Join-Path ([System.IO.Path]::GetTempPath()) ("pybun-release-" + [System.Guid]::NewGuid().ToString() + ".json")
         Download-File -Url $ManifestSource -Destination $ManifestPath
@@ -228,7 +269,11 @@ $ManifestReleaseUrl = $null
 $AssetSha = $null
 $SigType = $null
 $SigValue = $null
-$SigPub = $null
+# SigPub always comes from the trusted, script-embedded key. It is never
+# overridden by manifest content: trusting a public key sourced from the
+# same manifest being verified would let an attacker who controls the
+# manifest self-sign a malicious artifact.
+$SigPub = $TrustedMinisignPublicKey
 
 if ($ManifestPath) {
     $manifestData = Get-ManifestData -ManifestPath $ManifestPath -Target $Target
@@ -238,12 +283,14 @@ if ($ManifestPath) {
     $ManifestChannel = $manifest.channel
     $ManifestReleaseUrl = $manifest.release_url
     $AssetName = $asset.name
-    $AssetUrl = $asset.url
+    if ($asset.url) {
+        Test-AssetUrl -Url $asset.url
+        $AssetUrl = $asset.url
+    }
     $AssetSha = $asset.sha256
     if ($asset.signature) {
         $SigType = $asset.signature.type
         $SigValue = $asset.signature.value
-        $SigPub = $asset.signature.public_key
     }
     if (-not $Version -and $ManifestVersion) {
         $Version = $ManifestVersion
@@ -345,20 +392,21 @@ try {
         if ($computed -ne $AssetSha.ToLowerInvariant()) {
             throw "checksum mismatch: expected $AssetSha, got $computed"
         }
-        if ($SigValue -and $SigPub) {
-            $minisign = Get-Command minisign -ErrorAction SilentlyContinue
-            if (-not $minisign) {
-                throw "minisign is required for signature verification (install minisign or use --no-verify)"
-            }
-            $SigPath = Join-Path $TempDir ($AssetName + ".minisig")
-            $PubPath = Join-Path $TempDir "pybun-release.pub"
-            Set-Content -Path $SigPath -Value $SigValue -Encoding ASCII
-            Set-Content -Path $PubPath -Value $SigPub -Encoding ASCII
-            Write-Log "Verifying signature (minisign)"
-            & minisign -Vm $ArtifactPath -x $SigPath -p $PubPath | Out-Null
-            if ($LASTEXITCODE -ne 0) {
-                throw "minisign verification failed"
-            }
+        if (-not $SigValue) {
+            throw "manifest missing signature value for asset (refusing to install unsigned artifact)"
+        }
+        $minisign = Get-Command minisign -ErrorAction SilentlyContinue
+        if (-not $minisign) {
+            throw "minisign is required for signature verification (install minisign or use --no-verify)"
+        }
+        $SigPath = Join-Path $TempDir ($AssetName + ".minisig")
+        $PubPath = Join-Path $TempDir "pybun-release.pub"
+        Set-Content -Path $SigPath -Value $SigValue -Encoding ASCII
+        Set-Content -Path $PubPath -Value "untrusted comment: minisign public key`n$SigPub" -Encoding ASCII
+        Write-Log "Verifying signature (minisign)"
+        & minisign -Vm $ArtifactPath -x $SigPath -p $PubPath | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "minisign verification failed"
         }
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -148,22 +148,41 @@ sha256sum_file() {
 # manifest before it is used to download an artifact.
 validate_asset_url() {
   url="$1"
-  case "$url" in
-    https://*)
-      host="${url#https://}"
+  if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 is required to validate asset URLs"
+  fi
+  parsed="$(python3 - "$url" <<'PY'
+import sys
+from urllib.parse import urlsplit
+
+url = sys.argv[1]
+parts = urlsplit(url)
+scheme = (parts.scheme or "").lower()
+host = (parts.hostname or "").lower()
+print(scheme)
+print(host)
+PY
+)"
+  scheme="$(printf '%s\n' "$parsed" | sed -n '1p')"
+  host="$(printf '%s\n' "$parsed" | sed -n '2p')"
+
+  case "$scheme" in
+    https)
       ;;
-    http://*)
+    http)
       if [ "$ASSET_URL_ALLOW_INSECURE" != "1" ]; then
         die "insecure asset URL rejected (must be https): $url"
       fi
-      host="${url#http://}"
       ;;
     *)
       die "insecure asset URL rejected (must be https): $url"
       ;;
   esac
-  host="${host%%/*}"
-  host="${host%%:*}"
+
+  if [ -z "$host" ]; then
+    die "asset URL missing host: $url"
+  fi
+
   old_ifs="$IFS"
   IFS=,
   matched=0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,6 +10,22 @@ DRY_RUN=0
 FORMAT="text"
 ALIAS_NAME="pybun-cli"
 
+# Trusted minisign public key for verifying release artifacts. This is the
+# project's actual signing key (security/pybun-release.pub) baked into the
+# script so that a compromised/MITM'd manifest cannot supply its own key and
+# self-sign a malicious artifact. Override only for testing.
+TRUSTED_MINISIGN_PUBLIC_KEY="${PYBUN_INSTALL_TRUSTED_PUBKEY:-RWQtfZNEyNnATcgzxfwDB+iNwGwW8bwflfnjHMizq6H84B1VRXO92yZ5}"
+
+# Hosts allowed for asset download URLs (comma separated). Prevents a
+# compromised/MITM'd manifest from redirecting the download to an
+# attacker-controlled host.
+ASSET_URL_HOST_ALLOWLIST="${PYBUN_INSTALL_ASSET_HOST_ALLOWLIST:-github.com}"
+
+# Test-only escape hatch to allow http:// asset URLs against an allowlisted
+# host (e.g. a local mock server in integration tests). Defaults to disabled;
+# never set this in production use.
+ASSET_URL_ALLOW_INSECURE="${PYBUN_INSTALL_ASSET_ALLOW_INSECURE:-0}"
+
 usage() {
   cat <<'EOF'
 PyBun installer (macOS/Linux)
@@ -127,6 +143,41 @@ sha256sum_file() {
   die "sha256sum or shasum is required for verification"
 }
 
+# Validates that an asset URL uses HTTPS and its host is in the configured
+# allowlist. Called on any asset URL sourced from a (potentially untrusted)
+# manifest before it is used to download an artifact.
+validate_asset_url() {
+  url="$1"
+  case "$url" in
+    https://*)
+      host="${url#https://}"
+      ;;
+    http://*)
+      if [ "$ASSET_URL_ALLOW_INSECURE" != "1" ]; then
+        die "insecure asset URL rejected (must be https): $url"
+      fi
+      host="${url#http://}"
+      ;;
+    *)
+      die "insecure asset URL rejected (must be https): $url"
+      ;;
+  esac
+  host="${host%%/*}"
+  host="${host%%:*}"
+  old_ifs="$IFS"
+  IFS=,
+  matched=0
+  for allowed in $ASSET_URL_HOST_ALLOWLIST; do
+    if [ "$host" = "$allowed" ]; then
+      matched=1
+    fi
+  done
+  IFS="$old_ifs"
+  if [ "$matched" -ne 1 ]; then
+    die "asset URL host not in allowlist ($ASSET_URL_HOST_ALLOWLIST): $host"
+  fi
+}
+
 detect_existing_pybun() {
   DETECTED_PYBUN_PATH=""
   DETECTED_PYBUN_KIND=""
@@ -184,12 +235,25 @@ create_alias() {
   ALIAS_STATUS="error"
 }
 
+# Emits plain NAME=VALUE lines (one per field) for the caller to parse with a
+# whitelist-based `case` loop. Deliberately does NOT shell-quote or eval the
+# values: since the shell side never executes the value content, no quoting
+# is needed and no injection is possible.
+#
+# Values may legitimately contain embedded newlines (e.g. a minisign
+# signature's multi-line file content), so backslashes and newlines are
+# escaped here (\ -> \\, LF -> \n, CR -> \r) and reversed by the shell side
+# with `printf '%b'` after extraction, keeping each emitted line single-line.
+#
+# Note: SIG_PUB (the minisign public key) is intentionally never emitted here.
+# Trusting a public key sourced from the same manifest being verified would
+# let an attacker who controls the manifest self-sign a malicious artifact.
+# The public key always comes from the script's TRUSTED_MINISIGN_PUBLIC_KEY.
 parse_manifest() {
   manifest_path="$1"
   target="$2"
   python3 - "$manifest_path" "$target" <<'PY'
 import json
-import shlex
 import sys
 
 manifest_path = sys.argv[1]
@@ -208,8 +272,11 @@ if not asset:
 
 release_notes = manifest.get("release_notes") or {}
 sig = asset.get("signature") or {}
+
 def emit(name, value):
-    print(f"{name}={shlex.quote(value or '')}")
+    value = value or ""
+    escaped = value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r")
+    print(f"{name}={escaped}")
 
 emit("MANIFEST_VERSION", manifest.get("version", ""))
 emit("MANIFEST_CHANNEL", manifest.get("channel", ""))
@@ -219,7 +286,6 @@ emit("ASSET_URL_FROM_MANIFEST", asset.get("url", ""))
 emit("ASSET_SHA_FROM_MANIFEST", asset.get("sha256", ""))
 emit("SIG_TYPE_FROM_MANIFEST", sig.get("type", ""))
 emit("SIG_VALUE_FROM_MANIFEST", sig.get("value", ""))
-emit("SIG_PUB_FROM_MANIFEST", sig.get("public_key", ""))
 emit("RELEASE_NOTES_NAME_FROM_MANIFEST", release_notes.get("name", ""))
 emit("RELEASE_NOTES_URL_FROM_MANIFEST", release_notes.get("url", ""))
 emit("RELEASE_NOTES_SHA_FROM_MANIFEST", release_notes.get("sha256", ""))
@@ -464,7 +530,10 @@ case "$MANIFEST_SOURCE" in
   file://*)
     MANIFEST_PATH="${MANIFEST_SOURCE#file://}"
     ;;
-  http://*|https://*)
+  http://*)
+    die "insecure manifest source rejected (http): use https:// or file://, got $MANIFEST_SOURCE"
+    ;;
+  https://*)
     if [ "${PYBUN_INSTALL_FETCH:-}" = "1" ] || { [ "$NO_VERIFY" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; }; then
       tmp_manifest="$(mktemp_file)"
       download_file "$MANIFEST_SOURCE" "$tmp_manifest"
@@ -481,10 +550,14 @@ esac
 MANIFEST_VERSION=""
 MANIFEST_CHANNEL=""
 MANIFEST_RELEASE_URL=""
+ASSET_NAME_FROM_MANIFEST=""
+ASSET_URL_FROM_MANIFEST=""
 ASSET_SHA=""
 SIG_TYPE=""
 SIG_VALUE=""
-SIG_PUB=""
+# SIG_PUB is always the trusted, script-embedded key. It is never overridden
+# by manifest content (see parse_manifest for rationale).
+SIG_PUB="$TRUSTED_MINISIGN_PUBLIC_KEY"
 RELEASE_NOTES_NAME=""
 RELEASE_NOTES_URL=""
 RELEASE_NOTES_SHA=""
@@ -493,24 +566,49 @@ if [ -n "$MANIFEST_PATH" ]; then
   if ! command -v python3 >/dev/null 2>&1; then
     die "python3 is required to parse the release manifest"
   fi
-  if manifest_vars="$(parse_manifest "$MANIFEST_PATH" "$TARGET")"; then
-    eval "$manifest_vars"
-    MANIFEST_VERSION="${MANIFEST_VERSION:-}"
-    MANIFEST_CHANNEL="${MANIFEST_CHANNEL:-}"
-    MANIFEST_RELEASE_URL="${MANIFEST_RELEASE_URL:-}"
-    ASSET_NAME="${ASSET_NAME_FROM_MANIFEST:-$ASSET_NAME}"
-    ASSET_URL="${ASSET_URL_FROM_MANIFEST:-$ASSET_URL}"
-    ASSET_SHA="${ASSET_SHA_FROM_MANIFEST:-}"
-    SIG_TYPE="${SIG_TYPE_FROM_MANIFEST:-}"
-    SIG_VALUE="${SIG_VALUE_FROM_MANIFEST:-}"
-    SIG_PUB="${SIG_PUB_FROM_MANIFEST:-}"
-    RELEASE_NOTES_NAME="${RELEASE_NOTES_NAME_FROM_MANIFEST:-}"
-    RELEASE_NOTES_URL="${RELEASE_NOTES_URL_FROM_MANIFEST:-}"
-    RELEASE_NOTES_SHA="${RELEASE_NOTES_SHA_FROM_MANIFEST:-}"
+  manifest_vars_file="$(mktemp_file)"
+  trap 'rm -f "$manifest_vars_file"' EXIT
+  if parse_manifest "$MANIFEST_PATH" "$TARGET" > "$manifest_vars_file"; then
+    # Whitelist-based assignment: no eval, no execution of manifest content.
+    # Reading from a file (not a pipe) avoids the POSIX subshell that would
+    # otherwise discard these assignments once the loop exits.
+    while IFS= read -r manifest_line || [ -n "$manifest_line" ]; do
+      field_name="${manifest_line%%=*}"
+      field_value="${manifest_line#*=}"
+      # Reverse parse_manifest's \\/\n/\r escaping. The format string is a
+      # fixed literal, not derived from field_value, so this cannot execute
+      # or interpret field_value as anything other than data.
+      field_value="$(printf '%b' "$field_value")"
+      case "$field_name" in
+        MANIFEST_VERSION) MANIFEST_VERSION="$field_value" ;;
+        MANIFEST_CHANNEL) MANIFEST_CHANNEL="$field_value" ;;
+        MANIFEST_RELEASE_URL) MANIFEST_RELEASE_URL="$field_value" ;;
+        ASSET_NAME_FROM_MANIFEST) ASSET_NAME_FROM_MANIFEST="$field_value" ;;
+        ASSET_URL_FROM_MANIFEST) ASSET_URL_FROM_MANIFEST="$field_value" ;;
+        ASSET_SHA_FROM_MANIFEST) ASSET_SHA="$field_value" ;;
+        SIG_TYPE_FROM_MANIFEST) SIG_TYPE="$field_value" ;;
+        SIG_VALUE_FROM_MANIFEST) SIG_VALUE="$field_value" ;;
+        RELEASE_NOTES_NAME_FROM_MANIFEST) RELEASE_NOTES_NAME="$field_value" ;;
+        RELEASE_NOTES_URL_FROM_MANIFEST) RELEASE_NOTES_URL="$field_value" ;;
+        RELEASE_NOTES_SHA_FROM_MANIFEST) RELEASE_NOTES_SHA="$field_value" ;;
+        *) ;;
+      esac
+    done < "$manifest_vars_file"
+    rm -f "$manifest_vars_file"
+    trap - EXIT
+    if [ -n "$ASSET_NAME_FROM_MANIFEST" ]; then
+      ASSET_NAME="$ASSET_NAME_FROM_MANIFEST"
+    fi
+    if [ -n "$ASSET_URL_FROM_MANIFEST" ]; then
+      validate_asset_url "$ASSET_URL_FROM_MANIFEST"
+      ASSET_URL="$ASSET_URL_FROM_MANIFEST"
+    fi
     if [ -n "$MANIFEST_VERSION" ] && [ -z "$VERSION" ]; then
       VERSION="$MANIFEST_VERSION"
     fi
   else
+    rm -f "$manifest_vars_file"
+    trap - EXIT
     die "no asset found in manifest for target: $TARGET"
   fi
 elif [ "$NO_VERIFY" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
@@ -586,17 +684,18 @@ if [ "$NO_VERIFY" -eq 0 ]; then
   if [ "$computed_sha" != "$ASSET_SHA" ]; then
     die "checksum mismatch: expected $ASSET_SHA, got $computed_sha"
   fi
-  if [ -n "$SIG_VALUE" ] && [ -n "$SIG_PUB" ]; then
-    if ! command -v minisign >/dev/null 2>&1; then
-      die "minisign is required for signature verification (install minisign or use --no-verify)"
-    fi
-    sig_path="$tmp_dir/${ASSET_NAME}.minisig"
-    pub_path="$tmp_dir/pybun-release.pub"
-    printf '%s\n' "$SIG_VALUE" > "$sig_path"
-    printf '%s\n' "$SIG_PUB" > "$pub_path"
-    log "Verifying signature (minisign)"
-    minisign -Vm "$artifact_path" -x "$sig_path" -p "$pub_path" >/dev/null
+  if [ -z "$SIG_VALUE" ]; then
+    die "manifest missing signature value for asset (refusing to install unsigned artifact)"
   fi
+  if ! command -v minisign >/dev/null 2>&1; then
+    die "minisign is required for signature verification (install minisign or use --no-verify)"
+  fi
+  sig_path="$tmp_dir/${ASSET_NAME}.minisig"
+  pub_path="$tmp_dir/pybun-release.pub"
+  printf '%s\n' "$SIG_VALUE" > "$sig_path"
+  printf 'untrusted comment: minisign public key\n%s\n' "$SIG_PUB" > "$pub_path"
+  log "Verifying signature (minisign)"
+  minisign -Vm "$artifact_path" -x "$sig_path" -p "$pub_path" >/dev/null
 fi
 
 log "Extracting archive"

--- a/tests/docs.rs
+++ b/tests/docs.rs
@@ -65,7 +65,7 @@ fn install_one_liner_reports_release_notes_from_manifest() {
             {
                 "name": asset_name,
                 "target": target,
-                "url": "https://example.com/pybun.tar.gz",
+                "url": "https://github.com/VOID-TECHNOLOGY-INC/PyBun/releases/download/v9.9.9/pybun.tar.gz",
                 "sha256": "abc123",
                 "signature": {
                     "type": "ed25519",
@@ -76,7 +76,7 @@ fn install_one_liner_reports_release_notes_from_manifest() {
         ],
         "release_notes": {
             "name": "RELEASE_NOTES.md",
-            "url": "https://example.com/notes",
+            "url": "https://github.com/VOID-TECHNOLOGY-INC/PyBun/releases/download/v9.9.9/notes",
             "sha256": "deadbeef"
         }
     });
@@ -118,7 +118,7 @@ fn install_one_liner_reports_release_notes_from_manifest() {
 
     assert_eq!(
         release_notes.get("url").and_then(|v| v.as_str()),
-        Some("https://example.com/notes")
+        Some("https://github.com/VOID-TECHNOLOGY-INC/PyBun/releases/download/v9.9.9/notes")
     );
     assert_eq!(
         json.get("asset")

--- a/tests/install_scripts.rs
+++ b/tests/install_scripts.rs
@@ -3,9 +3,54 @@
 use std::fs;
 use std::process::Command;
 
+use httpmock::prelude::*;
 use pybun::release_manifest::current_release_target;
 use serde_json::json;
 use tempfile::tempdir;
+
+/// Generates a fresh, unencrypted minisign keypair for test use via the
+/// locally installed `minisign` binary. Returns `None` if minisign is
+/// unavailable so callers can skip gracefully.
+fn generate_test_minisign_keypair(dir: &std::path::Path) -> Option<(String, std::path::PathBuf)> {
+    if Command::new("minisign").arg("-v").output().is_err() {
+        return None;
+    }
+    let pub_path = dir.join("test.pub");
+    let sec_path = dir.join("test.key");
+    let status = Command::new("minisign")
+        .args(["-G", "-W", "-p"])
+        .arg(&pub_path)
+        .arg("-s")
+        .arg(&sec_path)
+        .output()
+        .expect("failed to run minisign -G")
+        .status;
+    assert!(status.success(), "minisign keypair generation failed");
+    let pub_contents = fs::read_to_string(&pub_path).unwrap();
+    let public_key = pub_contents
+        .lines()
+        .nth(1)
+        .expect("minisign pubkey file should have a key line")
+        .to_string();
+    Some((public_key, sec_path))
+}
+
+fn sign_file(sec_path: &std::path::Path, artifact_path: &std::path::Path) -> String {
+    let sig_path = artifact_path.with_extension("minisig");
+    let status = Command::new("minisign")
+        .arg("-S")
+        .arg("-s")
+        .arg(sec_path)
+        .arg("-m")
+        .arg(artifact_path)
+        .arg("-x")
+        .arg(&sig_path)
+        .output()
+        .expect("failed to run minisign -S")
+        .status;
+    assert!(status.success(), "minisign signing failed");
+    fs::read_to_string(&sig_path).unwrap()
+}
 
 fn write_manifest(target: &str, path: &std::path::Path) -> (String, String) {
     let archive_ext = if target.contains("windows") {
@@ -14,7 +59,10 @@ fn write_manifest(target: &str, path: &std::path::Path) -> (String, String) {
         "tar.gz"
     };
     let asset_name = format!("pybun-{}.{}", target, archive_ext);
-    let asset_url = format!("https://example.com/{}", asset_name);
+    let asset_url = format!(
+        "https://github.com/VOID-TECHNOLOGY-INC/PyBun/releases/download/v9.9.9/{}",
+        asset_name
+    );
     let manifest = json!({
         "version": "9.9.9",
         "channel": "stable",
@@ -215,4 +263,386 @@ fn install_sh_warns_when_bun_pybun_present() {
         }),
         "expected bun pybun warning in {warnings:?}"
     );
+}
+
+// --- Issue #378: install script supply-chain hardening tests ---
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_rejects_http_manifest_source() {
+    let temp = tempdir().unwrap();
+    let prefix = temp.path().join("prefix");
+
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--dry-run")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env(
+            "PYBUN_INSTALL_MANIFEST",
+            "http://example.com/pybun-release.json",
+        )
+        .env("PYBUN_INSTALL_FETCH", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "installer should reject http manifest source"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("insecure manifest source rejected"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_rejects_manifest_asset_url_outside_allowlist() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join("pybun-release.json");
+    let target = current_release_target().expect("supported release target");
+    let asset_name = format!(
+        "pybun-{}.{}",
+        target,
+        if target.contains("windows") {
+            "zip"
+        } else {
+            "tar.gz"
+        }
+    );
+    let manifest = json!({
+        "version": "9.9.9",
+        "channel": "stable",
+        "assets": [
+            {
+                "name": asset_name,
+                "target": target,
+                "url": format!("https://evil.example.com/{asset_name}"),
+                "sha256": "deadbeef",
+                "signature": {
+                    "type": "minisign",
+                    "value": "ZHVtbXktc2lnbmF0dXJl",
+                    "public_key": "ZHVtbXktcHVibGljLWtleQ=="
+                }
+            }
+        ]
+    });
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let prefix = temp.path().join("prefix");
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--dry-run")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "installer should reject asset URL host outside allowlist"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("asset URL host not in allowlist"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_manifest_field_injection_is_inert() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join("pybun-release.json");
+    let target = current_release_target().expect("supported release target");
+    let canary = temp.path().join("pwned");
+    let canary_str = canary.display().to_string();
+    let (asset_url, asset_sha) = write_manifest(&target, &manifest_path);
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    // Attempt shell injection via a manifest field that flows through
+    // parse_manifest -> shell variable assignment. With eval removed, this
+    // must never execute as shell code.
+    manifest["release_notes"] = json!({
+        "name": format!("$(touch {canary_str})`touch {canary_str}`"),
+        "url": "https://github.com/example/notes",
+        "sha256": "deadbeef"
+    });
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let prefix = temp.path().join("prefix");
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--dry-run")
+        .arg("--format")
+        .arg("json")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "installer should exit cleanly: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !canary.exists(),
+        "manifest field content must never be executed as shell code"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(detail["asset"]["url"].as_str(), Some(asset_url.as_str()));
+    assert_eq!(detail["asset"]["sha256"].as_str(), Some(asset_sha.as_str()));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_ignores_manifest_supplied_public_key() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join("pybun-release.json");
+    let target = current_release_target().expect("supported release target");
+    write_manifest(&target, &manifest_path);
+
+    let prefix = temp.path().join("prefix");
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--dry-run")
+        .arg("--format")
+        .arg("json")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "installer should exit cleanly: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let sig_pub = detail["asset"]["signature"]["public_key"]
+        .as_str()
+        .expect("signature.public_key should be present");
+    assert_ne!(
+        sig_pub, "ZHVtbXktcHVibGljLWtleQ==",
+        "installer must never trust a public key supplied by the manifest itself"
+    );
+    assert_eq!(
+        sig_pub, "RWQtfZNEyNnATcgzxfwDB+iNwGwW8bwflfnjHMizq6H84B1VRXO92yZ5",
+        "installer should use the trusted embedded public key"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_full_install_fails_closed_without_signature() {
+    let Some(tar_ok) = Command::new("tar").arg("--version").output().ok() else {
+        eprintln!("tar not available; skipping");
+        return;
+    };
+    if !tar_ok.status.success() {
+        eprintln!("tar not available; skipping");
+        return;
+    }
+
+    let temp = tempdir().unwrap();
+    let target = current_release_target().expect("supported release target");
+    let archive_path = temp.path().join(format!("pybun-{target}.tar.gz"));
+    build_archive(&target, &archive_path);
+    let asset_sha = sha256_hex(&archive_path);
+    let archive_bytes = fs::read(&archive_path).unwrap();
+
+    let server = MockServer::start();
+    let _asset_mock = server.mock(|when, then| {
+        when.method(GET).path(format!("/pybun-{target}.tar.gz"));
+        then.status(200).body(archive_bytes);
+    });
+
+    let manifest_path = temp.path().join("pybun-release.json");
+    let manifest = json!({
+        "version": "9.9.9",
+        "channel": "stable",
+        "assets": [
+            {
+                "name": format!("pybun-{target}.tar.gz"),
+                "target": target,
+                "url": format!("{}/pybun-{target}.tar.gz", server.base_url()),
+                "sha256": asset_sha,
+            }
+        ]
+    });
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let prefix = temp.path().join("prefix");
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .env("PYBUN_INSTALL_ASSET_HOST_ALLOWLIST", "127.0.0.1")
+        .env("PYBUN_INSTALL_ASSET_ALLOW_INSECURE", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "installer must fail closed when the manifest lacks a signature"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("missing signature value"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(
+        !prefix.join("bin/pybun").exists(),
+        "unsigned artifact must not be installed"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn install_sh_full_install_succeeds_with_trusted_signature() {
+    let Some(tar_ok) = Command::new("tar").arg("--version").output().ok() else {
+        eprintln!("tar not available; skipping");
+        return;
+    };
+    if !tar_ok.status.success() {
+        eprintln!("tar not available; skipping");
+        return;
+    }
+
+    let temp = tempdir().unwrap();
+    let Some((public_key, secret_key_path)) = generate_test_minisign_keypair(temp.path()) else {
+        eprintln!("minisign not available; skipping");
+        return;
+    };
+
+    let target = current_release_target().expect("supported release target");
+    let archive_path = temp.path().join(format!("pybun-{target}.tar.gz"));
+    build_archive(&target, &archive_path);
+    let asset_sha = sha256_hex(&archive_path);
+    let signature = sign_file(&secret_key_path, &archive_path);
+    let archive_bytes = fs::read(&archive_path).unwrap();
+
+    let server = MockServer::start();
+    let _asset_mock = server.mock(|when, then| {
+        when.method(GET).path(format!("/pybun-{target}.tar.gz"));
+        then.status(200).body(archive_bytes);
+    });
+
+    let manifest_path = temp.path().join("pybun-release.json");
+    let manifest = json!({
+        "version": "9.9.9",
+        "channel": "stable",
+        "assets": [
+            {
+                "name": format!("pybun-{target}.tar.gz"),
+                "target": target,
+                "url": format!("{}/pybun-{target}.tar.gz", server.base_url()),
+                "sha256": asset_sha,
+                "signature": {
+                    "type": "minisign",
+                    "value": signature,
+                    // Deliberately a bogus key: must be ignored in favor of
+                    // the trusted PYBUN_INSTALL_TRUSTED_PUBKEY override below.
+                    "public_key": "ZHVtbXktcHVibGljLWtleQ=="
+                }
+            }
+        ]
+    });
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let prefix = temp.path().join("prefix");
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .env("PYBUN_INSTALL_ASSET_HOST_ALLOWLIST", "127.0.0.1")
+        .env("PYBUN_INSTALL_ASSET_ALLOW_INSECURE", "1")
+        .env("PYBUN_INSTALL_TRUSTED_PUBKEY", &public_key)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "installer should succeed with a valid trusted signature: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        prefix.join("bin/pybun").exists(),
+        "expected pybun binary to be installed"
+    );
+}
+
+/// Builds a minimal tar.gz archive containing `pybun-<target>/pybun`, matching
+/// the layout install.sh expects to extract.
+fn build_archive(target: &str, archive_path: &std::path::Path) {
+    let stage = tempdir().unwrap();
+    let dir = stage.path().join(format!("pybun-{target}"));
+    fs::create_dir_all(&dir).unwrap();
+    let bin_path = dir.join("pybun");
+    fs::write(&bin_path, "#!/bin/sh\necho pybun-test-binary\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let status = Command::new("tar")
+        .arg("-czf")
+        .arg(archive_path)
+        .arg("-C")
+        .arg(stage.path())
+        .arg(format!("pybun-{target}"))
+        .status()
+        .expect("failed to run tar");
+    assert!(status.success(), "failed to build test archive");
+}
+
+fn sha256_hex(path: &std::path::Path) -> String {
+    let output = Command::new("shasum")
+        .arg("-a")
+        .arg("256")
+        .arg(path)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .unwrap_or_else(|| {
+            Command::new("sha256sum")
+                .arg(path)
+                .output()
+                .expect("sha256sum or shasum required")
+        });
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .split_whitespace()
+        .next()
+        .expect("sha256 output should contain a hash")
+        .to_string()
 }

--- a/tests/install_scripts.rs
+++ b/tests/install_scripts.rs
@@ -358,6 +358,67 @@ fn install_sh_rejects_manifest_asset_url_outside_allowlist() {
 
 #[cfg(not(windows))]
 #[test]
+fn install_sh_rejects_asset_url_with_userinfo_host_confusion() {
+    let temp = tempdir().unwrap();
+    let manifest_path = temp.path().join("pybun-release.json");
+    let target = current_release_target().expect("supported release target");
+    let asset_name = format!(
+        "pybun-{}.{}",
+        target,
+        if target.contains("windows") {
+            "zip"
+        } else {
+            "tar.gz"
+        }
+    );
+    // Userinfo syntax (user:pass@host) must not let the allowlist check see
+    // the trusted host while curl/wget actually connect to evil.com.
+    let manifest = json!({
+        "version": "9.9.9",
+        "channel": "stable",
+        "assets": [
+            {
+                "name": asset_name,
+                "target": target,
+                "url": format!("https://github.com:@evil.com/{asset_name}"),
+                "sha256": "deadbeef",
+                "signature": {
+                    "type": "minisign",
+                    "value": "ZHVtbXktc2lnbmF0dXJl",
+                    "public_key": "ZHVtbXktcHVibGljLWtleQ=="
+                }
+            }
+        ]
+    });
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    let prefix = temp.path().join("prefix");
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--dry-run")
+        .arg("--prefix")
+        .arg(&prefix)
+        .env("PYBUN_INSTALL_MANIFEST", &manifest_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "installer should reject asset URL host outside allowlist via userinfo confusion"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("asset URL host not in allowlist"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
 fn install_sh_manifest_field_injection_is_inert() {
     let temp = tempdir().unwrap();
     let manifest_path = temp.path().join("pybun-release.json");

--- a/tests/install_scripts.rs
+++ b/tests/install_scripts.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::process::Command;
 
+#[cfg(not(windows))]
 use httpmock::prelude::*;
 use pybun::release_manifest::current_release_target;
 use serde_json::json;
@@ -11,6 +12,7 @@ use tempfile::tempdir;
 /// Generates a fresh, unencrypted minisign keypair for test use via the
 /// locally installed `minisign` binary. Returns `None` if minisign is
 /// unavailable so callers can skip gracefully.
+#[cfg(not(windows))]
 fn generate_test_minisign_keypair(dir: &std::path::Path) -> Option<(String, std::path::PathBuf)> {
     if Command::new("minisign").arg("-v").output().is_err() {
         return None;
@@ -35,6 +37,7 @@ fn generate_test_minisign_keypair(dir: &std::path::Path) -> Option<(String, std:
     Some((public_key, sec_path))
 }
 
+#[cfg(not(windows))]
 fn sign_file(sec_path: &std::path::Path, artifact_path: &std::path::Path) -> String {
     let sig_path = artifact_path.with_extension("minisig");
     let status = Command::new("minisign")
@@ -663,6 +666,7 @@ fn install_sh_full_install_succeeds_with_trusted_signature() {
 
 /// Builds a minimal tar.gz archive containing `pybun-<target>/pybun`, matching
 /// the layout install.sh expects to extract.
+#[cfg(not(windows))]
 fn build_archive(target: &str, archive_path: &std::path::Path) {
     let stage = tempdir().unwrap();
     let dir = stage.path().join(format!("pybun-{target}"));
@@ -686,6 +690,7 @@ fn build_archive(target: &str, archive_path: &std::path::Path) {
     assert!(status.success(), "failed to build test archive");
 }
 
+#[cfg(not(windows))]
 fn sha256_hex(path: &std::path::Path) -> String {
     let output = Command::new("shasum")
         .arg("-a")


### PR DESCRIPTION
Closes #378

## Summary

`scripts/install.sh` and `scripts/install.ps1` had five systemic signature-verification weaknesses that undermined the supply-chain integrity they were meant to provide. This PR fixes all of them:

- **Self-signed manifest**: The trusted minisign public key is now hardcoded in both install scripts (`TRUSTED_MINISIGN_PUBLIC_KEY` / `$TrustedMinisignPublicKey`), matching `security/pybun-release.pub`. The manifest's own `signature.public_key` field is parsed but never used for verification.
- **Partial-manifest bypass**: Verification now fails closed — if `SIG_VALUE` is empty, install aborts with "manifest missing signature value for asset (refusing to install unsigned artifact)" instead of silently degrading to checksum-only mode.
- **HTTP accepted**: Non-HTTPS manifest sources (`http://*`) are now rejected outright in both scripts; only `https://` and `file://` are accepted.
- **`eval` on external data**: Manifest field parsing no longer uses `eval`. Python emits `NAME=VALUE` lines with backslash/newline/CR escaping; the shell reads them via `while IFS= read -r line < file` and decodes with `printf '%b'` (a fixed literal format string, so no injection risk regardless of field content).
- **Asset URL override**: Manifest-supplied asset URLs are now validated against an HTTPS + host allowlist (`ASSET_URL_HOST_ALLOWLIST`, default `github.com`) via `validate_asset_url()` / `Test-AssetUrl` before being accepted.

New env var overrides (for testing/ops):
- `PYBUN_INSTALL_TRUSTED_PUBKEY` — override the trusted pubkey
- `PYBUN_INSTALL_ASSET_HOST_ALLOWLIST` — override the allowlist
- `PYBUN_INSTALL_ASSET_ALLOW_INSECURE` — narrow, default-off escape hatch permitting `http://` asset URLs against an allowlisted host, needed because `httpmock` (our test HTTP mock server) has no TLS support. Never set in production.

## Test plan

- [x] New tests in `tests/install_scripts.rs`: HTTP manifest source rejection, out-of-allowlist asset URL rejection, manifest field injection inertness (proves `eval` removal via canary-file check), ignored manifest-supplied public key, fail-closed install when signature missing, full signed install using a real `minisign`-generated keypair via `httpmock::MockServer`
- [x] Updated pre-existing `tests/docs.rs` installer test fixture to use an allowlisted host instead of `example.com`
- [x] `cargo test --test '*'`: 627 passed, 5 ignored, no regressions
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: no issues
- [x] `cargo fmt -- --check`: clean
- [x] `sh -n scripts/install.sh`: syntax OK