### PR TITLE
fix(security): validate/escape external input before URL, command, and HTML interpolation

### DIFF
--- a/scripts/benchmark/report/generate.py
+++ b/scripts/benchmark/report/generate.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import sys
 from datetime import datetime
@@ -232,14 +233,15 @@ def generate_html_report(
     meta = latest.get("meta", {})
     summary = latest.get("summary", {})
     sys_info = meta.get("system", {})
-    
-    html = f"""\
+    safe_title = html.escape(title)
+
+    html_out = f"""\
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{title}</title>
+    <title>{safe_title}</title>
     <style>
         :root {{
             --bg: #0d1117;
@@ -319,7 +321,7 @@ def generate_html_report(
     </style>
 </head>
 <body>
-    <h1>{title}</h1>
+    <h1>{safe_title}</h1>
     
     <p>
         <strong>Generated:</strong> {meta.get('timestamp', 'Unknown')}<br>
@@ -371,9 +373,10 @@ def generate_html_report(
     
     for scenario in sorted(by_scenario.keys()):
         scenario_results = by_scenario[scenario]
-        
-        html += f"""
-    <h3>{scenario}</h3>
+        safe_scenario = html.escape(scenario)
+
+        html_out += f"""
+    <h3>{safe_scenario}</h3>
     <table>
         <tr>
             <th>Tool</th>
@@ -384,14 +387,15 @@ def generate_html_report(
             <th>Status</th>
         </tr>
 """
-        
+
         for r in sorted(scenario_results, key=lambda x: x.get("duration_ms", 0)):
             status_class = "success" if r.get("success", True) else "error"
             status_icon = "✅" if r.get("success", True) else "❌"
-            
-            html += f"""
+            safe_tool = html.escape(r["tool"])
+
+            html_out += f"""
         <tr>
-            <td>{r['tool']}</td>
+            <td>{safe_tool}</td>
             <td>{r.get('duration_ms', 0):.2f}</td>
             <td>{r.get('min_ms', 0):.2f}</td>
             <td>{r.get('max_ms', 0):.2f}</td>
@@ -399,17 +403,17 @@ def generate_html_report(
             <td class="{status_class}">{status_icon}</td>
         </tr>
 """
-        
-        html += "    </table>\n"
-    
-    html += f"""
+
+        html_out += "    </table>\n"
+
+    html_out += f"""
     <hr>
     <p><em>Report generated at {datetime.now().isoformat()}</em></p>
 </body>
 </html>
 """
-    
-    return html
+
+    return html_out
 
 
 def main():

--- a/scripts/benchmark/report/generate.py
+++ b/scripts/benchmark/report/generate.py
@@ -234,6 +234,14 @@ def generate_html_report(
     summary = latest.get("summary", {})
     sys_info = meta.get("system", {})
     safe_title = html.escape(title)
+    safe_timestamp = html.escape(str(meta.get("timestamp", "Unknown")))
+    safe_pybun_version = html.escape(str(meta.get("pybun_version", "Unknown")))
+    safe_os = html.escape(str(sys_info.get("os", "Unknown")))
+    safe_os_version = html.escape(str(sys_info.get("os_version", "")))
+    safe_architecture = html.escape(str(sys_info.get("architecture", "Unknown")))
+    safe_cpu = html.escape(str(sys_info.get("cpu", "Unknown")))
+    safe_memory_gb = html.escape(str(sys_info.get("memory_gb", "Unknown")))
+    safe_python_version = html.escape(str(sys_info.get("python_version", "Unknown")))
 
     html_out = f"""\
 <!DOCTYPE html>
@@ -324,18 +332,18 @@ def generate_html_report(
     <h1>{safe_title}</h1>
     
     <p>
-        <strong>Generated:</strong> {meta.get('timestamp', 'Unknown')}<br>
-        <strong>PyBun Version:</strong> {meta.get('pybun_version', 'Unknown')}
+        <strong>Generated:</strong> {safe_timestamp}<br>
+        <strong>PyBun Version:</strong> {safe_pybun_version}
     </p>
-    
+
     <h2>System Information</h2>
     <table>
         <tr><th>Property</th><th>Value</th></tr>
-        <tr><td>OS</td><td>{sys_info.get('os', 'Unknown')} {sys_info.get('os_version', '')}</td></tr>
-        <tr><td>Architecture</td><td>{sys_info.get('architecture', 'Unknown')}</td></tr>
-        <tr><td>CPU</td><td>{sys_info.get('cpu', 'Unknown')}</td></tr>
-        <tr><td>Memory</td><td>{sys_info.get('memory_gb', 'Unknown')} GB</td></tr>
-        <tr><td>Python</td><td>{sys_info.get('python_version', 'Unknown')}</td></tr>
+        <tr><td>OS</td><td>{safe_os} {safe_os_version}</td></tr>
+        <tr><td>Architecture</td><td>{safe_architecture}</td></tr>
+        <tr><td>CPU</td><td>{safe_cpu}</td></tr>
+        <tr><td>Memory</td><td>{safe_memory_gb} GB</td></tr>
+        <tr><td>Python</td><td>{safe_python_version}</td></tr>
     </table>
     
     <h2>Summary</h2>

--- a/scripts/benchmark/tests/test_generate.py
+++ b/scripts/benchmark/tests/test_generate.py
@@ -50,6 +50,40 @@ class TestGenerateHtmlReportEscaping(unittest.TestCase):
         self.assertNotIn(payload, html_out)
         self.assertIn("&lt;script&gt;", html_out)
 
+    def test_meta_and_system_fields_are_html_escaped(self) -> None:
+        payload = "<script>alert('xss')</script>"
+        results = [
+            {
+                "meta": {
+                    "timestamp": payload,
+                    "pybun_version": payload,
+                    "system": {
+                        "os": payload,
+                        "os_version": payload,
+                        "architecture": payload,
+                        "cpu": payload,
+                        "memory_gb": payload,
+                        "python_version": payload,
+                    },
+                },
+                "summary": {},
+                "results": [
+                    {
+                        "scenario": "install",
+                        "tool": "pip",
+                        "duration_ms": 1.0,
+                        "min_ms": 1.0,
+                        "max_ms": 1.0,
+                        "stddev_ms": 0.0,
+                        "success": True,
+                    }
+                ],
+            }
+        ]
+        html_out = generate.generate_html_report(results)
+        self.assertNotIn(payload, html_out)
+        self.assertIn("&lt;script&gt;", html_out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/benchmark/tests/test_generate.py
+++ b/scripts/benchmark/tests/test_generate.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+_GENERATE_PATH = Path(__file__).resolve().parents[1] / "report" / "generate.py"
+_spec = importlib.util.spec_from_file_location("report_generate", _GENERATE_PATH)
+generate = importlib.util.module_from_spec(_spec)
+sys.modules["report_generate"] = generate
+_spec.loader.exec_module(generate)
+
+
+class TestGenerateHtmlReportEscaping(unittest.TestCase):
+    def _results_with(self, scenario: str, tool: str) -> list[dict]:
+        return [
+            {
+                "meta": {"timestamp": "now", "pybun_version": "0.0.0", "system": {}},
+                "summary": {},
+                "results": [
+                    {
+                        "scenario": scenario,
+                        "tool": tool,
+                        "duration_ms": 1.0,
+                        "min_ms": 1.0,
+                        "max_ms": 1.0,
+                        "stddev_ms": 0.0,
+                        "success": True,
+                    }
+                ],
+            }
+        ]
+
+    def test_scenario_name_is_html_escaped(self) -> None:
+        payload = "<script>alert('xss')</script>"
+        html_out = generate.generate_html_report(self._results_with(payload, "pip"))
+        self.assertNotIn(payload, html_out)
+        self.assertIn("&lt;script&gt;", html_out)
+
+    def test_tool_name_is_html_escaped(self) -> None:
+        payload = "<img src=x onerror=alert(1)>"
+        html_out = generate.generate_html_report(self._results_with("install", payload))
+        self.assertNotIn(payload, html_out)
+        self.assertIn("&lt;img", html_out)
+
+    def test_title_is_html_escaped(self) -> None:
+        payload = "<script>alert('xss')</script>"
+        html_out = generate.generate_html_report(
+            self._results_with("install", "pip"), title=payload
+        )
+        self.assertNotIn(payload, html_out)
+        self.assertIn("&lt;script&gt;", html_out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -41,6 +41,17 @@ $AssetUrlHostAllowlist = if ($env:PYBUN_INSTALL_ASSET_HOST_ALLOWLIST) {
 # never set this in production use.
 $AssetUrlAllowInsecure = $env:PYBUN_INSTALL_ASSET_ALLOW_INSECURE -eq "1"
 
+function Test-Version {
+    param([string]$VersionValue)
+    # Reject anything that isn't a plain version string (optionally prefixed
+    # with "v") before it is interpolated into a GitHub release URL. This
+    # blocks path traversal / URL-control characters (e.g. "/", "?", "#",
+    # whitespace) from altering the constructed manifest or asset URL.
+    if ($VersionValue -notmatch '^v?[0-9]+(\.[0-9]+){0,3}([.-][0-9A-Za-z]+)*$') {
+        throw "invalid version string rejected: $VersionValue"
+    }
+}
+
 function Test-AssetUrl {
     param([string]$Url)
     if ($Url -match "^https://") {
@@ -224,6 +235,10 @@ $AssetName = "pybun-$Target.$ArchiveExt"
 $BinaryName = if ($IsWindows) { "pybun.exe" } else { "pybun" }
 $InstallPath = Join-Path $BinDir $BinaryName
 $AliasPath = Join-Path $BinDir $AliasBinaryName
+
+if ($Version) {
+    Test-Version -VersionValue $Version
+}
 
 $ManifestSource = $env:PYBUN_INSTALL_MANIFEST
 if (-not $ManifestSource) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -197,6 +197,17 @@ PY
   fi
 }
 
+# Reject anything that isn't a plain version string (optionally prefixed with
+# "v") before it is interpolated into a GitHub release URL. This blocks path
+# traversal / URL-control characters (e.g. "/", "?", "#", whitespace) from
+# altering the constructed manifest or asset URL.
+validate_version() {
+  version="$1"
+  if ! printf '%s' "$version" | grep -Eq '^v?[0-9]+(\.[0-9]+){0,3}([.-][0-9A-Za-z]+)*$'; then
+    die "invalid version string rejected: $version"
+  fi
+}
+
 detect_existing_pybun() {
   DETECTED_PYBUN_PATH=""
   DETECTED_PYBUN_KIND=""
@@ -521,6 +532,10 @@ ARCHIVE_EXT="tar.gz"
 ASSET_NAME="pybun-${TARGET}.${ARCHIVE_EXT}"
 INSTALL_PATH="$BIN_DIR/pybun"
 ALIAS_PATH="$BIN_DIR/$ALIAS_NAME"
+
+if [ -n "$VERSION" ]; then
+  validate_version "$VERSION"
+fi
 
 MANIFEST_SOURCE="${PYBUN_INSTALL_MANIFEST:-}"
 if [ -z "$MANIFEST_SOURCE" ]; then

--- a/src/commands/tooling.rs
+++ b/src/commands/tooling.rs
@@ -753,6 +753,7 @@ pub(super) fn execute_tool(
         .package
         .as_ref()
         .ok_or_else(|| eyre!("package name is required"))?;
+    validate_package_spec(package_spec)?;
 
     // Parse package name and version
     let (package_name, version) = parse_package_spec(package_spec);
@@ -903,6 +904,33 @@ pub(super) fn execute_tool(
 }
 
 /// Parse a package specification like "cowsay==6.1" into (name, version)
+/// Validate a `pybun x` package spec against expected PEP 508 syntax before
+/// it is passed to `pip`/`uv`. Rejects specs starting with `-` (which pip/uv
+/// would otherwise interpret as a CLI flag rather than a package name) and
+/// any characters outside the PEP 508 name/version-specifier grammar.
+fn validate_package_spec(spec: &str) -> Result<()> {
+    if spec.trim().is_empty() {
+        return Err(eyre!("package spec must not be empty"));
+    }
+    if spec.starts_with('-') {
+        return Err(eyre!("package spec must not start with '-': {}", spec));
+    }
+    let valid = spec.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(
+                c,
+                '.' | '_' | '-' | '=' | '<' | '>' | '!' | '~' | ',' | '*' | '+' | '[' | ']'
+            )
+    });
+    if !valid {
+        return Err(eyre!(
+            "package spec contains characters outside PEP 508 syntax: {}",
+            spec
+        ));
+    }
+    Ok(())
+}
+
 pub(super) fn parse_package_spec(spec: &str) -> (String, Option<String>) {
     // Handle various specifier formats
     for sep in ["==", ">=", "<=", "!=", "~=", ">", "<"] {
@@ -1141,6 +1169,26 @@ fn release_url_for_version(version: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_package_spec_accepts_normal_specs() {
+        assert!(validate_package_spec("cowsay").is_ok());
+        assert!(validate_package_spec("cowsay==6.1").is_ok());
+        assert!(validate_package_spec("requests>=2.28.0").is_ok());
+        assert!(validate_package_spec("flask~=2.0.0").is_ok());
+        assert!(validate_package_spec("pkg[extra]==1.0").is_ok());
+    }
+
+    #[test]
+    fn validate_package_spec_rejects_leading_dash_and_bad_chars() {
+        assert!(validate_package_spec("-e file:///etc/passwd").is_err());
+        assert!(validate_package_spec("--upgrade").is_err());
+        assert!(validate_package_spec("").is_err());
+        assert!(validate_package_spec("   ").is_err());
+        assert!(validate_package_spec("pkg; rm -rf /").is_err());
+        assert!(validate_package_spec("pkg && echo pwned").is_err());
+        assert!(validate_package_spec("pkg\nrm -rf /").is_err());
+    }
 
     #[test]
     fn parse_package_spec_simple_name() {

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -27,6 +27,8 @@ pub enum PyPiError {
     Parse(String),
     #[error("invalid package name: {0}")]
     InvalidPackageName(String),
+    #[error("invalid version: {0}")]
+    InvalidVersion(String),
 }
 
 impl From<reqwest::Error> for PyPiError {
@@ -313,6 +315,7 @@ impl PyPiClient {
         version: &str,
     ) -> Result<Vec<String>, PyPiError> {
         validate_package_name(name)?;
+        validate_version(version)?;
         let url = self
             .base
             .join(&format!("pypi/{}/{}/json", name, version))
@@ -654,6 +657,22 @@ fn validate_package_name(name: &str) -> Result<(), PyPiError> {
         Ok(())
     } else {
         Err(PyPiError::InvalidPackageName(name.to_string()))
+    }
+}
+
+/// Validate a version string against the PEP 440 character set
+/// (alphanumerics plus `.`, `+`, `-`, `_`, `!`) before it is interpolated into
+/// a PyPI URL path, blocking `/`, `?`, `#`, whitespace, and control characters
+/// that could otherwise redirect or manipulate the constructed request.
+fn validate_version(version: &str) -> Result<(), PyPiError> {
+    let valid = !version.is_empty()
+        && version
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'+' | b'-' | b'_' | b'!'));
+    if valid {
+        Ok(())
+    } else {
+        Err(PyPiError::InvalidVersion(version.to_string()))
     }
 }
 
@@ -1081,6 +1100,26 @@ mod tests {
         assert!(validate_package_name("").is_err());
         assert!(validate_package_name("-leading-dash").is_err());
         assert!(validate_package_name("trailing-dash-").is_err());
+    }
+
+    #[test]
+    fn validate_version_accepts_pep440_versions() {
+        assert!(validate_version("1.2.3").is_ok());
+        assert!(validate_version("2.0.0rc1").is_ok());
+        assert!(validate_version("1.0.0+local.build").is_ok());
+        assert!(validate_version("1.0.0.dev0").is_ok());
+        assert!(validate_version("1!2.0").is_ok());
+    }
+
+    #[test]
+    fn validate_version_rejects_path_traversal_and_control_chars() {
+        assert!(validate_version("../../etc/passwd").is_err());
+        assert!(validate_version("1.2.3/../evil").is_err());
+        assert!(validate_version("1.2.3?x=1").is_err());
+        assert!(validate_version("1.2.3#frag").is_err());
+        assert!(validate_version("1.2 3").is_err());
+        assert!(validate_version("1.2\n3").is_err());
+        assert!(validate_version("").is_err());
     }
 
     #[test]

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -25,6 +25,8 @@ pub enum PyPiError {
     Io(String),
     #[error("parse error: {0}")]
     Parse(String),
+    #[error("invalid package name: {0}")]
+    InvalidPackageName(String),
 }
 
 impl From<reqwest::Error> for PyPiError {
@@ -226,6 +228,7 @@ impl PyPiClient {
     }
 
     async fn fetch_packages(&self, name: &str) -> Result<Vec<CachedPackage>, PyPiError> {
+        validate_package_name(name)?;
         let cached_entry = self.load_cache(name).await?;
 
         if self.offline {
@@ -309,6 +312,7 @@ impl PyPiClient {
         name: &str,
         version: &str,
     ) -> Result<Vec<String>, PyPiError> {
+        validate_package_name(name)?;
         let url = self
             .base
             .join(&format!("pypi/{}/{}/json", name, version))
@@ -630,6 +634,27 @@ struct CacheControlDirectives {
     max_age: Option<u64>,
     no_cache: bool,
     no_store: bool,
+}
+
+/// Validate a package name against the PEP 503 naming rule
+/// (`[A-Za-z0-9]` optionally followed by runs of `[A-Za-z0-9._-]` and ending
+/// in an alphanumeric) before it is interpolated into a PyPI URL path.
+fn validate_package_name(name: &str) -> Result<(), PyPiError> {
+    let bytes = name.as_bytes();
+    let is_alnum = |b: u8| b.is_ascii_alphanumeric();
+    let is_sep = |b: u8| matches!(b, b'.' | b'_' | b'-');
+    let valid = match bytes {
+        [] => false,
+        [single] => is_alnum(*single),
+        [first, .., last] => {
+            is_alnum(*first) && is_alnum(*last) && bytes.iter().all(|b| is_alnum(*b) || is_sep(*b))
+        }
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(PyPiError::InvalidPackageName(name.to_string()))
+    }
 }
 
 fn normalize_base(input: &str) -> Result<Url, PyPiError> {
@@ -1035,6 +1060,28 @@ fn build_cached_packages(
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn validate_package_name_accepts_pep503_names() {
+        assert!(validate_package_name("requests").is_ok());
+        assert!(validate_package_name("zope.interface").is_ok());
+        assert!(validate_package_name("django-storages").is_ok());
+        assert!(validate_package_name("foo_bar").is_ok());
+        assert!(validate_package_name("a").is_ok());
+        assert!(validate_package_name("A1").is_ok());
+    }
+
+    #[test]
+    fn validate_package_name_rejects_path_traversal_and_control_chars() {
+        assert!(validate_package_name("../../etc/passwd").is_err());
+        assert!(validate_package_name("foo/bar").is_err());
+        assert!(validate_package_name("foo bar").is_err());
+        assert!(validate_package_name("foo\nbar").is_err());
+        assert!(validate_package_name("foo?bar=1").is_err());
+        assert!(validate_package_name("").is_err());
+        assert!(validate_package_name("-leading-dash").is_err());
+        assert!(validate_package_name("trailing-dash-").is_err());
+    }
 
     #[test]
     fn marker_rejects_extra() {

--- a/tests/install_scripts.rs
+++ b/tests/install_scripts.rs
@@ -213,6 +213,33 @@ fn install_ps1_dry_run_emits_json() {
 
 // --- Issue #387: unvalidated `-Version` input hardening ---
 
+#[cfg(not(windows))]
+#[test]
+fn install_sh_rejects_malformed_version() {
+    let temp = tempdir().unwrap();
+    let prefix = temp.path().join("prefix");
+
+    let output = Command::new("sh")
+        .arg("scripts/install.sh")
+        .arg("--version")
+        .arg("1.2.3/../../etc/passwd")
+        .arg("--dry-run")
+        .arg("--prefix")
+        .arg(&prefix)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "installer should reject a malformed version string"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid version string rejected"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
 #[test]
 fn install_ps1_rejects_malformed_version() {
     let temp = tempdir().unwrap();

--- a/tests/install_scripts.rs
+++ b/tests/install_scripts.rs
@@ -211,6 +211,47 @@ fn install_ps1_dry_run_emits_json() {
     assert!(warnings.is_empty(), "no warnings expected: {warnings:?}");
 }
 
+// --- Issue #387: unvalidated `-Version` input hardening ---
+
+#[test]
+fn install_ps1_rejects_malformed_version() {
+    let temp = tempdir().unwrap();
+    let prefix = temp.path().join("prefix");
+
+    let pwsh_available = Command::new("pwsh")
+        .args(["-NoProfile", "-Command", "$PSVersionTable.PSVersion.Major"])
+        .output()
+        .is_ok();
+    if !pwsh_available {
+        eprintln!("pwsh not available; skipping PowerShell installer test");
+        return;
+    }
+
+    let output = Command::new("pwsh")
+        .args([
+            "-NoProfile",
+            "-File",
+            "scripts/install.ps1",
+            "-Version",
+            "1.2.3/../../etc/passwd",
+            "-DryRun",
+            "-Prefix",
+        ])
+        .arg(&prefix)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "installer should reject a malformed version string"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid version string rejected"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
 #[cfg(not(windows))]
 #[test]
 fn install_sh_warns_when_bun_pybun_present() {


### PR DESCRIPTION
## Summary
- Validate `-Version` in `scripts/install.ps1` against a version-string pattern before it's interpolated into GitHub release/manifest URLs, rejecting path-traversal/URL-control characters.
- Validate package names in `src/pypi.rs` against PEP 503 naming rules before interpolating into PyPI URL paths.
- Validate `pybun x` package specs in `src/commands/tooling.rs` against PEP 508 syntax (and reject leading `-`, which pip/uv would otherwise interpret as a CLI flag) before passing them to pip/uv.
- HTML-escape title/scenario/tool names in `scripts/benchmark/report/generate.py` before interpolating into generated HTML reports, preventing stored XSS if a scenario/tool name contains a payload.

Closes #387

## Test plan
- [x] `cargo test` (1159 passed, 7 ignored)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no issues)
- [x] `cargo fmt`
- [x] Added Rust unit tests: `validate_package_name_*` (pypi.rs), `validate_package_spec_*` (tooling.rs), `install_ps1_rejects_malformed_version` (tests/install_scripts.rs, skips gracefully if `pwsh` unavailable)
- [x] Added Python unit tests: `scripts/benchmark/tests/test_generate.py` (verifies scenario/tool/title HTML-escaping), run via `python3 -m unittest`